### PR TITLE
chore: simplify network monitor counter script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## v0.14.9 (2026-04-21)
+
+- Simplified network monitor counter script loading by linking the counter module directly via `with_linked_module` instead of assembling a standalone library ([#1957](https://github.com/0xMiden/node/pull/1957)).
+
 ## v0.14.8 (2026-04-19)
 
 - Fixed a startup race in the network transaction builder that could panic the chain MMR when a block committed between subscribing to the mempool and fetching the chain tip from the store ([#1953](https://github.com/0xMiden/node/pull/1953)).
 - Enabled `miden-tx/concurrent` feature across all crates ([#1956](https://github.com/0xMiden/node/pull/1956)).
-- Simplified network monitor counter script loading by linking the counter module directly via `with_linked_module` instead of assembling a standalone library ([#1957](https://github.com/0xMiden/node/pull/1957)).
 
 ## v0.14.7 (2026-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.14.8 (TBA)
 
 - Enabled `miden-tx/concurrent` feature across all crates ([#1956](https://github.com/0xMiden/node/pull/1956)).
+- Simplified network monitor counter script loading by linking the counter module directly via `with_linked_module` instead of assembling a standalone library ([#1957](https://github.com/0xMiden/node/pull/1957)).
 
 ## v0.14.7 (2026-04-15)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "miden-genesis"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "deadpool",
  "deadpool-diesel",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-ntx-builder"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3311,11 +3311,11 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.14.8"
+version = "0.14.9"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "futures",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "clap",
  "fs-err",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-validator"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.8"
+version = "0.14.9"
 dependencies = [
  "build-rs",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.93"
-version      = "0.14.8"
+version      = "0.14.9"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -14,7 +14,6 @@ use miden_node_proto::generated::rpc::BlockHeaderByNumberRequest;
 use miden_node_proto::generated::transaction::ProvenTransaction;
 use miden_protocol::account::auth::AuthSecretKey;
 use miden_protocol::account::{Account, AccountFile, AccountHeader, AccountId};
-use miden_protocol::assembly::Library;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey;
 use miden_protocol::note::{
@@ -46,7 +45,7 @@ const RESYNC_FAILURE_THRESHOLD: usize = 3;
 use crate::COMPONENT;
 use crate::config::MonitorConfig;
 use crate::deploy::counter::COUNTER_SLOT_NAME;
-use crate::deploy::{MonitorDataStore, create_genesis_aware_rpc_client, get_counter_library};
+use crate::deploy::{MonitorDataStore, create_genesis_aware_rpc_client};
 use crate::status::{
     CounterTrackingDetails,
     IncrementDetails,
@@ -345,13 +344,12 @@ async fn setup_increment_task(
     let block_header = get_genesis_block_header(rpc_client).await?;
 
     // Create the increment procedure script and get the library
-    let (increment_script, library) = create_increment_script()?;
+    let increment_script = create_increment_script()?;
 
     // Create unified data store for transaction execution
     let mut data_store = MonitorDataStore::new(block_header.clone(), PartialBlockchain::default());
     data_store.add_account(wallet_account.clone());
     data_store.add_account(counter_account.clone());
-    data_store.insert_library(&library);
 
     Ok((
         details,
@@ -880,11 +878,12 @@ async fn create_and_submit_network_note(
 }
 
 /// Create the increment procedure script.
-fn create_increment_script() -> Result<(NoteScript, Library)> {
-    let library = get_counter_library()?;
+fn create_increment_script() -> Result<NoteScript> {
+    let script =
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/assets/counter_program.masm"));
 
     let script_builder = CodeBuilder::new()
-        .with_dynamically_linked_library(&library)
+        .with_linked_module("external_contract::counter_contract", script)
         .context("Failed to create script builder with library")?;
 
     // Compile the script directly as a NoteScript
@@ -895,7 +894,7 @@ fn create_increment_script() -> Result<(NoteScript, Library)> {
         )))
         .context("Failed to compile note script")?;
 
-    Ok((note_script, library))
+    Ok(note_script)
 }
 
 /// Create a network note that targets the counter account.

--- a/bin/network-monitor/src/deploy/mod.rs
+++ b/bin/network-monitor/src/deploy/mod.rs
@@ -12,24 +12,11 @@ use miden_node_proto::clients::{Builder, RpcClient};
 use miden_node_proto::generated::rpc::BlockHeaderByNumberRequest;
 use miden_node_proto::generated::transaction::ProvenTransaction;
 use miden_protocol::account::{Account, AccountId, PartialAccount, StorageMapKey};
-use miden_protocol::assembly::{
-    DefaultSourceManager,
-    Library,
-    Module,
-    ModuleKind,
-    Path as MidenPath,
-};
 use miden_protocol::asset::{AssetVaultKey, AssetWitness};
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::crypto::merkle::mmr::{MmrPeaks, PartialMmr};
 use miden_protocol::note::NoteScript;
-use miden_protocol::transaction::{
-    AccountInputs,
-    InputNotes,
-    PartialBlockchain,
-    TransactionArgs,
-    TransactionKernel,
-};
+use miden_protocol::transaction::{AccountInputs, InputNotes, PartialBlockchain, TransactionArgs};
 use miden_protocol::utils::serde::Serializable;
 use miden_protocol::{MastForest, Word};
 use miden_tx::auth::BasicAuthenticator;
@@ -218,26 +205,6 @@ pub async fn deploy_counter_account(counter_account: &Account, rpc_url: &Url) ->
     Ok(())
 }
 
-pub(crate) fn get_counter_library() -> Result<Library> {
-    let assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let script =
-        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/assets/counter_program.masm"));
-
-    let library_path = MidenPath::new("external_contract::counter_contract");
-
-    let module = Module::parser(ModuleKind::Library)
-        .parse_str(library_path, script, source_manager)
-        .map_err(|e| anyhow::anyhow!("Failed to parse module: {e}"))?;
-
-    let library = assembler
-        .clone()
-        .assemble_library([module])
-        .map_err(|e| anyhow::anyhow!("Failed to assemble library: {e}"))?;
-
-    Ok(Arc::unwrap_or_clone(library))
-}
-
 // MONITOR DATA STORE
 // ================================================================================================
 
@@ -268,11 +235,6 @@ impl MonitorDataStore {
     /// Update an account after a transaction (loads latest code too).
     pub fn update_account(&mut self, account: Account) {
         self.add_account(account);
-    }
-
-    /// Insert external library procedures used by transactions.
-    pub fn insert_library(&mut self, library: &Library) {
-        self.mast_store.insert(library.mast_forest().clone());
     }
 
     /// Returns a reference to the account or a standardized "unknown account" error.


### PR DESCRIPTION
Due to upstream changes, and considering that we are about to do a new release, this PR adds a simplification to the counter creation and fixes the source manager handling following the changes from https://github.com/0xMiden/miden-client/pull/2006