### PR TITLE
fix(github): remove prover proxy job from debian publish workflow

### DIFF
--- a/.github/workflows/publish-debian-all.yml
+++ b/.github/workflows/publish-debian-all.yml
@@ -67,29 +67,6 @@ jobs:
           crate: miden-remote-prover
           arch: ${{ matrix.arch }}
 
-  publish-prover-proxy:
-    name: Publish Prover Proxy ${{ matrix.arch }} Debian
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-    runs-on:
-      labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@main
-        with:
-          fetch-depth: 0
-      - name: Build and Publish Prover Proxy
-        uses: ./.github/actions/debian
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          gitref: ${{ env.version }}
-          crate_dir: remote-prover
-          package: miden-prover-proxy
-          packaging_dir: prover-proxy
-          crate: miden-remote-prover
-          arch: ${{ matrix.arch }}
-
   publish-network-monitor:
     name: Publish Network Monitor ${{ matrix.arch }} Debian
     strategy:


### PR DESCRIPTION
The prover proxy was removed in #1688, so the related job in the debian publish workflow is no longer needed.