### PR TITLE
refactor(lru_cache): simplify locking in LRU cache wrapper

### DIFF
--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -566,7 +566,7 @@ impl DataStore for NtxDataStore {
     ) -> impl FutureMaybeSend<Result<Option<NoteScript>, DataStoreError>> {
         async move {
             // 1. In-memory LRU cache.
-            if let Some(cached_script) = self.script_cache.get(&script_root).await {
+            if let Some(cached_script) = self.script_cache.get(&script_root) {
                 return Ok(Some(cached_script));
             }
 
@@ -574,7 +574,7 @@ impl DataStore for NtxDataStore {
             if let Some(script) = self.db.lookup_note_script(script_root).await.map_err(|err| {
                 DataStoreError::other_with_source("failed to look up note script in local DB", err)
             })? {
-                self.script_cache.put(script_root, script.clone()).await;
+                self.script_cache.put(script_root, script.clone());
                 return Ok(Some(script));
             }
 
@@ -590,7 +590,7 @@ impl DataStore for NtxDataStore {
             if let Some(script) = maybe_script {
                 // Collect for later persistence by the coordinator.
                 self.fetched_scripts.lock().await.push((script_root, script.clone()));
-                self.script_cache.put(script_root, script.clone()).await;
+                self.script_cache.put(script_root, script.clone());
                 Ok(Some(script))
             } else {
                 Ok(None)

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -197,7 +197,7 @@ impl RpcService {
     /// This is retrieved from the local LRU cache, or otherwise from the store on cache miss.
     #[tracing::instrument(target = COMPONENT, name = "get_block_commitment", skip_all, fields(block.number = %block))]
     async fn get_block_commitment(&self, block: BlockNumber) -> Result<Word, Status> {
-        if let Some(commitment) = self.block_commitment_cache.get(&block).await {
+        if let Some(commitment) = self.block_commitment_cache.get(&block) {
             return Ok(commitment);
         }
 
@@ -216,7 +216,7 @@ impl RpcService {
             .ok_or_else(|| Status::invalid_argument(format!("unknown block {block}")))?;
 
         let commitment = header.commitment();
-        self.block_commitment_cache.put(block, commitment).await;
+        self.block_commitment_cache.put(block, commitment);
 
         Ok(commitment)
     }

--- a/crates/utils/src/lru_cache.rs
+++ b/crates/utils/src/lru_cache.rs
@@ -1,9 +1,8 @@
 use std::hash::Hash;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use lru::LruCache as InnerCache;
-use tokio::sync::{Mutex, MutexGuard};
 use tracing::instrument;
 
 /// A newtype wrapper around an LRU cache. Ensures that the cache lock is not held across
@@ -22,17 +21,20 @@ where
     }
 
     /// Retrieves a value from the cache.
-    pub async fn get(&self, key: &K) -> Option<V> {
-        self.lock().await.get(key).cloned()
+    pub fn get(&self, key: &K) -> Option<V> {
+        self.lock().get(key).cloned()
     }
 
     /// Puts a value into the cache.
-    pub async fn put(&self, key: K, value: V) {
-        self.lock().await.put(key, value);
+    pub fn put(&self, key: K, value: V) {
+        self.lock().put(key, value);
     }
 
     #[instrument(name = "lru.lock", skip_all)]
-    async fn lock(&self) -> MutexGuard<'_, InnerCache<K, V>> {
-        self.0.lock().await
+    fn lock(&self) -> MutexGuard<'_, InnerCache<K, V>> {
+        // SAFETY: The mutex is only held for the duration of the get/put operation
+        // where panics are possible only if we're running out of memory, in which
+        // case the entire process is likely to be unstable anyway.
+        self.0.lock().expect("LRU cache mutex poisoned")
     }
 }


### PR DESCRIPTION
The API explicitly guarantees that the lock cannot be held across await points, so we can simplify the implementation by removing the async mutex and using a standard mutex instead.

See the [Tokio documentation](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use) for a more detailed reasoning why a sync mutex should be used here.