### PR TITLE
fix(docker): use correct runtime-base image

### DIFF
--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -28,7 +28,7 @@ COPY . .
 RUN cargo build --release --locked --bin miden-node
 
 # Base line runtime image with runtime dependencies installed.
-FROM debian:bullseye-slim AS runtime-base
+FROM debian:bookworm-slim AS runtime-base
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends sqlite3 \


### PR DESCRIPTION
Binaries built on Debian `bookworm` won't run on `bullseye` due to the older glibc version.