### PR TITLE
chore(docker): ignore rust-toolchain.toml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,3 +34,4 @@ accounts
 genesis.dat
 miden-store.*
 store.*
+/rust-toolchain.toml


### PR DESCRIPTION
Copying `rust-toolchain.toml` results in `rustup` installing a new Rust toolchain even if we already have one in the base image.