### PR TITLE
ci: fix profile overrides not observed by cache

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,24 @@ rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
 # memory allocator which can cause contention and performance
 # degradation in high-concurrency scenarios we have in the node.
 LIBSQLITE3_FLAGS = "-USQLITE_ENABLE_MEMORY_MANAGEMENT -DSQLITE_DEFAULT_MEMSTATUS=0"
+
+[profile.release]
+debug = true
+
+# Optimise for test execution speed. These overrides live here so that CI
+# rust-cache picks up on them as part of its key hash. Changes in Cargo.toml
+# are ignored because they're part of a virtual manifest and not a package per se.
+#
+# Proving in particular is extremely slow without this.
+#
+# Unfortunately, we cannot simply optimise specific dependencies because at the
+# moment the slow code is monomorphised only at the final executable stage,
+# which means it inherits the binaries optimisation level.
+#
+# This uses the dev profile because we share a single build in CI for all jobs so this
+# cannot be set for test only.
+[profile.dev.package."*"]
+opt-level = 2
+
+[profile.dev.package.miden-remote-prover]
+opt-level = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           shared-key: ${{ env.RUST_CACHE_SHARED_KEY }}
           prefix-key: ${{ env.RUST_CACHE_KEY }}
+          cache-workspace-crates: true
           save-if: ${{ github.ref == 'refs/heads/next' || github.ref == 'refs/heads/main' }}
       - name: cargo build
         run: cargo build --workspace --all-targets --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,24 +34,6 @@ repository   = "https://github.com/0xMiden/node"
 rust-version = "1.93"
 version      = "0.14.9"
 
-[profile.release]
-debug = true
-
-# Optimise for test execution speed.
-#
-# Proving in particular is extremely slow without this.
-#
-# Unfortunately, we cannot simply optimise specific dependencies because at the
-# moment the slow code is monomorphised only at the final executable stage,
-# which means it inherits the binaries optimisation level.
-#
-# This uses the dev profile because we share a single build in CI for all jobs so this
-# cannot be set for test only.
-[profile.dev.package."*"]
-opt-level = 2
-[profile.dev.package.miden-remote-prover]
-opt-level = 2
-
 [workspace.dependencies]
 # Workspace crates.
 miden-large-smt-backend-rocksdb = { path = "crates/large-smt-backend-rocksdb", version = "0.14" }


### PR DESCRIPTION
#2004 changed the optimisation levels in CI. Unfortunately rust-cache doesn't observe `Cargo.toml` as part of its hash key, so its not persisting the new builds (it keeps the old one).

This PR fixes this by moving the profile overrides into the root cargo config (which is observed). In addition we also now cache workspace crates.. we'll have to see if this is too much, or worth it.