### PR TITLE
refactor: replace BTreeMap/BTreeSet with HashMap/HashSet where ordering is not required

### DIFF
--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use miden_node_utils::ErrorReport;
@@ -398,7 +398,7 @@ struct NtxDataStore {
     /// single entry with the storage slot name that was added last. Thus, technically, requests
     /// to the store could be "wrong", but given that two identical maps have identical witnesses
     /// this does not cause issues in practice.
-    storage_slots: Arc<Mutex<BTreeMap<(AccountId, Word), StorageSlotName>>>,
+    storage_slots: Arc<Mutex<HashMap<(AccountId, Word), StorageSlotName>>>,
 }
 
 impl NtxDataStore {
@@ -423,7 +423,7 @@ impl NtxDataStore {
             script_cache,
             db,
             fetched_scripts: Arc::new(Mutex::new(Vec::new())),
-            storage_slots: Arc::new(Mutex::new(BTreeMap::default())),
+            storage_slots: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 

--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
 
@@ -67,7 +67,7 @@ mod tests;
 
 type StorageMapValueRow = (i64, String, Vec<u8>, Vec<u8>);
 type StorageHeaderWithEntries =
-    (AccountStorageHeader, BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>);
+    (AccountStorageHeader, HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>);
 
 // NETWORK ACCOUNT TYPE
 // ================================================================================================
@@ -799,7 +799,7 @@ pub(crate) fn select_latest_account_storage_components(
 fn select_latest_storage_map_entries_all(
     conn: &mut SqliteConnection,
     account_id: &AccountId,
-) -> Result<BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>, DatabaseError> {
+) -> Result<HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>, DatabaseError> {
     use schema::account_storage_map_values as t;
 
     let map_values: Vec<(String, Vec<u8>, Vec<u8>)> =
@@ -815,20 +815,20 @@ fn select_latest_storage_map_entries_for_slots(
     conn: &mut SqliteConnection,
     account_id: &AccountId,
     slot_names: &[StorageSlotName],
-) -> Result<BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>, DatabaseError> {
+) -> Result<HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>, DatabaseError> {
     use schema::account_storage_map_values as t;
 
     if slot_names.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(HashMap::new());
     }
 
     if let [slot_name] = slot_names {
         let entries = select_latest_storage_map_entries_for_slot(conn, account_id, slot_name)?;
         if entries.is_empty() {
-            return Ok(BTreeMap::new());
+            return Ok(HashMap::new());
         }
 
-        let mut map_entries = BTreeMap::new();
+        let mut map_entries = HashMap::new();
         map_entries.insert(slot_name.clone(), entries);
         return Ok(map_entries);
     }
@@ -863,9 +863,9 @@ fn select_latest_storage_map_entries_for_slot(
 
 fn group_storage_map_entries(
     map_values: Vec<(String, Vec<u8>, Vec<u8>)>,
-) -> Result<BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>, DatabaseError> {
-    let mut map_entries_by_slot: BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>> =
-        BTreeMap::new();
+) -> Result<HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>, DatabaseError> {
+    let mut map_entries_by_slot: HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>> =
+        HashMap::new();
     for (slot_name_str, key_bytes, value_bytes) in map_values {
         let slot_name: StorageSlotName = slot_name_str.parse().map_err(|_| {
             DatabaseError::DataCorrupted(format!("Invalid slot name: {slot_name_str}"))

--- a/crates/store/src/db/models/queries/accounts/delta.rs
+++ b/crates/store/src/db/models/queries/accounts/delta.rs
@@ -8,7 +8,7 @@
 //!
 //! Instead, only the minimal data needed for the update is fetched.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use diesel::query_dsl::methods::SelectDsl;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SqliteConnection};
@@ -151,11 +151,11 @@ pub(super) fn select_vault_balances_by_faucet_ids(
     conn: &mut SqliteConnection,
     account_id: AccountId,
     faucet_ids: &[AccountId],
-) -> Result<BTreeMap<AccountId, u64>, DatabaseError> {
+) -> Result<HashMap<AccountId, u64>, DatabaseError> {
     use schema::account_vault_assets as vault;
 
     if faucet_ids.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(HashMap::new());
     }
 
     let account_id_bytes = account_id.to_bytes();
@@ -175,7 +175,7 @@ pub(super) fn select_vault_balances_by_faucet_ids(
             .filter(vault::vault_key.eq_any(&vault_keys))
             .load(conn)?;
 
-    let mut balances = BTreeMap::from_iter(faucet_ids.iter().map(|faucet_id| (*faucet_id, 0)));
+    let mut balances = HashMap::from_iter(faucet_ids.iter().map(|faucet_id| (*faucet_id, 0)));
 
     for (_vault_key_bytes, maybe_asset_bytes) in entries {
         if let Some(asset_bytes) = maybe_asset_bytes {
@@ -229,10 +229,10 @@ pub(super) fn select_latest_vault_assets(
 pub(super) fn apply_storage_delta(
     header: &AccountStorageHeader,
     delta: &AccountStorageDelta,
-    map_entries: &BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>,
+    map_entries: &HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>,
 ) -> Result<AccountStorageHeader, DatabaseError> {
-    let mut value_updates: BTreeMap<&StorageSlotName, Word> = BTreeMap::new();
-    let mut map_updates: BTreeMap<&StorageSlotName, Word> = BTreeMap::new();
+    let mut value_updates: HashMap<&StorageSlotName, Word> = HashMap::new();
+    let mut map_updates: HashMap<&StorageSlotName, Word> = HashMap::new();
 
     for (slot_name, new_value) in delta.values() {
         value_updates.insert(slot_name, *new_value);


### PR DESCRIPTION
 Closes #1199

  Replaces `BTreeMap`/`BTreeSet` with `HashMap`/`HashSet` in cases where
  sorted ordering is not required, as an incremental step toward resolving #1199.

  ## Changes

  - **`NtxDataStore::storage_slots`** (`ntx-builder`): pure lookup map keyed by
    `(AccountId, Word)` — both implement `Hash`, no ordering needed.

  - **`select_vault_balances_by_faucet_ids`** (`store`): result is only ever
    accessed via `.get()` by its single caller.

  - **`apply_storage_delta` locals** (`store`): `value_updates` and `map_updates`
    are built and consumed only via `.insert()`/`.get()` within the same function.

  - **Outer storage-map entry maps** (`store`): `group_storage_map_entries`,
    `select_latest_storage_map_entries_*`, and `StorageHeaderWithEntries` all use
    `StorageSlotName` as the outer key (implements `Hash`); callers only do
    `.get()` lookups. The inner `BTreeMap<StorageMapKey, Word>` is kept ordered
    because `StorageMapKey` does not implement `Hash` and `StorageMap::with_entries`
    consumes it.

  ## Not changed

  The following usages intentionally remain as `BTreeMap`/`BTreeSet`:
  - `AccountTreeWithHistory::overlays` — uses `pop_first()` and `.range()`, requires ordering.
  - `InflightTransactions` in `subscription.rs` — explicitly documented as needing event ordering.
  - `Graph::selection_candidates` in `dag.rs` — tests verify deterministic sorted iteration.
  - All `BTreeSet<BlockNumber>` in `state/mod.rs` — `blocks.last()` relies on ordering.
  - `BlockInputs::new()` and `ProposedBatch::new()` call sites — external API requires `BTreeMap`.
  - `BTreeSet<AssetVaultKey>` — `AssetVaultKey` does not implement `Hash`.