### PR TITLE
feat(mempool): Avoid allocating in `SelectedBatch` query

### DIFF
--- a/crates/block-producer/src/domain/batch.rs
+++ b/crates/block-producer/src/domain/batch.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use miden_protocol::Word;
@@ -23,6 +23,7 @@ pub(crate) struct SelectedBatch {
     txs: Vec<Arc<AuthenticatedTransaction>>,
     id: BatchId,
     account_updates: HashMap<AccountId, (Word, Word, Option<Word>)>,
+    unauthenticated_notes: HashSet<Word>,
 }
 
 impl SelectedBatch {
@@ -53,6 +54,10 @@ impl SelectedBatch {
         self.account_updates
             .iter()
             .map(|(account, (from, to, store))| (*account, *from, *to, *store))
+    }
+
+    pub(crate) fn unauthenticated_note_commitments(&self) -> impl Iterator<Item = Word> {
+        self.unauthenticated_notes.iter().copied()
     }
 
     pub(crate) fn expires_at(&self) -> BlockNumber {
@@ -116,6 +121,18 @@ not match the current commitment {}",
         let Self { txs, account_updates } = self;
         let id = BatchId::from_ids(txs.iter().map(|tx| (tx.id(), tx.account_id())));
 
-        SelectedBatch { txs, id, account_updates }
+        let mut unauthenticated_notes: HashSet<_> =
+            txs.iter().flat_map(|tx| tx.unauthenticated_note_commitments()).collect();
+
+        for output_note in txs.iter().flat_map(|tx| tx.output_note_commitments()) {
+            unauthenticated_notes.remove(&output_note);
+        }
+
+        SelectedBatch {
+            txs,
+            id,
+            account_updates,
+            unauthenticated_notes,
+        }
     }
 }

--- a/crates/block-producer/src/mempool/graph/batch.rs
+++ b/crates/block-producer/src/mempool/graph/batch.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use miden_protocol::Word;
@@ -29,14 +29,7 @@ impl GraphNode for SelectedBatch {
     }
 
     fn unauthenticated_notes(&self) -> Box<dyn Iterator<Item = Word> + '_> {
-        // Filter notes that are produced within this batch.
-        let output_notes: HashSet<Word> = self.output_notes().collect();
-        Box::new(
-            self.transactions()
-                .iter()
-                .flat_map(|tx| tx.unauthenticated_note_commitments())
-                .filter(move |note| !output_notes.contains(note)),
-        )
+        Box::new(self.unauthenticated_note_commitments())
     }
 
     fn account_updates(


### PR DESCRIPTION
Current impl allocated every time a batch is queried for its unauthenticated notes.

Instead we now construct this list when the batch is created, avoiding the repeated allocation.

This won't have a perceivable effect at our current scale, but still a good thing to handle.

Closes #1878 