### PR TITLE
rpc/store: align list-limit metadata and document query limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated the RocksDB SMT backend to use budgeted deserialization for bytes read from disk, ported from `0xMiden/crypto` PR [#846](https://github.com/0xMiden/crypto/pull/846) ([#1923](https://github.com/0xMiden/node/pull/1923)).
 - [BREAKING] Network monitor `/status` endpoint now emits a single `RemoteProverStatus` entry per remote prover that bundles status, workers, and test results, instead of separate entries ([#1980](https://github.com/0xMiden/node/pull/1980)).
 - Refactored the validator gRPC API implementation to use the new per-method trait implementations ([#1959](https://github.com/0xMiden/node/pull/1959)).
+- Aligned `SyncNullifiers` list-limit validation in RPC and store with `nullifier_prefix` parameter semantics, extended `GetLimits` test coverage, and documented query parameter limits ([#1986](https://github.com/0xMiden/node/pull/1986)).
 
 ## v0.14.9 (2026-04-21)
 

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -21,6 +21,7 @@ use miden_node_utils::limiter::{
     QueryParamNoteIdLimit,
     QueryParamNoteTagLimit,
     QueryParamNullifierLimit,
+    QueryParamNullifierPrefixLimit,
     QueryParamStorageMapKeyTotalLimit,
 };
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
@@ -216,7 +217,7 @@ impl api_server::Api for RpcService {
     ) -> Result<Response<proto::rpc::SyncNullifiersResponse>, Status> {
         debug!(target: COMPONENT, request = ?request.get_ref());
 
-        check::<QueryParamNullifierLimit>(request.get_ref().nullifiers.len())?;
+        check::<QueryParamNullifierPrefixLimit>(request.get_ref().nullifiers.len())?;
 
         self.store.clone().sync_nullifiers(request).await
     }
@@ -652,6 +653,7 @@ static RPC_LIMITS: LazyLock<proto::rpc::RpcLimits> = LazyLock::new(|| {
     use QueryParamNoteIdLimit as NoteId;
     use QueryParamNoteTagLimit as NoteTag;
     use QueryParamNullifierLimit as Nullifier;
+    use QueryParamNullifierPrefixLimit as NullifierPrefix;
     use QueryParamStorageMapKeyTotalLimit as StorageMapKeyTotal;
 
     proto::rpc::RpcLimits {
@@ -662,7 +664,7 @@ static RPC_LIMITS: LazyLock<proto::rpc::RpcLimits> = LazyLock::new(|| {
             ),
             (
                 "SyncNullifiers".into(),
-                endpoint_limits(&[(Nullifier::PARAM_NAME, Nullifier::LIMIT)]),
+                endpoint_limits(&[(NullifierPrefix::PARAM_NAME, NullifierPrefix::LIMIT)]),
             ),
             (
                 "SyncTransactions".into(),

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -15,7 +15,9 @@ use miden_node_utils::limiter::{
     QueryParamAccountIdLimit,
     QueryParamLimiter,
     QueryParamNoteIdLimit,
+    QueryParamNoteTagLimit,
     QueryParamNullifierLimit,
+    QueryParamNullifierPrefixLimit,
 };
 use miden_protocol::Word;
 use miden_protocol::account::delta::AccountUpdateDetails;
@@ -574,6 +576,27 @@ async fn get_limits_endpoint() {
         "SyncTransactions {} limit should be {}",
         QueryParamAccountIdLimit::PARAM_NAME,
         QueryParamAccountIdLimit::LIMIT
+    );
+
+    // Verify SyncNullifiers endpoint
+    let sync_nullifiers =
+        limits.endpoints.get("SyncNullifiers").expect("SyncNullifiers should exist");
+    assert_eq!(
+        sync_nullifiers.parameters.get(QueryParamNullifierPrefixLimit::PARAM_NAME),
+        Some(&(QueryParamNullifierPrefixLimit::LIMIT as u32)),
+        "SyncNullifiers {} limit should be {}",
+        QueryParamNullifierPrefixLimit::PARAM_NAME,
+        QueryParamNullifierPrefixLimit::LIMIT
+    );
+
+    // Verify SyncNotes endpoint
+    let sync_notes = limits.endpoints.get("SyncNotes").expect("SyncNotes should exist");
+    assert_eq!(
+        sync_notes.parameters.get(QueryParamNoteTagLimit::PARAM_NAME),
+        Some(&(QueryParamNoteTagLimit::LIMIT as u32)),
+        "SyncNotes {} limit should be {}",
+        QueryParamNoteTagLimit::PARAM_NAME,
+        QueryParamNoteTagLimit::LIMIT
     );
 
     // SyncAccountVault and SyncAccountStorageMaps accept a singular account_id,

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -8,6 +8,7 @@ use miden_node_utils::limiter::{
     QueryParamNoteIdLimit,
     QueryParamNoteTagLimit,
     QueryParamNullifierLimit,
+    QueryParamNullifierPrefixLimit,
 };
 use miden_protocol::Word;
 use miden_protocol::account::AccountId;
@@ -93,6 +94,9 @@ impl rpc_server::Rpc for StoreApi {
         if request.prefix_len != 16 {
             return Err(SyncNullifiersError::InvalidPrefixLength(request.prefix_len).into());
         }
+
+        // Validate nullifier prefix list size before querying state.
+        check::<QueryParamNullifierPrefixLimit>(request.nullifiers.len())?;
 
         let chain_tip = self.state.chain_tip(Finality::Committed).await;
         let block_range =

--- a/crates/utils/src/limiter.rs
+++ b/crates/utils/src/limiter.rs
@@ -58,7 +58,7 @@ impl QueryParamLimiter for QueryParamAccountIdLimit {
 }
 
 /// Used for the following RPC endpoints:
-/// * `select_nullifiers_by_prefix`
+/// * `sync_nullifiers`
 ///
 /// Capped at 1000 prefixes to keep queries and responses comfortably within the 4 MB payload
 /// budget and to avoid unbounded prefix scans.
@@ -69,8 +69,7 @@ impl QueryParamLimiter for QueryParamNullifierPrefixLimit {
 }
 
 /// Used for the following RPC endpoints:
-/// * `select_nullifiers_by_prefix`
-/// * `sync_nullifiers`
+/// * `check_nullifiers`
 ///
 /// Capped at 1000 nullifiers to bound `IN` clauses and keep response sizes under the 4 MB budget.
 pub struct QueryParamNullifierLimit;

--- a/docs/internal/src/rpc.md
+++ b/docs/internal/src/rpc.md
@@ -32,7 +32,7 @@ the store) to keep database queries bounded and to keep response payloads within
 | Endpoint | Parameter | Limit | Rationale |
 |---|---:|---:|---|
 | `CheckNullifiers` | `nullifier` | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget |
-| `SyncNullifiers` | `nullifier` | `1000` | Bounds prefix-based nullifier scans |
+| `SyncNullifiers` | `nullifier_prefix` | `1000` | Bounds prefix-based nullifier scans |
 | `SyncNotes` | `note_tag` | `1000` | Keeps note sync responses within payload budget |
 | `GetNotesById` | `note_id` | `100` | Notes can be large (~32 KiB), so this is intentionally tighter |
 | `SyncTransactions` | `account_id` | `1000` | Bounds account filter fan-out and response size |
@@ -42,7 +42,6 @@ Additional internal-only limits in `miden_node_utils::limiter` (not surfaced by 
 
 | Parameter | Limit | Used by |
 |---:|---:|---|
-| `nullifier_prefix` | `1000` | Store-side prefix query validation |
 | `note_commitment` | `1000` | Internal note proof lookups |
 | `block_header` | `1000` | Internal batch/block header operations |
 

--- a/docs/internal/src/rpc.md
+++ b/docs/internal/src/rpc.md
@@ -27,6 +27,25 @@ multi-value parameters (e.g. number of nullifiers, note tags, note IDs, account 
 These limits are defined centrally in `miden_node_utils::limiter` and are enforced at the RPC boundary (and also inside
 the store) to keep database queries bounded and to keep response payloads within the ~4 MB budget.
 
+`GENERAL_REQUEST_LIMIT` is currently `1000`, and endpoint-specific limits are:
+
+| Endpoint | Parameter | Limit | Rationale |
+|---|---:|---:|---|
+| `CheckNullifiers` | `nullifier` | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget |
+| `SyncNullifiers` | `nullifier` | `1000` | Bounds prefix-based nullifier scans |
+| `SyncNotes` | `note_tag` | `1000` | Keeps note sync responses within payload budget |
+| `GetNotesById` | `note_id` | `100` | Notes can be large (~32 KiB), so this is intentionally tighter |
+| `SyncTransactions` | `account_id` | `1000` | Bounds account filter fan-out and response size |
+| `GetAccount` | `storage_map_key` | `64` | SMT proof generation for storage map keys is comparatively expensive |
+
+Additional internal-only limits in `miden_node_utils::limiter` (not surfaced by `GetLimits`) include:
+
+| Parameter | Limit | Used by |
+|---:|---:|---|
+| `nullifier_prefix` | `1000` | Store-side prefix query validation |
+| `note_commitment` | `1000` | Internal note proof lookups |
+| `block_header` | `1000` | Internal batch/block header operations |
+
 ## Error Handling
 
 The RPC component uses domain-specific error enums for structured error reporting instead of proto-generated error types. This provides better control over error codes and makes error handling more maintainable.
@@ -57,4 +76,3 @@ enum SubmitProvenTransactionGrpcError {
 ```
 
 Error codes are embedded as single bytes in `Status.details`
-

--- a/docs/internal/src/rpc.md
+++ b/docs/internal/src/rpc.md
@@ -31,12 +31,12 @@ the store) to keep database queries bounded and to keep response payloads within
 
 | Endpoint           | Parameter          | Limit  | Rationale                                                            |
 | ------------------ | ------------------ | ------ | -------------------------------------------------------------------- |
-| `CheckNullifiers`  | `nullifier`        | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget   |
-| `SyncNullifiers`   | `nullifier_prefix` | `1000` | Bounds prefix-based nullifier scans                                  |
-| `SyncNotes`        | `note_tag`         | `1000` | Keeps note sync responses within payload budget                      |
-| `GetNotesById`     | `note_id`          | `100`  | Notes can be large (~32 KiB), so this is intentionally tighter       |
-| `SyncTransactions` | `account_id`       | `1000` | Bounds account filter fan-out and response size                      |
+| | `CheckNullifiers`  | `nullifier`        | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget    |
 | `GetAccount`       | `storage_map_key`  | `64`   | SMT proof generation for storage map keys is comparatively expensive |
+| `GetNotesById`     | `note_id`          | `100`  | Notes can be large (~32 KiB), so this is intentionally tighter       |
+| `SyncNotes`        | `note_tag`         | `1000` | Keeps note sync responses within payload budget                      |
+| `SyncNullifiers`   | `nullifier_prefix` | `1000` | Bounds prefix-based nullifier scans                                  |
+| `SyncTransactions` | `account_id`       | `1000` | Bounds account filter fan-out and response size                      |
 
 Additional internal-only limits in `miden_node_utils::limiter` (not surfaced by `GetLimits`) include:
 

--- a/docs/internal/src/rpc.md
+++ b/docs/internal/src/rpc.md
@@ -29,21 +29,21 @@ the store) to keep database queries bounded and to keep response payloads within
 
 `GENERAL_REQUEST_LIMIT` is currently `1000`, and endpoint-specific limits are:
 
-| Endpoint | Parameter | Limit | Rationale |
-|---|---:|---:|---|
-| `CheckNullifiers` | `nullifier` | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget |
-| `SyncNullifiers` | `nullifier_prefix` | `1000` | Bounds prefix-based nullifier scans |
-| `SyncNotes` | `note_tag` | `1000` | Keeps note sync responses within payload budget |
-| `GetNotesById` | `note_id` | `100` | Notes can be large (~32 KiB), so this is intentionally tighter |
-| `SyncTransactions` | `account_id` | `1000` | Bounds account filter fan-out and response size |
-| `GetAccount` | `storage_map_key` | `64` | SMT proof generation for storage map keys is comparatively expensive |
+| Endpoint           | Parameter          | Limit  | Rationale                                                            |
+| ------------------ | ------------------ | ------ | -------------------------------------------------------------------- |
+| `CheckNullifiers`  | `nullifier`        | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget   |
+| `SyncNullifiers`   | `nullifier_prefix` | `1000` | Bounds prefix-based nullifier scans                                  |
+| `SyncNotes`        | `note_tag`         | `1000` | Keeps note sync responses within payload budget                      |
+| `GetNotesById`     | `note_id`          | `100`  | Notes can be large (~32 KiB), so this is intentionally tighter       |
+| `SyncTransactions` | `account_id`       | `1000` | Bounds account filter fan-out and response size                      |
+| `GetAccount`       | `storage_map_key`  | `64`   | SMT proof generation for storage map keys is comparatively expensive |
 
 Additional internal-only limits in `miden_node_utils::limiter` (not surfaced by `GetLimits`) include:
 
-| Parameter | Limit | Used by |
-|---:|---:|---|
-| `note_commitment` | `1000` | Internal note proof lookups |
-| `block_header` | `1000` | Internal batch/block header operations |
+| Parameter         | Limit  | Used by                                |
+| ----------------- | ------ | -------------------------------------- |
+| `note_commitment` | `1000` | Internal note proof lookups            |
+| `block_header`    | `1000` | Internal batch/block header operations |
 
 ## Error Handling
 

--- a/docs/internal/src/rpc.md
+++ b/docs/internal/src/rpc.md
@@ -31,7 +31,7 @@ the store) to keep database queries bounded and to keep response payloads within
 
 | Endpoint           | Parameter          | Limit  | Rationale                                                            |
 | ------------------ | ------------------ | ------ | -------------------------------------------------------------------- |
-| | `CheckNullifiers`  | `nullifier`        | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget    |
+| `CheckNullifiers`  | `nullifier`        | `1000` | Bounds `IN`-style lookups and keeps responses under payload budget    |
 | `GetAccount`       | `storage_map_key`  | `64`   | SMT proof generation for storage map keys is comparatively expensive |
 | `GetNotesById`     | `note_id`          | `100`  | Notes can be large (~32 KiB), so this is intentionally tighter       |
 | `SyncNotes`        | `note_tag`         | `1000` | Keeps note sync responses within payload budget                      |


### PR DESCRIPTION
## Summary
- align `SyncNullifiers` list-limit validation in RPC and store with the parameter semantics (`nullifier_prefix`)
- expose the same `SyncNullifiers` parameter key via `GetLimits`
- extend `GetLimits` test coverage to assert `SyncNullifiers` and `SyncNotes` limits
- expand internal RPC docs with a concrete query-limits table and rationale

## Why
Issue #1080 asks to revisit/document list parameter limits.

This keeps limit handling consistent across:
- runtime validation
- `GetLimits` response metadata
- tests
- internal docs

## Validation
- `cargo test -p miden-node-rpc get_limits_endpoint`
- `cargo check -p miden-node-store -p miden-node-rpc`

Partially addresses #1080

