### PR TITLE
perf(store): add composite index on transactions for SyncTransactions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.15.0 (TBD)
 
+- Added composite index `idx_transactions_account_block_txid` on `transactions(account_id, block_num, transaction_id)` to speed up `select_transactions_records` queries used by `SyncTransactions` ([#1965](https://github.com/0xMiden/node/issues/1965)).
 - [BREAKING] Changed `GetBlockByNumber` to accept a `BlockRequest` (with optional `include_proof` flag) and returns a response containing the block and an optional block proof ([#1864](https://github.com/0xMiden/node/pull/1864)).
 - Network monitor now auto-regenerates accounts after persistent increment failures instead of staying unhealthy indefinitely ([#1942](https://github.com/0xMiden/node/pull/1942)).
 - [BREAKING] Renamed `GetNoteError` endpoint to `GetNetworkNoteStatus` and extended it to return the full lifecycle status of a network note (`Pending`, `Processed`, `Discarded`, `Committed`) instead of only error information. Consumed notes are now retained in the database after block commit instead of being deleted ([#1892](https://github.com/0xMiden/node/pull/1892)).

--- a/crates/store/src/db/migrations/2026042800000_add_idx_transactions_sync/down.sql
+++ b/crates/store/src/db/migrations/2026042800000_add_idx_transactions_sync/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_transactions_account_block_txid;

--- a/crates/store/src/db/migrations/2026042800000_add_idx_transactions_sync/up.sql
+++ b/crates/store/src/db/migrations/2026042800000_add_idx_transactions_sync/up.sql
@@ -1,0 +1,13 @@
+-- Composite index to speed up select_transactions_records.
+--
+-- The query filters by account_id (IN), block_num range, and paginates via a
+-- (block_num, transaction_id) cursor, then orders by (block_num, transaction_id).
+-- The existing idx_transactions_account_id index only covers account_id, forcing
+-- a full scan over matching rows to apply the block_num filter and sort.
+--
+-- With (account_id, block_num, transaction_id) SQLite can:
+--   1. Seek to each account_id bucket directly,
+--   2. Range-scan block_num within that bucket, and
+--   3. Use transaction_id for cursor comparison and ORDER BY — all index-only.
+CREATE INDEX idx_transactions_account_block_txid
+    ON transactions(account_id, block_num, transaction_id);


### PR DESCRIPTION
  ## Summary

  Fixes #1965.

  The `select_transactions_records` query (used by `SyncTransactions`) filters
  by `account_id` (IN), a `block_num` range, and paginates via a
  `(block_num, transaction_id)` cursor ordered `(block_num ASC, transaction_id ASC)`.

  The existing `idx_transactions_account_id` only covers `account_id`, so SQLite
  must scan all matching rows to apply the block_num filter and sort:

  SEARCH transactions USING INDEX idx_transactions_account_id (account_id=?)

  The new composite index `(account_id, block_num, transaction_id)` lets SQLite:
  1. Seek into each `account_id` bucket directly,
  2. Range-scan `block_num` within that bucket, and
  3. Resolve the cursor + ORDER BY from the index alone — no extra sort step.

  ## Changes
  - Migration `2026042800000_add_idx_transactions_sync`: adds `idx_transactions_account_block_txid ON
  transactions(account_id, block_num, transaction_id)` with a matching `down.sql`.
  - Updated `CHANGELOG.md`.

  ## Test plan
  - [ ] Existing store tests pass
  - [ ] `EXPLAIN QUERY PLAN` on `select_transactions_records` shows the new index used