### PR TITLE
fix(store): wrap RocksDB blocking ops with block_in_place in async context

### DIFF
--- a/crates/store/src/state/apply_block.rs
+++ b/crates/store/src/state/apply_block.rs
@@ -130,12 +130,16 @@ impl State {
             }
 
             // compute update for nullifier tree
-            let nullifier_tree_update = inner
-                .nullifier_tree
-                .compute_mutations(
-                    body.created_nullifiers().iter().map(|nullifier| (*nullifier, block_num)),
-                )
-                .map_err(InvalidBlockError::NewBlockNullifierAlreadySpent)?;
+            let nullifier_tree_update = tokio::task::block_in_place(|| {
+                inner
+                    .nullifier_tree
+                    .compute_mutations(
+                        body.created_nullifiers()
+                            .iter()
+                            .map(|nullifier| (*nullifier, block_num)),
+                    )
+                    .map_err(InvalidBlockError::NewBlockNullifierAlreadySpent)
+            })?;
 
             if nullifier_tree_update.as_mutation_set().root() != header.nullifier_root() {
                 // We do our best here to notify the serve routine, if it doesn't care (dropped the
@@ -147,21 +151,25 @@ impl State {
             }
 
             // compute update for account tree
-            let account_tree_update = inner
-                .account_tree
-                .compute_mutations(
-                    body.updated_accounts()
-                        .iter()
-                        .map(|update| (update.account_id(), update.final_state_commitment())),
-                )
-                .map_err(|e| match e {
-                    HistoricalError::AccountTreeError(err) => {
-                        InvalidBlockError::NewBlockDuplicateAccountIdPrefix(err)
-                    },
-                    HistoricalError::MerkleError(_) => {
-                        panic!("Unexpected MerkleError during account tree mutation computation")
-                    },
-                })?;
+            let account_tree_update = tokio::task::block_in_place(|| {
+                inner
+                    .account_tree
+                    .compute_mutations(
+                        body.updated_accounts()
+                            .iter()
+                            .map(|update| (update.account_id(), update.final_state_commitment())),
+                    )
+                    .map_err(|e| match e {
+                        HistoricalError::AccountTreeError(err) => {
+                            InvalidBlockError::NewBlockDuplicateAccountIdPrefix(err)
+                        },
+                        HistoricalError::MerkleError(_) => {
+                            panic!(
+                                "Unexpected MerkleError during account tree mutation computation"
+                            )
+                        },
+                    })
+            })?;
 
             if account_tree_update.as_mutation_set().root() != header.account_root() {
                 let _ = self.termination_ask.try_send(ApplyBlockError::InvalidBlockError(
@@ -275,15 +283,20 @@ impl State {
                 .await?
                 .map_err(|err| ApplyBlockError::DbUpdateTaskFailed(err.as_report()))?;
 
-            // Update the in-memory data structures after successful commit of the DB transaction
-            inner
-                .nullifier_tree
-                .apply_mutations(nullifier_tree_update)
-                .expect("Unreachable: old nullifier tree root must be checked before this step");
-            inner
-                .account_tree
-                .apply_mutations(account_tree_update)
-                .expect("Unreachable: old account tree root must be checked before this step");
+            // Update the in-memory data structures after successful commit of the DB transaction.
+            // These write to RocksDB and must run on a blocking-capable thread.
+            tokio::task::block_in_place(|| {
+                inner
+                    .nullifier_tree
+                    .apply_mutations(nullifier_tree_update)
+                    .expect(
+                        "Unreachable: old nullifier tree root must be checked before this step",
+                    );
+                inner
+                    .account_tree
+                    .apply_mutations(account_tree_update)
+                    .expect("Unreachable: old account tree root must be checked before this step");
+            });
 
             inner.blockchain.push(block_commitment);
 

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -265,11 +265,13 @@ impl State {
     #[instrument(level = "debug", target = COMPONENT, skip_all, ret)]
     pub async fn check_nullifiers(&self, nullifiers: &[Nullifier]) -> Vec<SmtProof> {
         let inner = self.inner.read().await;
-        nullifiers
-            .iter()
-            .map(|n| inner.nullifier_tree.open(n))
-            .map(NullifierWitness::into_proof)
-            .collect()
+        tokio::task::block_in_place(|| {
+            nullifiers
+                .iter()
+                .map(|n| inner.nullifier_tree.open(n))
+                .map(NullifierWitness::into_proof)
+                .collect()
+        })
     }
 
     /// Queries a list of notes from the database.
@@ -552,19 +554,27 @@ impl State {
             );
 
         // Fetch witnesses for all accounts.
-        let account_witnesses = account_ids
-            .iter()
-            .copied()
-            .map(|account_id| (account_id, inner.account_tree.open_latest(account_id)))
-            .collect::<BTreeMap<AccountId, AccountWitness>>();
+        // open_latest() reads from RocksDB for deep subtrees — use block_in_place.
+        let account_witnesses: BTreeMap<AccountId, AccountWitness> =
+            tokio::task::block_in_place(|| {
+                account_ids
+                    .iter()
+                    .copied()
+                    .map(|account_id| (account_id, inner.account_tree.open_latest(account_id)))
+                    .collect()
+            });
 
         // Fetch witnesses for all nullifiers. We don't check whether the nullifiers are spent or
         // not as this is done as part of proposing the block.
-        let nullifier_witnesses: BTreeMap<Nullifier, NullifierWitness> = nullifiers
-            .iter()
-            .copied()
-            .map(|nullifier| (nullifier, inner.nullifier_tree.open(&nullifier)))
-            .collect();
+        // open() reads from RocksDB for deep subtrees — use block_in_place.
+        let nullifier_witnesses: BTreeMap<Nullifier, NullifierWitness> =
+            tokio::task::block_in_place(|| {
+                nullifiers
+                    .iter()
+                    .copied()
+                    .map(|nullifier| (nullifier, inner.nullifier_tree.open(&nullifier)))
+                    .collect()
+            });
 
         Ok((latest_block_number, account_witnesses, nullifier_witnesses, partial_mmr))
     }
@@ -581,10 +591,13 @@ impl State {
 
         let inner = self.inner.read().await;
 
-        let account_commitment = inner.account_tree.get_latest_commitment(account_id);
+        let account_commitment =
+            tokio::task::block_in_place(|| inner.account_tree.get_latest_commitment(account_id));
 
         let new_account_id_prefix_is_unique = if account_commitment.is_empty() {
-            Some(!inner.account_tree.contains_account_id_prefix_in_latest(account_id.prefix()))
+            Some(!tokio::task::block_in_place(|| {
+                inner.account_tree.contains_account_id_prefix_in_latest(account_id.prefix())
+            }))
         } else {
             None
         };
@@ -597,13 +610,15 @@ impl State {
             });
         }
 
-        let nullifiers = nullifiers
-            .iter()
-            .map(|nullifier| NullifierInfo {
-                nullifier: *nullifier,
-                block_num: inner.nullifier_tree.get_block_num(nullifier).unwrap_or_default(),
-            })
-            .collect();
+        let nullifiers = tokio::task::block_in_place(|| {
+            nullifiers
+                .iter()
+                .map(|nullifier| NullifierInfo {
+                    nullifier: *nullifier,
+                    block_num: inner.nullifier_tree.get_block_num(nullifier).unwrap_or_default(),
+                })
+                .collect()
+        });
 
         let found_unauthenticated_notes = self
             .db
@@ -691,24 +706,28 @@ impl State {
             self.inner.read().instrument(tracing::info_span!("acquire_inner_state")).await;
 
         // Determine which block to query
-        let (block_num, witness) = if let Some(requested_block) = block_num {
-            // Historical query: use the account tree with history
-            let witness =
-                inner_state.account_tree.open_at(account_id, requested_block).ok_or_else(|| {
-                    let latest_block = inner_state.account_tree.block_number_latest();
-                    if requested_block > latest_block {
-                        GetAccountError::UnknownBlock(requested_block)
-                    } else {
-                        GetAccountError::BlockPruned(requested_block)
-                    }
-                })?;
-            (requested_block, witness)
-        } else {
-            // Latest query: use the latest state
-            let block_num = inner_state.account_tree.block_number_latest();
-            let witness = inner_state.account_tree.open_latest(account_id);
-            (block_num, witness)
-        };
+        let (block_num, witness) = tokio::task::block_in_place(|| {
+            if let Some(requested_block) = block_num {
+                // Historical query: use the account tree with history
+                let witness = inner_state
+                    .account_tree
+                    .open_at(account_id, requested_block)
+                    .ok_or_else(|| {
+                        let latest_block = inner_state.account_tree.block_number_latest();
+                        if requested_block > latest_block {
+                            GetAccountError::UnknownBlock(requested_block)
+                        } else {
+                            GetAccountError::BlockPruned(requested_block)
+                        }
+                    })?;
+                Ok::<_, GetAccountError>((requested_block, witness))
+            } else {
+                // Latest query: use the latest state
+                let block_num = inner_state.account_tree.block_number_latest();
+                let witness = inner_state.account_tree.open_latest(account_id);
+                Ok((block_num, witness))
+            }
+        })?;
 
         Ok((block_num, witness))
     }


### PR DESCRIPTION
Closes #1969

  ## Problem

  `LargeSmt<RocksDbStorage>` operations that read or write deep subtrees
  touch RocksDB directly and can block the current OS thread for disk I/O.
  These methods were being called inside async functions while holding
  tokio `RwLock` guards, which starves the async runtime because blocked
  tokio threads cannot run other tasks.

  Affected methods: `open`, `open_at`, `open_latest`, `compute_mutations`,
  `apply_mutations`, `get_block_num`, `get_latest_commitment`,
  `contains_account_id_prefix_in_latest`.

  ## Solution

  Wrap each blocking call site with `tokio::task::block_in_place`. Unlike
  `spawn_blocking`, `block_in_place` keeps the current thread (and its
  held lock guards) in place while signalling the runtime to move
  cooperative tasks off it — making it safe to use while holding
  `RwLockReadGuard` / `RwLockWriteGuard`.

  ## Changed files

  - `crates/store/src/state/apply_block.rs` — `compute_mutations` and `apply_mutations` for both trees
  - `crates/store/src/state/mod.rs` — all remaining tree read sites in `check_nullifiers`, `get_batch_inputs`,
  `get_transaction_inputs`, and `get_account_witness`