### PR TITLE
feat(rocksdb): tune LargeSmt profile and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## v0.14.7 (2026-04-15)
 
 - [BREAKING] Aligned proto `TransactionHeader` with domain type and exposed erased notes in `SyncTransactions` ([#1941](https://github.com/0xMiden/node/pull/1941)).
+- Improved LargeSmt RocksDB defaults, added tuning and memory-budget controls, and defaulted durability mode to sync ([#1947](https://github.com/0xMiden/node/pull/1947))
 
 ## v0.14.6 (2026-04-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## v0.14.7 (2026-04-15)
 
 - [BREAKING] Aligned proto `TransactionHeader` with domain type and exposed erased notes in `SyncTransactions` ([#1941](https://github.com/0xMiden/node/pull/1941)).
-- Improved LargeSmt RocksDB defaults, added tuning and memory-budget controls, and defaulted durability mode to sync ([#1947](https://github.com/0xMiden/node/pull/1947))
+- Improved LargeSmt RocksDB defaults, added per-DB memory-budget controls, and exposed durability mode selection ([#1947](https://github.com/0xMiden/node/pull/1947)).
 
 ## v0.14.6 (2026-04-10)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -7625,3 +7626,13 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/large-smt-backend-rocksdb/Cargo.toml
+++ b/crates/large-smt-backend-rocksdb/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 miden-crypto   = { features = ["concurrent", "std"], workspace = true }
 miden-protocol = { features = ["std"], workspace = true }
 rayon          = { version = "1.10" }
-rocksdb        = { default-features = false, features = ["bindgen-runtime", "lz4"], version = "0.24" }
+rocksdb        = { default-features = false, features = ["bindgen-runtime", "lz4", "zstd"], version = "0.24" }
 
 [build-dependencies]
 miden-node-rocksdb-cxx-linkage-fix = { workspace = true }

--- a/crates/large-smt-backend-rocksdb/src/lib.rs
+++ b/crates/large-smt-backend-rocksdb/src/lib.rs
@@ -56,4 +56,12 @@ pub use miden_protocol::{
         merkle::{EmptySubtreeRoots, InnerNodeInfo, MerkleError, NodeIndex, SparseMerklePath},
     },
 };
-pub use rocksdb::{RocksDbConfig, RocksDbStorage};
+pub use rocksdb::{
+    RocksDbBloomFilterBitsPerKey,
+    RocksDbConfig,
+    RocksDbDurabilityMode,
+    RocksDbMemoryBudget,
+    RocksDbStorage,
+    RocksDbTuningOptions,
+    RocksDbWriteBufferManagerBudget,
+};

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -1439,11 +1439,11 @@ impl Default for RocksDbBloomFilterBitsPerKey {
         Self {
             leaves: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
             depth_24: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
-            subtree_24: 8.0,
+            subtree_24: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
             subtree_32: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
             subtree_40: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
-            subtree_48: 12.0,
-            subtree_56: 12.0,
+            subtree_48: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
+            subtree_56: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
         }
     }
 }

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -33,13 +33,6 @@ const DEFAULT_CACHE_SIZE: usize = 1 << 30;
 const DEFAULT_MAX_OPEN_FILES: i32 = 512;
 const DEFAULT_BLOCK_SIZE: usize = 16 << 10;
 const DEFAULT_MAX_TOTAL_WAL_SIZE: u64 = 512 * 1024 * 1024;
-const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 << 20;
-const DEFAULT_MAX_WRITE_BUFFER_NUMBER: i32 = 3;
-const DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: i32 = 1;
-const DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN: i64 = 0;
-const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 512 << 20;
-const DEFAULT_TARGET_FILE_SIZE_MULTIPLIER: i32 = 2;
-const DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: i32 = 8;
 const DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES: i32 = 1 << 20;
 const DEFAULT_BLOOM_FILTER_BITS_PER_KEY: f64 = 10.0;
 
@@ -143,7 +136,7 @@ impl RocksDbStorage {
         // Column family for leaves
         let mut leaves_opts = Options::default();
         leaves_opts.set_block_based_table_factory(&table_opts);
-        configure_smt_cf_options(&mut leaves_opts, tuning_options);
+        configure_smt_cf_options(&mut leaves_opts);
         if let Some(write_buffer_manager) = write_buffer_manager.as_ref() {
             db_opts.set_write_buffer_manager(write_buffer_manager);
             leaves_opts.set_write_buffer_manager(write_buffer_manager);
@@ -167,7 +160,7 @@ impl RocksDbStorage {
 
             let mut opts = Options::default();
             opts.set_block_based_table_factory(&table_opts);
-            configure_smt_cf_options(&mut opts, tuning_options);
+            configure_smt_cf_options(&mut opts);
             if let Some(write_buffer_manager) = write_buffer_manager {
                 opts.set_write_buffer_manager(write_buffer_manager);
             }
@@ -1181,21 +1174,26 @@ impl Iterator for RocksDbSubtreeIterator<'_> {
     }
 }
 
-fn configure_smt_cf_options(opts: &mut Options, tuning_options: &RocksDbTuningOptions) {
-    opts.set_write_buffer_size(tuning_options.write_buffer_size);
-    opts.set_max_write_buffer_number(tuning_options.max_write_buffer_number);
-    opts.set_min_write_buffer_number_to_merge(tuning_options.min_write_buffer_number_to_merge);
-    opts.set_max_write_buffer_size_to_maintain(tuning_options.max_write_buffer_size_to_maintain);
+fn configure_smt_cf_options(opts: &mut Options) {
+    // 128 MB memtable
+    opts.set_write_buffer_size(128 << 20);
+    // Allow up to 3 memtables
+    opts.set_max_write_buffer_number(3);
+    opts.set_min_write_buffer_number_to_merge(1);
+    // Do not retain flushed memtables in memory
+    opts.set_max_write_buffer_size_to_maintain(0);
+    // Use level-based compaction
     opts.set_compaction_style(DBCompactionStyle::Level);
-    opts.set_target_file_size_base(tuning_options.target_file_size_base);
-    opts.set_target_file_size_multiplier(tuning_options.target_file_size_multiplier);
+    // 512 MB target file size
+    opts.set_target_file_size_base(512 << 20);
+    opts.set_target_file_size_multiplier(2);
+    // LZ4 compression for active files, ZSTD for bottommost files
     opts.set_compression_type(DBCompressionType::Lz4);
     opts.set_bottommost_compression_type(DBCompressionType::Zstd);
     // Enable the bottommost compression setting; selecting ZSTD alone is not enough.
     opts.set_bottommost_zstd_max_train_bytes(DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES, true);
-    opts.set_level_zero_file_num_compaction_trigger(
-        tuning_options.level_zero_file_num_compaction_trigger,
-    );
+    // Set level-based compaction parameters
+    opts.set_level_zero_file_num_compaction_trigger(8);
 }
 
 fn configure_block_table_options(
@@ -1408,13 +1406,6 @@ pub struct RocksDbWriteBufferManagerBudget {
 pub struct RocksDbTuningOptions {
     pub block_size: usize,
     pub max_total_wal_size: u64,
-    pub write_buffer_size: usize,
-    pub max_write_buffer_number: i32,
-    pub min_write_buffer_number_to_merge: i32,
-    pub max_write_buffer_size_to_maintain: i64,
-    pub target_file_size_base: u64,
-    pub target_file_size_multiplier: i32,
-    pub level_zero_file_num_compaction_trigger: i32,
     pub bloom_filter_bits_per_key: RocksDbBloomFilterBitsPerKey,
 }
 
@@ -1423,13 +1414,6 @@ impl Default for RocksDbTuningOptions {
         Self {
             block_size: DEFAULT_BLOCK_SIZE,
             max_total_wal_size: DEFAULT_MAX_TOTAL_WAL_SIZE,
-            write_buffer_size: DEFAULT_WRITE_BUFFER_SIZE,
-            max_write_buffer_number: DEFAULT_MAX_WRITE_BUFFER_NUMBER,
-            min_write_buffer_number_to_merge: DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE,
-            max_write_buffer_size_to_maintain: DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN,
-            target_file_size_base: DEFAULT_TARGET_FILE_SIZE_BASE,
-            target_file_size_multiplier: DEFAULT_TARGET_FILE_SIZE_MULTIPLIER,
-            level_zero_file_num_compaction_trigger: DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
             bloom_filter_bits_per_key: RocksDbBloomFilterBitsPerKey::default(),
         }
     }

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -1258,7 +1258,7 @@ impl RocksDbConfig {
     /// * `max_open_files`: 512
     /// * `write_buffer_manager`: disabled
     /// * `tuning_options`: [`RocksDbTuningOptions::default()`]
-    /// * `durability_mode`: [`RocksDbDurabilityMode::Sync`]
+    /// * `durability_mode`: [`RocksDbDurabilityMode::Relaxed`]
     ///
     /// # Examples
     /// ```
@@ -1344,7 +1344,8 @@ impl RocksDbConfig {
 
     /// Sets the RocksDB write durability mode.
     ///
-    /// The default is [`RocksDbDurabilityMode::Sync`].
+    /// The default is [`RocksDbDurabilityMode::Relaxed`], matching RocksDB's default non-sync
+    /// writes.
     #[must_use]
     pub fn with_durability_mode(mut self, durability_mode: RocksDbDurabilityMode) -> Self {
         self.durability_mode = durability_mode;
@@ -1368,8 +1369,8 @@ impl RocksDbConfig {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum RocksDbDurabilityMode {
-    Relaxed,
     #[default]
+    Relaxed,
     Sync,
 }
 
@@ -1496,6 +1497,14 @@ mod tests {
                 tuning_options,
                 durability_mode: RocksDbDurabilityMode::Sync,
             }
+        );
+    }
+
+    #[test]
+    fn rocksdb_config_defaults_to_relaxed_durability() {
+        assert_eq!(
+            RocksDbConfig::new("/tmp/smt").durability_mode,
+            RocksDbDurabilityMode::Relaxed
         );
     }
 }

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -105,6 +105,7 @@ impl RocksDbStorage {
     /// # Errors
     /// Returns `StorageError::Backend` if the database cannot be opened or configured,
     /// for example, due to path issues, permissions, or RocksDB internal errors.
+    #[expect(clippy::too_many_lines)]
     pub fn open(config: RocksDbConfig) -> Result<Self, StorageError> {
         let tuning_options = &config.tuning_options;
 
@@ -1306,8 +1307,9 @@ impl RocksDbConfig {
     /// * `memory_budget` - Memory budget settings for RocksDB.
     #[must_use]
     pub fn with_memory_budget(mut self, memory_budget: RocksDbMemoryBudget) -> Self {
-        self.cache_size = memory_budget.block_cache_size;
-        self.write_buffer_manager = memory_budget.write_buffer_manager;
+        let RocksDbMemoryBudget { block_cache_size, write_buffer_manager } = memory_budget;
+        self.cache_size = block_cache_size;
+        self.write_buffer_manager = write_buffer_manager;
         self
     }
 
@@ -1371,7 +1373,7 @@ pub enum RocksDbDurabilityMode {
     Sync,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RocksDbMemoryBudget {
     pub block_cache_size: usize,
     pub write_buffer_manager: Option<RocksDbWriteBufferManagerBudget>,
@@ -1479,7 +1481,7 @@ mod tests {
         };
 
         let config = RocksDbConfig::new("/tmp/smt")
-            .with_memory_budget(memory_budget.clone())
+            .with_memory_budget(memory_budget)
             .with_max_open_files(1024)
             .with_tuning_options(tuning_options.clone())
             .with_durability_mode(RocksDbDurabilityMode::Sync);

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -40,6 +40,7 @@ const DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN: i64 = 0;
 const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 512 << 20;
 const DEFAULT_TARGET_FILE_SIZE_MULTIPLIER: i32 = 2;
 const DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: i32 = 8;
+const DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES: i32 = 1 << 20;
 const DEFAULT_BLOOM_FILTER_BITS_PER_KEY: f64 = 10.0;
 
 /// The name of the `RocksDB` column family used for storing SMT leaves.
@@ -185,6 +186,11 @@ impl RocksDbStorage {
         let mut depth24_opts = Options::default();
         depth24_opts.set_compression_type(DBCompressionType::Lz4);
         depth24_opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+        // Enable the bottommost compression setting; selecting ZSTD alone is not enough.
+        depth24_opts.set_bottommost_zstd_max_train_bytes(
+            DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES,
+            true,
+        );
         depth24_opts.set_block_based_table_factory(&depth24_table_opts);
         if let Some(write_buffer_manager) = write_buffer_manager.as_ref() {
             depth24_opts.set_write_buffer_manager(write_buffer_manager);
@@ -1185,6 +1191,8 @@ fn configure_smt_cf_options(opts: &mut Options, tuning_options: &RocksDbTuningOp
     opts.set_target_file_size_multiplier(tuning_options.target_file_size_multiplier);
     opts.set_compression_type(DBCompressionType::Lz4);
     opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+    // Enable the bottommost compression setting; selecting ZSTD alone is not enough.
+    opts.set_bottommost_zstd_max_train_bytes(DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES, true);
     opts.set_level_zero_file_num_compaction_trigger(
         tuning_options.level_zero_file_num_compaction_trigger,
     );

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -90,7 +90,7 @@ impl RocksDbStorage {
     /// and compaction strategies tailored for SMT workloads.
     ///
     /// The default profile uses:
-    /// - a 1 GiB shared block cache
+    /// - a 1 GiB block cache shared by this database's column families
     /// - up to 512 open files
     /// - 16 KiB block-based table blocks with cached index/filter blocks
     /// - 128 MiB write buffers with up to 3 memtables per write-heavy column family
@@ -120,7 +120,7 @@ impl RocksDbStorage {
         // Maximum WAL size
         db_opts.set_max_total_wal_size(tuning_options.max_total_wal_size);
 
-        // Shared block cache across all column families
+        // Cache and optional write-buffer manager are shared across this DB's column families.
         let cache = Cache::new_lru_cache(config.cache_size);
         let write_buffer_manager = config.write_buffer_manager(&cache);
 
@@ -1242,7 +1242,7 @@ pub struct RocksDbConfig {
     /// increase resource usage. Default: 512 files
     pub(crate) max_open_files: i32,
 
-    /// Optional shared memtable budget settings.
+    /// Optional per-DB write-buffer manager shared by this DB's column families.
     pub(crate) write_buffer_manager: Option<RocksDbWriteBufferManagerBudget>,
 
     /// Tunable RocksDB profile values.
@@ -1305,9 +1305,11 @@ impl RocksDbConfig {
         self
     }
 
-    /// Sets the RocksDB memory budget.
+    /// Sets the RocksDB memory budget for this database instance.
     ///
-    /// This controls the shared block cache size and optional shared write-buffer manager.
+    /// This controls the block cache size and optional write-buffer manager created by
+    /// [`RocksDbStorage::open`] for one DB and its column families. It is not a process-wide
+    /// budget across multiple RocksDB instances.
     ///
     /// # Arguments
     /// * `memory_budget` - Memory budget settings for RocksDB.
@@ -1382,7 +1384,9 @@ pub enum RocksDbDurabilityMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RocksDbMemoryBudget {
+    /// Block cache size for one RocksDB instance.
     pub block_cache_size: usize,
+    /// Optional write-buffer manager for one RocksDB instance.
     pub write_buffer_manager: Option<RocksDbWriteBufferManagerBudget>,
 }
 

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -20,6 +20,8 @@ use rocksdb::{
     Options,
     ReadOptions,
     WriteBatch,
+    WriteBufferManager,
+    WriteOptions,
 };
 
 use super::{SmtStorage, StorageError, StorageUpdateParts, StorageUpdates, SubtreeUpdate};
@@ -27,6 +29,18 @@ use crate::helpers::{insert_into_leaf, map_rocksdb_err, remove_from_leaf};
 use crate::{EMPTY_WORD, Word};
 
 const IN_MEMORY_DEPTH: u8 = 24;
+const DEFAULT_CACHE_SIZE: usize = 1 << 30;
+const DEFAULT_MAX_OPEN_FILES: i32 = 512;
+const DEFAULT_BLOCK_SIZE: usize = 16 << 10;
+const DEFAULT_MAX_TOTAL_WAL_SIZE: u64 = 512 * 1024 * 1024;
+const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 << 20;
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: i32 = 3;
+const DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: i32 = 1;
+const DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN: i64 = 0;
+const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 512 << 20;
+const DEFAULT_TARGET_FILE_SIZE_MULTIPLIER: i32 = 2;
+const DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: i32 = 8;
+const DEFAULT_BLOOM_FILTER_BITS_PER_KEY: f64 = 10.0;
 
 /// The name of the `RocksDB` column family used for storing SMT leaves.
 const LEAVES_CF: &str = "leaves";
@@ -70,6 +84,7 @@ const ENTRY_COUNT_KEY: &[u8] = b"entry_count";
 #[derive(Debug, Clone)]
 pub struct RocksDbStorage {
     db: Arc<DB>,
+    durability_mode: RocksDbDurabilityMode,
 }
 
 impl RocksDbStorage {
@@ -80,10 +95,19 @@ impl RocksDbStorage {
     /// and applies various RocksDB options for performance, such as caching, bloom filters,
     /// and compaction strategies tailored for SMT workloads.
     ///
+    /// The default profile uses:
+    /// - a 1 GiB shared block cache
+    /// - up to 512 open files
+    /// - 16 KiB block-based table blocks with cached index/filter blocks
+    /// - 128 MiB write buffers with up to 3 memtables per write-heavy column family
+    /// - LZ4 compression for active data and ZSTD for bottommost files
+    ///
     /// # Errors
     /// Returns `StorageError::Backend` if the database cannot be opened or configured,
     /// for example, due to path issues, permissions, or RocksDB internal errors.
     pub fn open(config: RocksDbConfig) -> Result<Self, StorageError> {
+        let tuning_options = &config.tuning_options;
+
         // Base DB options
         let mut db_opts = Options::default();
         // Create DB if it doesn't exist
@@ -99,90 +123,127 @@ impl RocksDbStorage {
         // Parallelize flush/compaction up to CPU count
         db_opts.set_max_background_jobs(rayon::current_num_threads() as i32);
         // Maximum WAL size
-        db_opts.set_max_total_wal_size(512 * 1024 * 1024);
+        db_opts.set_max_total_wal_size(tuning_options.max_total_wal_size);
 
         // Shared block cache across all column families
         let cache = Cache::new_lru_cache(config.cache_size);
+        let write_buffer_manager = config.write_buffer_manager(&cache);
 
         // Common table options for bloom filtering and cache
         let mut table_opts = BlockBasedOptions::default();
-        // Use shared LRU cache for block data
-        table_opts.set_block_cache(&cache);
-        table_opts.set_bloom_filter(10.0, false);
-        // Enable whole-key bloom filtering (better with point lookups)
-        table_opts.set_whole_key_filtering(true);
-        // Pin L0 filter and index blocks in cache (improves performance)
-        table_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        configure_block_table_options(
+            &mut table_opts,
+            &cache,
+            tuning_options,
+            tuning_options.bloom_filter_bits_per_key.leaves,
+        );
 
         // Column family for leaves
         let mut leaves_opts = Options::default();
         leaves_opts.set_block_based_table_factory(&table_opts);
-        // 128 MB memtable
-        leaves_opts.set_write_buffer_size(128 << 20);
-        // Allow up to 3 memtables
-        leaves_opts.set_max_write_buffer_number(3);
-        leaves_opts.set_min_write_buffer_number_to_merge(1);
-        // Do not retain flushed memtables in memory
-        leaves_opts.set_max_write_buffer_size_to_maintain(0);
-        // Use level-based compaction
-        leaves_opts.set_compaction_style(DBCompactionStyle::Level);
-        // 512 MB target file size
-        leaves_opts.set_target_file_size_base(512 << 20);
-        leaves_opts.set_target_file_size_multiplier(2);
-        // LZ4 compression
-        leaves_opts.set_compression_type(DBCompressionType::Lz4);
-        // Set level-based compaction parameters
-        leaves_opts.set_level_zero_file_num_compaction_trigger(8);
+        configure_smt_cf_options(&mut leaves_opts, tuning_options);
+        if let Some(write_buffer_manager) = write_buffer_manager.as_ref() {
+            db_opts.set_write_buffer_manager(write_buffer_manager);
+            leaves_opts.set_write_buffer_manager(write_buffer_manager);
+        }
 
-        // Helper to build subtree CF options with correct prefix length
+        // Helper to build subtree CF options with the tuned block-table profile
         #[expect(clippy::items_after_statements)]
-        fn subtree_cf(cache: &Cache, bloom_filter_bits: f64) -> Options {
-            let mut tbl = BlockBasedOptions::default();
-            // Use shared LRU cache for block data
-            tbl.set_block_cache(cache);
-            // Set bloom filter for subtree lookups
-            tbl.set_bloom_filter(bloom_filter_bits, false);
-            // Enable whole-key bloom filtering
-            tbl.set_whole_key_filtering(true);
-            // Pin L0 filter and index blocks in cache
-            tbl.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        fn subtree_cf(
+            cache: &Cache,
+            tuning_options: &RocksDbTuningOptions,
+            bloom_filter_bits: f64,
+            write_buffer_manager: Option<&WriteBufferManager>,
+        ) -> Options {
+            let mut table_opts = BlockBasedOptions::default();
+            configure_block_table_options(
+                &mut table_opts,
+                cache,
+                tuning_options,
+                bloom_filter_bits,
+            );
 
             let mut opts = Options::default();
-            opts.set_block_based_table_factory(&tbl);
-            // 128 MB memtable
-            opts.set_write_buffer_size(128 << 20);
-            opts.set_max_write_buffer_number(3);
-            opts.set_min_write_buffer_number_to_merge(1);
-            // Do not retain flushed memtables in memory
-            opts.set_max_write_buffer_size_to_maintain(0);
-            // Use level-based compaction
-            opts.set_compaction_style(DBCompactionStyle::Level);
-            // 512 MB target file size
-            opts.set_target_file_size_base(512 << 20);
-            opts.set_target_file_size_multiplier(2);
-            // LZ4 compression
-            opts.set_compression_type(DBCompressionType::Lz4);
-            // Set level-based compaction parameters
-            opts.set_level_zero_file_num_compaction_trigger(8);
+            opts.set_block_based_table_factory(&table_opts);
+            configure_smt_cf_options(&mut opts, tuning_options);
+            if let Some(write_buffer_manager) = write_buffer_manager {
+                opts.set_write_buffer_manager(write_buffer_manager);
+            }
             opts
         }
 
+        // Depth-24 cache column family
+        let mut depth24_table_opts = BlockBasedOptions::default();
+        configure_block_table_options(
+            &mut depth24_table_opts,
+            &cache,
+            tuning_options,
+            tuning_options.bloom_filter_bits_per_key.depth_24,
+        );
+
         let mut depth24_opts = Options::default();
         depth24_opts.set_compression_type(DBCompressionType::Lz4);
-        depth24_opts.set_block_based_table_factory(&table_opts);
+        depth24_opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+        depth24_opts.set_block_based_table_factory(&depth24_table_opts);
+        if let Some(write_buffer_manager) = write_buffer_manager.as_ref() {
+            depth24_opts.set_write_buffer_manager(write_buffer_manager);
+        }
 
         // Metadata CF with no compression
         let mut metadata_opts = Options::default();
         metadata_opts.set_compression_type(DBCompressionType::None);
+        if let Some(write_buffer_manager) = write_buffer_manager.as_ref() {
+            metadata_opts.set_write_buffer_manager(write_buffer_manager);
+        }
 
         // Define column families with tailored options
         let cfs = vec![
             ColumnFamilyDescriptor::new(LEAVES_CF, leaves_opts),
-            ColumnFamilyDescriptor::new(SUBTREE_24_CF, subtree_cf(&cache, 8.0)),
-            ColumnFamilyDescriptor::new(SUBTREE_32_CF, subtree_cf(&cache, 10.0)),
-            ColumnFamilyDescriptor::new(SUBTREE_40_CF, subtree_cf(&cache, 10.0)),
-            ColumnFamilyDescriptor::new(SUBTREE_48_CF, subtree_cf(&cache, 12.0)),
-            ColumnFamilyDescriptor::new(SUBTREE_56_CF, subtree_cf(&cache, 12.0)),
+            ColumnFamilyDescriptor::new(
+                SUBTREE_24_CF,
+                subtree_cf(
+                    &cache,
+                    tuning_options,
+                    tuning_options.bloom_filter_bits_per_key.subtree_24,
+                    write_buffer_manager.as_ref(),
+                ),
+            ),
+            ColumnFamilyDescriptor::new(
+                SUBTREE_32_CF,
+                subtree_cf(
+                    &cache,
+                    tuning_options,
+                    tuning_options.bloom_filter_bits_per_key.subtree_32,
+                    write_buffer_manager.as_ref(),
+                ),
+            ),
+            ColumnFamilyDescriptor::new(
+                SUBTREE_40_CF,
+                subtree_cf(
+                    &cache,
+                    tuning_options,
+                    tuning_options.bloom_filter_bits_per_key.subtree_40,
+                    write_buffer_manager.as_ref(),
+                ),
+            ),
+            ColumnFamilyDescriptor::new(
+                SUBTREE_48_CF,
+                subtree_cf(
+                    &cache,
+                    tuning_options,
+                    tuning_options.bloom_filter_bits_per_key.subtree_48,
+                    write_buffer_manager.as_ref(),
+                ),
+            ),
+            ColumnFamilyDescriptor::new(
+                SUBTREE_56_CF,
+                subtree_cf(
+                    &cache,
+                    tuning_options,
+                    tuning_options.bloom_filter_bits_per_key.subtree_56,
+                    write_buffer_manager.as_ref(),
+                ),
+            ),
             ColumnFamilyDescriptor::new(METADATA_CF, metadata_opts),
             ColumnFamilyDescriptor::new(DEPTH_24_CF, depth24_opts),
         ];
@@ -190,7 +251,24 @@ impl RocksDbStorage {
         // Open the database with our tuned CFs
         let db = DB::open_cf_descriptors(&db_opts, config.path, cfs).map_err(map_rocksdb_err)?;
 
-        Ok(Self { db: Arc::new(db) })
+        Ok(Self {
+            db: Arc::new(db),
+            durability_mode: config.durability_mode,
+        })
+    }
+
+    fn write_options(&self) -> WriteOptions {
+        let mut write_opts = WriteOptions::default();
+        write_opts.set_sync(self.should_sync_writes());
+        write_opts
+    }
+
+    fn write_batch(&self, batch: WriteBatch) -> Result<(), StorageError> {
+        self.db.write_opt(batch, &self.write_options()).map_err(map_rocksdb_err)
+    }
+
+    fn should_sync_writes(&self) -> bool {
+        self.durability_mode == RocksDbDurabilityMode::Sync
     }
 
     /// Syncs the RocksDB database to disk.
@@ -376,7 +454,7 @@ impl SmtStorage for RocksDbStorage {
         batch.put_cf(metadata_cf, ENTRY_COUNT_KEY, current_entry_count.to_be_bytes());
 
         // Atomically write all changes (leaf data and metadata counts).
-        self.db.write(batch).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
 
         Ok(value_to_return)
     }
@@ -423,7 +501,7 @@ impl SmtStorage for RocksDbStorage {
         }
         batch.put_cf(metadata_cf, LEAF_COUNT_KEY, leaf_count.to_be_bytes());
         batch.put_cf(metadata_cf, ENTRY_COUNT_KEY, entry_count.to_be_bytes());
-        self.db.write(batch).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
         Ok(current_value)
     }
 
@@ -470,7 +548,7 @@ impl SmtStorage for RocksDbStorage {
         let metadata_cf = self.cf_handle(METADATA_CF)?;
         batch.put_cf(metadata_cf, LEAF_COUNT_KEY, leaf_count.to_be_bytes());
         batch.put_cf(metadata_cf, ENTRY_COUNT_KEY, entry_count.to_be_bytes());
-        self.db.write(batch).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
         Ok(())
     }
 
@@ -492,7 +570,7 @@ impl SmtStorage for RocksDbStorage {
         let key = Self::index_db_key(index);
         let cf = self.cf_handle(LEAVES_CF)?;
         let old_bytes = self.db.get_cf(cf, key).map_err(map_rocksdb_err)?;
-        self.db.delete_cf(cf, key).map_err(map_rocksdb_err)?;
+        self.db.delete_cf_opt(cf, key, &self.write_options()).map_err(map_rocksdb_err)?;
         Ok(old_bytes.map(|bytes| {
             SmtLeaf::read_from_bytes_with_budget(&bytes, bytes.len())
                 .expect("failed to deserialize leaf")
@@ -669,7 +747,7 @@ impl SmtStorage for RocksDbStorage {
             batch.put_cf(depth24_cf, hash_key, root_hash.to_bytes());
         }
 
-        self.db.write(batch).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
         Ok(())
     }
 
@@ -705,7 +783,7 @@ impl SmtStorage for RocksDbStorage {
             }
         }
 
-        self.db.write(batch).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
         Ok(())
     }
 
@@ -728,7 +806,7 @@ impl SmtStorage for RocksDbStorage {
             batch.delete_cf(depth24_cf, hash_key);
         }
 
-        self.db.write(batch).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
         Ok(())
     }
 
@@ -915,10 +993,7 @@ impl SmtStorage for RocksDbStorage {
             batch.put_cf(metadata_cf, ENTRY_COUNT_KEY, new_entry_count.to_be_bytes());
         }
 
-        let mut write_opts = rocksdb::WriteOptions::default();
-        // Disable immediate WAL sync to disk for better performance
-        write_opts.set_sync(false);
-        self.db.write_opt(batch, &write_opts).map_err(map_rocksdb_err)?;
+        self.write_batch(batch)?;
 
         Ok(())
     }
@@ -1099,6 +1174,36 @@ impl Iterator for RocksDbSubtreeIterator<'_> {
     }
 }
 
+fn configure_smt_cf_options(opts: &mut Options, tuning_options: &RocksDbTuningOptions) {
+    opts.set_write_buffer_size(tuning_options.write_buffer_size);
+    opts.set_max_write_buffer_number(tuning_options.max_write_buffer_number);
+    opts.set_min_write_buffer_number_to_merge(tuning_options.min_write_buffer_number_to_merge);
+    opts.set_max_write_buffer_size_to_maintain(tuning_options.max_write_buffer_size_to_maintain);
+    opts.set_compaction_style(DBCompactionStyle::Level);
+    opts.set_target_file_size_base(tuning_options.target_file_size_base);
+    opts.set_target_file_size_multiplier(tuning_options.target_file_size_multiplier);
+    opts.set_compression_type(DBCompressionType::Lz4);
+    opts.set_bottommost_compression_type(DBCompressionType::Zstd);
+    opts.set_level_zero_file_num_compaction_trigger(
+        tuning_options.level_zero_file_num_compaction_trigger,
+    );
+}
+
+fn configure_block_table_options(
+    table_opts: &mut BlockBasedOptions,
+    cache: &Cache,
+    tuning_options: &RocksDbTuningOptions,
+    bloom_bits_per_key: f64,
+) {
+    // Keep all block-based column families on the same cache and metadata policy.
+    table_opts.set_block_cache(cache);
+    table_opts.set_cache_index_and_filter_blocks(true);
+    table_opts.set_bloom_filter(bloom_bits_per_key, false);
+    table_opts.set_block_size(tuning_options.block_size);
+    table_opts.set_whole_key_filtering(true);
+    table_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+}
+
 // ROCKSDB CONFIGURATION
 // --------------------------------------------------------------------------------------------
 
@@ -1107,7 +1212,7 @@ impl Iterator for RocksDbSubtreeIterator<'_> {
 /// This struct contains the essential configuration parameters needed to initialize
 /// and optimize RocksDB for SMT storage operations. It provides sensible defaults
 /// while allowing customization for specific performance requirements.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RocksDbConfig {
     /// The filesystem path where the RocksDB database will be stored.
     ///
@@ -1129,6 +1234,15 @@ pub struct RocksDbConfig {
     /// process. Higher values may improve performance for databases with many SST files but
     /// increase resource usage. Default: 512 files
     pub(crate) max_open_files: i32,
+
+    /// Optional shared memtable budget settings.
+    pub(crate) write_buffer_manager: Option<RocksDbWriteBufferManagerBudget>,
+
+    /// Tunable RocksDB profile values.
+    pub(crate) tuning_options: RocksDbTuningOptions,
+
+    /// Write durability mode for RocksDB write operations.
+    pub(crate) durability_mode: RocksDbDurabilityMode,
 }
 
 impl RocksDbConfig {
@@ -1141,6 +1255,9 @@ impl RocksDbConfig {
     /// # Default Settings
     /// * `cache_size`: 1GB (1,073,741,824 bytes)
     /// * `max_open_files`: 512
+    /// * `write_buffer_manager`: disabled
+    /// * `tuning_options`: [`RocksDbTuningOptions::default()`]
+    /// * `durability_mode`: [`RocksDbDurabilityMode::Sync`]
     ///
     /// # Examples
     /// ```
@@ -1151,8 +1268,11 @@ impl RocksDbConfig {
     pub fn new<P: Into<PathBuf>>(path: P) -> Self {
         Self {
             path: path.into(),
-            cache_size: 1 << 30,
-            max_open_files: 512,
+            cache_size: DEFAULT_CACHE_SIZE,
+            max_open_files: DEFAULT_MAX_OPEN_FILES,
+            write_buffer_manager: None,
+            tuning_options: RocksDbTuningOptions::default(),
+            durability_mode: RocksDbDurabilityMode::default(),
         }
     }
 
@@ -1178,6 +1298,19 @@ impl RocksDbConfig {
         self
     }
 
+    /// Sets the RocksDB memory budget.
+    ///
+    /// This controls the shared block cache size and optional shared write-buffer manager.
+    ///
+    /// # Arguments
+    /// * `memory_budget` - Memory budget settings for RocksDB.
+    #[must_use]
+    pub fn with_memory_budget(mut self, memory_budget: RocksDbMemoryBudget) -> Self {
+        self.cache_size = memory_budget.block_cache_size;
+        self.write_buffer_manager = memory_budget.write_buffer_manager;
+        self
+    }
+
     /// Sets the maximum number of files that RocksDB can have open simultaneously.
     ///
     /// This setting affects both memory usage and the number of file descriptors used by the
@@ -1198,6 +1331,170 @@ impl RocksDbConfig {
     pub fn with_max_open_files(mut self, count: i32) -> Self {
         self.max_open_files = count;
         self
+    }
+
+    /// Sets the RocksDB tuning options.
+    #[must_use]
+    pub fn with_tuning_options(mut self, tuning_options: RocksDbTuningOptions) -> Self {
+        self.tuning_options = tuning_options;
+        self
+    }
+
+    /// Sets the RocksDB write durability mode.
+    ///
+    /// The default is [`RocksDbDurabilityMode::Sync`].
+    #[must_use]
+    pub fn with_durability_mode(mut self, durability_mode: RocksDbDurabilityMode) -> Self {
+        self.durability_mode = durability_mode;
+        self
+    }
+
+    fn write_buffer_manager(&self, cache: &Cache) -> Option<WriteBufferManager> {
+        self.write_buffer_manager.as_ref().map(|budget| {
+            if budget.charge_to_block_cache {
+                WriteBufferManager::new_write_buffer_manager_with_cache(
+                    budget.buffer_size,
+                    budget.allow_stall,
+                    cache.clone(),
+                )
+            } else {
+                WriteBufferManager::new_write_buffer_manager(budget.buffer_size, budget.allow_stall)
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum RocksDbDurabilityMode {
+    Relaxed,
+    #[default]
+    Sync,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RocksDbMemoryBudget {
+    pub block_cache_size: usize,
+    pub write_buffer_manager: Option<RocksDbWriteBufferManagerBudget>,
+}
+
+impl Default for RocksDbMemoryBudget {
+    fn default() -> Self {
+        Self {
+            block_cache_size: DEFAULT_CACHE_SIZE,
+            write_buffer_manager: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RocksDbWriteBufferManagerBudget {
+    pub buffer_size: usize,
+    pub allow_stall: bool,
+    pub charge_to_block_cache: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RocksDbTuningOptions {
+    pub block_size: usize,
+    pub max_total_wal_size: u64,
+    pub write_buffer_size: usize,
+    pub max_write_buffer_number: i32,
+    pub min_write_buffer_number_to_merge: i32,
+    pub max_write_buffer_size_to_maintain: i64,
+    pub target_file_size_base: u64,
+    pub target_file_size_multiplier: i32,
+    pub level_zero_file_num_compaction_trigger: i32,
+    pub bloom_filter_bits_per_key: RocksDbBloomFilterBitsPerKey,
+}
+
+impl Default for RocksDbTuningOptions {
+    fn default() -> Self {
+        Self {
+            block_size: DEFAULT_BLOCK_SIZE,
+            max_total_wal_size: DEFAULT_MAX_TOTAL_WAL_SIZE,
+            write_buffer_size: DEFAULT_WRITE_BUFFER_SIZE,
+            max_write_buffer_number: DEFAULT_MAX_WRITE_BUFFER_NUMBER,
+            min_write_buffer_number_to_merge: DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE,
+            max_write_buffer_size_to_maintain: DEFAULT_MAX_WRITE_BUFFER_SIZE_TO_MAINTAIN,
+            target_file_size_base: DEFAULT_TARGET_FILE_SIZE_BASE,
+            target_file_size_multiplier: DEFAULT_TARGET_FILE_SIZE_MULTIPLIER,
+            level_zero_file_num_compaction_trigger: DEFAULT_LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER,
+            bloom_filter_bits_per_key: RocksDbBloomFilterBitsPerKey::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RocksDbBloomFilterBitsPerKey {
+    pub leaves: f64,
+    pub depth_24: f64,
+    pub subtree_24: f64,
+    pub subtree_32: f64,
+    pub subtree_40: f64,
+    pub subtree_48: f64,
+    pub subtree_56: f64,
+}
+
+impl Default for RocksDbBloomFilterBitsPerKey {
+    fn default() -> Self {
+        Self {
+            leaves: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
+            depth_24: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
+            subtree_24: 8.0,
+            subtree_32: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
+            subtree_40: DEFAULT_BLOOM_FILTER_BITS_PER_KEY,
+            subtree_48: 12.0,
+            subtree_56: 12.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rocksdb_config_builders_update_independent_knobs() {
+        let memory_budget = RocksDbMemoryBudget {
+            block_cache_size: 512 << 20,
+            write_buffer_manager: Some(RocksDbWriteBufferManagerBudget {
+                buffer_size: 64 << 20,
+                allow_stall: true,
+                charge_to_block_cache: true,
+            }),
+        };
+        let tuning_options = RocksDbTuningOptions {
+            block_size: 8 << 10,
+            max_total_wal_size: 2 << 30,
+            bloom_filter_bits_per_key: RocksDbBloomFilterBitsPerKey {
+                leaves: 11.0,
+                depth_24: 12.0,
+                subtree_24: 13.0,
+                subtree_32: 14.0,
+                subtree_40: 15.0,
+                subtree_48: 16.0,
+                subtree_56: 17.0,
+            },
+            ..RocksDbTuningOptions::default()
+        };
+
+        let config = RocksDbConfig::new("/tmp/smt")
+            .with_memory_budget(memory_budget.clone())
+            .with_max_open_files(1024)
+            .with_tuning_options(tuning_options.clone())
+            .with_durability_mode(RocksDbDurabilityMode::Sync);
+
+        assert_eq!(
+            config,
+            RocksDbConfig {
+                path: PathBuf::from("/tmp/smt"),
+                cache_size: 512 << 20,
+                max_open_files: 1024,
+                write_buffer_manager: memory_budget.write_buffer_manager,
+                tuning_options,
+                durability_mode: RocksDbDurabilityMode::Sync,
+            }
+        );
     }
 }
 

--- a/crates/large-smt-backend-rocksdb/src/rocksdb.rs
+++ b/crates/large-smt-backend-rocksdb/src/rocksdb.rs
@@ -180,10 +180,8 @@ impl RocksDbStorage {
         depth24_opts.set_compression_type(DBCompressionType::Lz4);
         depth24_opts.set_bottommost_compression_type(DBCompressionType::Zstd);
         // Enable the bottommost compression setting; selecting ZSTD alone is not enough.
-        depth24_opts.set_bottommost_zstd_max_train_bytes(
-            DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES,
-            true,
-        );
+        depth24_opts
+            .set_bottommost_zstd_max_train_bytes(DEFAULT_BOTTOMMOST_ZSTD_MAX_TRAIN_BYTES, true);
         depth24_opts.set_block_based_table_factory(&depth24_table_opts);
         if let Some(write_buffer_manager) = write_buffer_manager.as_ref() {
             depth24_opts.set_write_buffer_manager(write_buffer_manager);
@@ -1474,7 +1472,6 @@ mod tests {
                 subtree_48: 16.0,
                 subtree_56: 17.0,
             },
-            ..RocksDbTuningOptions::default()
         };
 
         let config = RocksDbConfig::new("/tmp/smt")
@@ -1498,10 +1495,7 @@ mod tests {
 
     #[test]
     fn rocksdb_config_defaults_to_relaxed_durability() {
-        assert_eq!(
-            RocksDbConfig::new("/tmp/smt").durability_mode,
-            RocksDbDurabilityMode::Relaxed
-        );
+        assert_eq!(RocksDbConfig::new("/tmp/smt").durability_mode, RocksDbDurabilityMode::Relaxed);
     }
 }
 

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -171,20 +171,17 @@ impl State {
         let latest_block_num = blockchain.chain_tip().unwrap_or(BlockNumber::GENESIS);
 
         #[cfg(feature = "rocksdb")]
-        let account_storage_config = storage_options.account_tree.into();
+        let (account_storage_config, nullifier_storage_config) =
+            (storage_options.account_tree.into(), storage_options.nullifier_tree.into());
         #[cfg(not(feature = "rocksdb"))]
-        let account_storage_config = {
+        let (account_storage_config, nullifier_storage_config) = {
             let _ = &storage_options;
-            ()
+            ((), ())
         };
         let account_storage =
             TreeStorage::create(data_path, &account_storage_config, ACCOUNT_TREE_STORAGE_DIR)?;
         let account_tree = account_storage.load_account_tree(&mut db).await?;
 
-        #[cfg(feature = "rocksdb")]
-        let nullifier_storage_config = storage_options.nullifier_tree.into();
-        #[cfg(not(feature = "rocksdb"))]
-        let nullifier_storage_config = ();
         let nullifier_storage =
             TreeStorage::create(data_path, &nullifier_storage_config, NULLIFIER_TREE_STORAGE_DIR)?;
         let nullifier_tree = nullifier_storage.load_nullifier_tree(&mut db).await?;

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -161,10 +161,12 @@ impl StorageOptions {
             let account_tree = AccountTreeRocksDbOptions {
                 max_open_fds: self::rocksdb::BENCH_ROCKSDB_MAX_OPEN_FDS,
                 cache_size_in_bytes: self::rocksdb::DEFAULT_ROCKSDB_CACHE_SIZE,
+                durability_mode: None,
             };
             let nullifier_tree = NullifierTreeRocksDbOptions {
                 max_open_fds: BENCH_ROCKSDB_MAX_OPEN_FDS,
                 cache_size_in_bytes: DEFAULT_ROCKSDB_CACHE_SIZE,
+                durability_mode: None,
             };
             Self { account_tree, nullifier_tree }
         }

--- a/crates/utils/src/clap/rocksdb.rs
+++ b/crates/utils/src/clap/rocksdb.rs
@@ -2,11 +2,26 @@
 
 use std::path::Path;
 
-use miden_large_smt_backend_rocksdb::RocksDbConfig;
+use miden_large_smt_backend_rocksdb::{RocksDbConfig, RocksDbDurabilityMode};
 
 pub(crate) const DEFAULT_ROCKSDB_MAX_OPEN_FDS: i32 = 64;
 pub(crate) const DEFAULT_ROCKSDB_CACHE_SIZE: usize = 2 << 30;
 pub(crate) const BENCH_ROCKSDB_MAX_OPEN_FDS: i32 = 512;
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CliRocksDbDurabilityMode {
+    Relaxed,
+    Sync,
+}
+
+impl From<CliRocksDbDurabilityMode> for RocksDbDurabilityMode {
+    fn from(value: CliRocksDbDurabilityMode) -> Self {
+        match value {
+            CliRocksDbDurabilityMode::Relaxed => Self::Relaxed,
+            CliRocksDbDurabilityMode::Sync => Self::Sync,
+        }
+    }
+}
 
 /// Per usage options for rocksdb configuration
 #[derive(clap::Args, Clone, Debug, PartialEq, Eq)]
@@ -25,6 +40,13 @@ pub struct NullifierTreeRocksDbOptions {
         value_name = "NULLIFIER_TREE__ROCKSDB__CACHE_SIZE"
     )]
     pub cache_size_in_bytes: usize,
+    #[arg(
+        id = "nullifier_tree_rocksdb_durability_mode",
+        long = "nullifier_tree.rocksdb.durability_mode",
+        value_enum,
+        value_name = "NULLIFIER_TREE__ROCKSDB__DURABILITY_MODE"
+    )]
+    pub durability_mode: Option<CliRocksDbDurabilityMode>,
 }
 
 impl Default for NullifierTreeRocksDbOptions {
@@ -50,6 +72,13 @@ pub struct AccountTreeRocksDbOptions {
         value_name = "ACCOUNT_TREE__ROCKSDB__CACHE_SIZE"
     )]
     pub cache_size_in_bytes: usize,
+    #[arg(
+        id = "account_tree_rocksdb_durability_mode",
+        long = "account_tree.rocksdb.durability_mode",
+        value_enum,
+        value_name = "ACCOUNT_TREE__ROCKSDB__DURABILITY_MODE"
+    )]
+    pub durability_mode: Option<CliRocksDbDurabilityMode>,
 }
 
 impl Default for AccountTreeRocksDbOptions {
@@ -63,6 +92,7 @@ impl Default for AccountTreeRocksDbOptions {
 pub struct RocksDbOptions {
     pub max_open_fds: i32,
     pub cache_size_in_bytes: usize,
+    pub durability_mode: Option<CliRocksDbDurabilityMode>,
 }
 
 impl Default for RocksDbOptions {
@@ -70,42 +100,81 @@ impl Default for RocksDbOptions {
         Self {
             max_open_fds: DEFAULT_ROCKSDB_MAX_OPEN_FDS,
             cache_size_in_bytes: DEFAULT_ROCKSDB_CACHE_SIZE,
+            durability_mode: None,
         }
     }
 }
 
 impl From<AccountTreeRocksDbOptions> for RocksDbOptions {
     fn from(value: AccountTreeRocksDbOptions) -> Self {
-        let AccountTreeRocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
-        Self { max_open_fds, cache_size_in_bytes }
+        let AccountTreeRocksDbOptions {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        } = value;
+        Self {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        }
     }
 }
 
 impl From<NullifierTreeRocksDbOptions> for RocksDbOptions {
     fn from(value: NullifierTreeRocksDbOptions) -> Self {
-        let NullifierTreeRocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
-        Self { max_open_fds, cache_size_in_bytes }
+        let NullifierTreeRocksDbOptions {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        } = value;
+        Self {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        }
     }
 }
 
 impl From<RocksDbOptions> for AccountTreeRocksDbOptions {
     fn from(value: RocksDbOptions) -> Self {
-        let RocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
-        Self { max_open_fds, cache_size_in_bytes }
+        let RocksDbOptions {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        } = value;
+        Self {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        }
     }
 }
 
 impl From<RocksDbOptions> for NullifierTreeRocksDbOptions {
     fn from(value: RocksDbOptions) -> Self {
-        let RocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
-        Self { max_open_fds, cache_size_in_bytes }
+        let RocksDbOptions {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        } = value;
+        Self {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        }
     }
 }
 
 impl RocksDbOptions {
     pub fn with_path(self, path: &Path) -> RocksDbConfig {
-        RocksDbConfig::new(path)
+        let mut config = RocksDbConfig::new(path)
             .with_cache_size(self.cache_size_in_bytes)
-            .with_max_open_files(self.max_open_fds)
+            .with_max_open_files(self.max_open_fds);
+
+        if let Some(durability_mode) = self.durability_mode {
+            config = config.with_durability_mode(durability_mode.into());
+        }
+
+        config
     }
 }


### PR DESCRIPTION
The new default uses cached index and filter blocks, 16 KiB block tables, tuned Bloom filters, and bottommost ZSTD compression for SMT data. Metadata stays uncompressed. The RocksDB config also keeps support for tuning overrides, memory-budget controls, and durability mode selection.

The main issue this helps is 0xMiden/node#1776. It should also help the write-heavy performance work in 0xMiden/node#1537. In earlier quick Criterion runs, the tuned block-table profile improved vanilla insertion/100 by 14.13%, with_history insertion/10 by 9.44%, and with_history insertion/500 by 12.62%. Bottommost ZSTD improved vanilla insertion/1 by 12.39%. Read-path changes in those runs were mostly within noise, so this is best treated as a better default write profile.

This PR does not try to fix the RocksDB correctness issues in 0xMiden/crypto#1095, 0xMiden/node#1729, or 0xMiden/miden-vm#3350. It changes defaults and config control, not error handling or storage semantics.

References:
- https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning
