### PR TITLE
feat: expose rpc listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Validator now persists validated transactions ([#1614](https://github.com/0xMiden/miden-node/pull/1614)).
 - [BREAKING] Remove `SynState` and introduce `SyncChainMmr` ([#1591](https://github.com/0xMiden/miden-node/issues/1591)).
 - Introduce `SyncChainMmr` RPC endpoint to sync chain MMR deltas within specified block ranges ([#1591](https://github.com/0xMiden/miden-node/issues/1591)).
-- Fixed `TransactionHeader` serialization for row insertion on database & fixed transaction cursor on retrievals ([#1701](https://github.com/0xMiden/miden-node/issues/1701)).
+- Re-Introduce `RpcListener` & expose remote prover as a library to allow instantiation on other crates ([#1709](https://github.com/0xMiden/miden-node/issues/1709)).
 
 ### Changes
 
@@ -24,6 +24,7 @@
 - Improved tracing span fields ([#1650](https://github.com/0xMiden/miden-node/pull/1650))
  - Replaced NTX Builder's in-memory state management with SQLite-backed persistence; account states, notes, and transaction effects are now stored in the database and inflight state is purged on startup ([#1662](https://github.com/0xMiden/miden-node/pull/1662)).
 - [BREAKING] Reworked `miden-remote-prover`, removing the `worker`/`proxy` distinction and simplifying to a `worker` with a request queue ([#1688](https://github.com/0xMiden/miden-node/pull/1688)).
+- Fixed `TransactionHeader` serialization for row insertion on database & fixed transaction cursor on retrievals ([#1701](https://github.com/0xMiden/miden-node/issues/1701)).
 
 ## v0.13.5 (2026-02-19)
 

--- a/bin/remote-prover/src/lib.rs
+++ b/bin/remote-prover/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod generated;
+pub mod server;
+
+/// Component identifier for structured logging and tracing.
+pub const COMPONENT: &str = "miden-prover";
+
+// Convenience re-exports for library consumers.
+pub use server::RpcListener;
+pub use server::proof_kind::ProofKind;

--- a/bin/remote-prover/src/main.rs
+++ b/bin/remote-prover/src/main.rs
@@ -1,20 +1,18 @@
 use anyhow::Context;
 use clap::Parser;
 use miden_node_utils::logging::{OpenTelemetry, setup_tracing};
+use miden_remote_prover::COMPONENT;
 use tracing::info;
-
-mod generated;
-mod server;
-
-const COMPONENT: &str = "miden-prover";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let _otel_guard = setup_tracing(OpenTelemetry::Enabled)?;
     info!(target: COMPONENT, "Tracing initialized");
 
-    let (handle, _port) =
-        server::Server::parse().spawn().await.context("failed to spawn server")?;
+    let (handle, _port) = miden_remote_prover::server::Server::parse()
+        .spawn()
+        .await
+        .context("failed to spawn server")?;
 
     handle.await.context("proof server panicked").flatten()
 }


### PR DESCRIPTION
After #1688 the miden-client lost the capability of using the testing prover due to it's previously used structures/methods becoming private or removed. This PR re-adds this functionality.
