### PR TITLE
ci: run optimised tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,6 @@ env:
   CARGO_INCREMENTAL: 0
   # Reduce cache usage by removing debug information.
   CARGO_PROFILE_DEV_DEBUG: 0
-  # Optimise for test execution speed.
-  #
-  # Proving in particular is extremely slow without this.
-  #
-  # Unfortunately, we cannot simply optimise specific dependencies because at the
-  # moment the slow code is monomorphised only at the final executable stage,
-  # which means it inherits the binaries optimisation level.
-  #
-  # This uses the dev profile because we share a single build for all jobs so this
-  # cannot be set for test only.
-  CARGO_PROFILE_DEV_OPT_LEVEL: 2
 
 # Limits workflow concurrency to only the latest commit in the PR.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,16 @@ on:
       - "docs/**"
 
 env:
-  # Name of the compilation artifact used to share the build across jobs.
-  BUILD_ARTIFACT_NAME: cargo-target
   # Shared prefix key for the rust cache.
   #
   # This provides a convenient way to evict old or corrupted cache.
   RUST_CACHE_KEY: rust-cache-2026.02.02
   # Shared branch-aware cache namespace for rust-cache.
   RUST_CACHE_SHARED_KEY: ${{ github.workflow }}-build-${{ github.base_ref || github.ref_name }}
+  # Per-run cache used to share build outputs across jobs within a single workflow run.
+  RUN_CACHE_KEY: ${{ github.workflow }}-run-${{ github.run_id }}
+  # Match rust-cache's compilation mode so restored outputs stay reusable downstream.
+  CARGO_INCREMENTAL: 0
   # Reduce cache usage by removing debug information.
   CARGO_PROFILE_DEV_DEBUG: 0
   # Optimise for test execution speed.
@@ -55,9 +57,8 @@ jobs:
   # Conventional builds, lints and tests that re-use a single cache for efficiency
   # ===============================================================================================
 
-  # Normal cargo build that uploads its outputs for all subsequent jobs to re-use.
-  #
-  # The build job itself maintains a cache on for itself on next and main branches.
+  # Normal cargo build that maintains a persistent trunk cache and publishes a
+  # single per-run cache for downstream jobs to restore immediately.
   build:
     runs-on: ubuntu-24.04
     steps:
@@ -112,12 +113,14 @@ jobs:
             fi
           done
           echo "Static linkage check passed for all of ${bin_targets[@]}"
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+      - name: Save run cache
+        uses: actions/cache/save@v4
         with:
-          name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: target
-          if-no-files-found: error
+          key: ${{ env.RUN_CACHE_KEY }}
+          path: |
+            target
+            ~/.cargo/registry
+            ~/.cargo/git
 
   clippy:
     name: lint - clippy
@@ -127,11 +130,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Rustup
         run: rustup update --no-self-update
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Restore run cache
+        uses: actions/cache/restore@v4
         with:
-          name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: .
+          key: ${{ env.RUN_CACHE_KEY }}
+          path: |
+            target
+            ~/.cargo/registry
+            ~/.cargo/git
       - name: clippy
         run: cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
 
@@ -146,11 +152,14 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.122
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Restore run cache
+        uses: actions/cache/restore@v4
         with:
-          name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: .
+          key: ${{ env.RUN_CACHE_KEY }}
+          path: |
+            target
+            ~/.cargo/registry
+            ~/.cargo/git
       - name: Build tests
         run: cargo nextest run --all-features --workspace --no-run
       - name: Run tests
@@ -167,11 +176,14 @@ jobs:
         uses: ./.github/actions/cleanup-runner
       - name: Rustup
         run: rustup update --no-self-update
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Restore run cache
+        uses: actions/cache/restore@v4
         with:
-          name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: .
+          key: ${{ env.RUN_CACHE_KEY }}
+          path: |
+            target
+            ~/.cargo/registry
+            ~/.cargo/git
       - name: Build docs
         run: cargo doc --no-deps --workspace --all-features --locked
 
@@ -187,11 +199,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Rustup
         run: rustup update --no-self-update
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Restore run cache
+        uses: actions/cache/restore@v4
         with:
-          name: ${{ env.BUILD_ARTIFACT_NAME }}
-          path: .
+          key: ${{ env.RUN_CACHE_KEY }}
+          path: |
+            target
+            ~/.cargo/registry
+            ~/.cargo/git
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.122
@@ -220,6 +235,29 @@ jobs:
           cargo run --bin miden-node-stress-test benchmark-store \
             --data-directory ${{ env.DATA_DIR }} \
             --iterations 10 --concurrency 1 sync-nullifiers --prefixes 10
+
+  cleanup-run-cache:
+    name: cleanup run cache
+    runs-on: ubuntu-24.04
+    if: ${{ always() }}
+    needs:
+      - build
+      - clippy
+      - tests
+      - doc
+      - stress-test
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete run cache
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/actions/caches?key=${{ env.RUN_CACHE_KEY }}"
 
   # ===============================================================================================
   # WASM related jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ env:
   RUST_CACHE_SHARED_KEY: ${{ github.workflow }}-build-${{ github.base_ref || github.ref_name }}
   # Reduce cache usage by removing debug information.
   CARGO_PROFILE_DEV_DEBUG: 0
+  # Optimise for test execution speed.
+  #
+  # Proving in particular is extremely slow without this.
+  #
+  # Unfortunately, we cannot simply optimise specific dependencies because at the
+  # moment the slow code is monomorphised only at the final executable stage,
+  # which means it inherits the binaries optimisation level.
+  #
+  # This uses the dev profile because we share a single build for all jobs so this
+  # cannot be set for test only.
+  CARGO_PROFILE_DEV_OPT_LEVEL: 2
 
 # Limits workflow concurrency to only the latest commit in the PR.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Continuous integration jobs.
 #
-# These get run on every pull-request, with github cache updated on push into `next`.
+# These get run on every pull-request.
 name: CI
 
 permissions:
@@ -23,6 +23,8 @@ on:
       - "docs/**"
 
 env:
+  # Name of the compilation artifact used to share the build across jobs.
+  BUILD_ARTIFACT_NAME: cargo-target
   # Shared prefix key for the rust cache.
   #
   # This provides a convenient way to evict old or corrupted cache.
@@ -53,7 +55,9 @@ jobs:
   # Conventional builds, lints and tests that re-use a single cache for efficiency
   # ===============================================================================================
 
-  # Normal cargo build that populates a cache for all subsequent jobs to re-use.
+  # Normal cargo build that uploads its outputs for all subsequent jobs to re-use.
+  #
+  # The build job itself maintains a cache on for itself on next and main branches.
   build:
     runs-on: ubuntu-24.04
     steps:
@@ -108,6 +112,12 @@ jobs:
             fi
           done
           echo "Static linkage check passed for all of ${bin_targets[@]}"
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_ARTIFACT_NAME }}
+          path: target
+          if-no-files-found: error
 
   clippy:
     name: lint - clippy
@@ -117,11 +127,11 @@ jobs:
       - uses: actions/checkout@v6
       - name: Rustup
         run: rustup update --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          shared-key: ${{ env.RUST_CACHE_SHARED_KEY }}
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          name: ${{ env.BUILD_ARTIFACT_NAME }}
+          path: .
       - name: clippy
         run: cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
 
@@ -136,11 +146,11 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.122
-      - uses: Swatinem/rust-cache@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          shared-key: ${{ env.RUST_CACHE_SHARED_KEY }}
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          name: ${{ env.BUILD_ARTIFACT_NAME }}
+          path: .
       - name: Build tests
         run: cargo nextest run --all-features --workspace --no-run
       - name: Run tests
@@ -157,11 +167,11 @@ jobs:
         uses: ./.github/actions/cleanup-runner
       - name: Rustup
         run: rustup update --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          shared-key: ${{ env.RUST_CACHE_SHARED_KEY }}
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          name: ${{ env.BUILD_ARTIFACT_NAME }}
+          path: .
       - name: Build docs
         run: cargo doc --no-deps --workspace --all-features --locked
 
@@ -177,11 +187,11 @@ jobs:
       - uses: actions/checkout@v6
       - name: Rustup
         run: rustup update --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          shared-key: ${{ env.RUST_CACHE_SHARED_KEY }}
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          name: ${{ env.BUILD_ARTIFACT_NAME }}
+          path: .
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.122

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,21 @@ version      = "0.14.9"
 [profile.release]
 debug = true
 
+# Optimise for test execution speed.
+#
+# Proving in particular is extremely slow without this.
+#
+# Unfortunately, we cannot simply optimise specific dependencies because at the
+# moment the slow code is monomorphised only at the final executable stage,
+# which means it inherits the binaries optimisation level.
+#
+# This uses the dev profile because we share a single build in CI for all jobs so this
+# cannot be set for test only.
+[profile.dev.package."*"]
+opt-level = 2
+[profile.dev.package.miden-remote-prover]
+opt-level = 2
+
 [workspace.dependencies]
 # Workspace crates.
 miden-large-smt-backend-rocksdb = { path = "crates/large-smt-backend-rocksdb", version = "0.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,6 @@ repository   = "https://github.com/0xMiden/node"
 rust-version = "1.93"
 version      = "0.14.9"
 
-# Optimize the cryptography for faster tests involving account creation.
-[profile.test.package.miden-crypto]
-opt-level = 2
-
 [profile.release]
 debug = true
 


### PR DESCRIPTION
Changes CI to build with optmisations (opt-level 2).

This drastically improves test performance, especially prover related tests. This isn't ideal, and requires longer compile times, but the trade off at the moment is definitely worth it. Test compile time went up for deps but since they're usually cached this is okay. Test runtime went from ~15 minutes to 2.

On my local machine, tests time went from over 6 minutes, to 15s.

Important to note that we could do much better ito compile time if the optimisations could be restricted to a subset of dependencies. Unfortunately as noted in #2002 this isn't practically possible due to late monomorphisation of prover generics, so we always have `miden-remote-prover` as a requirement.

------

Additionally, I noticed that this rebuild took forever because the cache was useless. However all jobs had to rebuild from scratch because the build job only saves its cache when its pushed to next to not flood github cache. This is correct but means the current build is never shared, only the latest trunk's build.

I changed this to share the artifacts directly between the current job. Each trunk has a base cache, which is used by `build`. `build` then creates a run specific cache, which gets deleted at the end of the run to spare cache capacity.

------

I originally had this change only for CI. But I think this is probably useful for dev setup as well so I made it broader.