### PR TITLE
fix: Bootstrap genesis accounts

### DIFF
--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -163,7 +163,20 @@ impl GenesisConfig {
                 let full_path = config_dir.join(&acc.path);
                 let account_file = AccountFile::read(&full_path)
                     .map_err(|e| GenesisConfigError::AccountFileRead(e, full_path.clone()))?;
-                Ok(account_file.account)
+                let mut account = account_file.account;
+                // Genesis accounts must have nonce=1. If the .mac file contains a new account
+                // (nonce=0, seed present), bump the nonce so the seed is cleared and the account
+                // can be represented as a delta in the genesis block.
+                if account.is_new() {
+                    let delta = AccountDelta::new(
+                        account.id(),
+                        AccountStorageDelta::default(),
+                        AccountVaultDelta::default(),
+                        ONE,
+                    )?;
+                    account.apply_delta(&delta)?;
+                }
+                Ok(account)
             })
             .collect::<Result<Vec<_>, GenesisConfigError>>()?;
 

--- a/crates/store/src/genesis/mod.rs
+++ b/crates/store/src/genesis/mod.rs
@@ -1,8 +1,6 @@
 use miden_node_utils::signer::BlockSigner;
-use miden_protocol::Word;
 use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
-use miden_protocol::ONE;
 use miden_protocol::block::account_tree::{AccountIdKey, AccountTree};
 use miden_protocol::block::{
     BlockAccountUpdate,
@@ -18,6 +16,7 @@ use miden_protocol::crypto::merkle::mmr::{Forest, MmrPeaks};
 use miden_protocol::crypto::merkle::smt::{LargeSmt, MemoryStorage, Smt};
 use miden_protocol::note::Nullifier;
 use miden_protocol::transaction::{OrderedTransactionHeaders, TransactionKernel};
+use miden_protocol::{ONE, Word};
 
 pub mod config;
 

--- a/crates/store/src/genesis/mod.rs
+++ b/crates/store/src/genesis/mod.rs
@@ -1,7 +1,8 @@
 use miden_node_utils::signer::BlockSigner;
 use miden_protocol::Word;
 use miden_protocol::account::delta::AccountUpdateDetails;
-use miden_protocol::account::{Account, AccountDelta};
+use miden_protocol::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
+use miden_protocol::ONE;
 use miden_protocol::block::account_tree::{AccountIdKey, AccountTree};
 use miden_protocol::block::{
     BlockAccountUpdate,
@@ -15,7 +16,6 @@ use miden_protocol::block::{
 };
 use miden_protocol::crypto::merkle::mmr::{Forest, MmrPeaks};
 use miden_protocol::crypto::merkle::smt::{LargeSmt, MemoryStorage, Smt};
-use miden_protocol::errors::AccountError;
 use miden_protocol::note::Nullifier;
 use miden_protocol::transaction::{OrderedTransactionHeaders, TransactionKernel};
 
@@ -92,11 +92,22 @@ impl<S: BlockSigner> GenesisState<S> {
     pub async fn into_block(self) -> anyhow::Result<GenesisBlock> {
         let accounts: Vec<BlockAccountUpdate> = self
             .accounts
-            .iter()
-            .map(|account| {
+            .into_iter()
+            .map(|mut account| -> anyhow::Result<BlockAccountUpdate> {
                 let account_update_details = if account.id().is_private() {
                     AccountUpdateDetails::Private
                 } else {
+                    // Genesis accounts must have nonce >= 1 to be representable as deltas.
+                    // Accounts loaded from .mac files with nonce=0 (seed present) are bumped here.
+                    if account.is_new() {
+                        let delta = AccountDelta::new(
+                            account.id(),
+                            AccountStorageDelta::default(),
+                            AccountVaultDelta::default(),
+                            ONE,
+                        )?;
+                        account.apply_delta(&delta)?;
+                    }
                     AccountUpdateDetails::Delta(AccountDelta::try_from(account.clone())?)
                 };
 
@@ -106,7 +117,7 @@ impl<S: BlockSigner> GenesisState<S> {
                     account_update_details,
                 ))
             })
-            .collect::<Result<Vec<_>, AccountError>>()?;
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         // Convert account updates to SMT entries using account_id_to_smt_key
         let smt_entries = accounts.iter().map(|update| {


### PR DESCRIPTION
v0.14.7 currently errors out when genesis.toml specifies the full list of accounts in genesis.toml:
```toml
version = 1
timestamp = 1776640574

[fee_parameters]
verification_base_fee = 0

[[account]]
path = "bridge.mac"

[[account]]
path = "bridge_admin.mac"

[[account]]
path = "ger_manager.mac"
```

```
$ miden-node validator bootstrap --genesis-block-directory /opt/miden-validator/ --accounts-directory /opt/miden-validator/ --data-directory /opt/miden-validator/ --genesis-config-f
ile ./genesis.toml 
Error: failed to build the genesis block

Caused by:
    an account with a seed cannot be converted into a delta since it represents an unregistered account
```