### PR TITLE
feat(store): use RocksDB-backed persistent account state forest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.14.11 (TBD)
+
+- Implement persistent RocksDB backend for `AccountStateForest`, improving startup time ([#2020](https://github.com/0xMiden/node/pull/2020)).
+
 ## v0.14.10 (2026-05-29)
 
 - Optimize `GetAccount` implementation to serve vault assets from `AccountStateForest` ([#1981](https://github.com/0xMiden/node/pull/1981)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "rand_core 0.9.5",
  "rand_hc",
  "rayon",
+ "rocksdb",
  "serde",
  "sha2",
  "sha3",

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -72,7 +72,7 @@ termtree              = "1.0"
 
 [features]
 default = ["rocksdb"]
-rocksdb = ["dep:miden-large-smt-backend-rocksdb", "miden-node-utils/rocksdb"]
+rocksdb = ["dep:miden-large-smt-backend-rocksdb", "miden-crypto/persistent-forest", "miden-node-utils/rocksdb"]
 
 [[bench]]
 harness           = false

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 
 use miden_crypto::hash::rpo::Rpo256;
-use miden_crypto::merkle::smt::ForestInMemoryBackend;
+#[cfg(feature = "rocksdb")]
+use miden_crypto::merkle::smt::ForestPersistentBackend;
+use miden_crypto::merkle::smt::{Backend, ForestInMemoryBackend};
 use miden_node_proto::domain::account::{AccountStorageMapDetails, AccountVaultDetails};
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
@@ -64,6 +66,15 @@ pub enum WitnessError {
     AssetError(#[from] AssetError),
 }
 
+#[cfg(feature = "rocksdb")]
+pub(crate) type AccountStateForestBackend = ForestPersistentBackend;
+#[cfg(not(feature = "rocksdb"))]
+pub(crate) type AccountStateForestBackend = ForestInMemoryBackend;
+
+const fn empty_smt_root() -> Word {
+    *EmptySubtreeRoots::entry(SMT_DEPTH, 0)
+}
+
 // ACCOUNT STATE FOREST
 // ================================================================================================
 
@@ -76,10 +87,10 @@ pub enum AccountStorageMapResult {
 }
 
 /// Container for forest-related state that needs to be updated atomically.
-pub(crate) struct AccountStateForest {
+pub(crate) struct AccountStateForest<B: Backend = ForestInMemoryBackend> {
     /// `LargeSmtForest` for efficient account storage reconstruction.
     /// Populated during block import with storage and vault SMTs.
-    forest: LargeSmtForest<ForestInMemoryBackend>,
+    forest: LargeSmtForest<B>,
 
     /// Reverse lookup from hashed SMT storage keys to raw storage map keys.
     ///
@@ -88,7 +99,8 @@ pub(crate) struct AccountStateForest {
     storage_map_key_cache: LruCache<Word, StorageMapKey>,
 }
 
-impl AccountStateForest {
+#[cfg(test)]
+impl AccountStateForest<ForestInMemoryBackend> {
     pub(crate) fn new() -> Self {
         Self {
             forest: Self::create_forest(),
@@ -99,18 +111,35 @@ impl AccountStateForest {
         }
     }
 
+    /// Returns the root of an empty SMT.
+    pub(crate) const fn empty_smt_root() -> Word {
+        empty_smt_root()
+    }
+
     fn create_forest() -> LargeSmtForest<ForestInMemoryBackend> {
         let backend = ForestInMemoryBackend::new();
         LargeSmtForest::new(backend).expect("in-memory backend should initialize")
     }
+}
+
+impl<B: Backend> AccountStateForest<B> {
+    pub(crate) fn from_backend(backend: B) -> Result<Self, LargeSmtForestError> {
+        Ok(Self {
+            forest: LargeSmtForest::new(backend)?,
+            storage_map_key_cache: LruCache::new(
+                NonZeroUsize::new(HASHED_STORAGE_MAP_KEY_CACHE_CAPACITY)
+                    .expect("storage map key cache capacity must be non-zero"),
+            ),
+        })
+    }
+
+    #[cfg(feature = "rocksdb")]
+    pub(crate) fn lineage_count(&self) -> usize {
+        self.forest.lineage_count()
+    }
 
     // HELPERS
     // --------------------------------------------------------------------------------------------
-
-    /// Returns the root of an empty SMT.
-    const fn empty_smt_root() -> Word {
-        *EmptySubtreeRoots::entry(SMT_DEPTH, 0)
-    }
 
     #[cfg(test)]
     fn tree_id_for_root(
@@ -519,7 +548,7 @@ impl AccountStateForest {
     /// account, returns an empty SMT root.
     fn get_latest_vault_root(&self, account_id: AccountId) -> Word {
         let lineage = Self::vault_lineage_id(account_id);
-        self.forest.latest_root(lineage).unwrap_or_else(Self::empty_smt_root)
+        self.forest.latest_root(lineage).unwrap_or_else(empty_smt_root)
     }
 
     /// Inserts asset vault data into the forest for the specified account. Assumes that asset
@@ -532,7 +561,7 @@ impl AccountStateForest {
     ) -> Result<(), AccountStateForestError> {
         let prev_root = self.get_latest_vault_root(account_id);
         let lineage = Self::vault_lineage_id(account_id);
-        assert_eq!(prev_root, Self::empty_smt_root(), "account should not be in the forest");
+        assert_eq!(prev_root, empty_smt_root(), "account should not be in the forest");
         assert!(
             self.forest.latest_version(lineage).is_none(),
             "account should not be in the forest"
@@ -602,7 +631,7 @@ impl AccountStateForest {
         for (slot_name, map_delta) in storage_delta.maps() {
             // get the latest root for this map, and make sure the root is for an empty tree
             let prev_root = self.get_latest_storage_map_root(account_id, slot_name);
-            assert_eq!(prev_root, Self::empty_smt_root(), "account should not be in the forest");
+            assert_eq!(prev_root, empty_smt_root(), "account should not be in the forest");
 
             let raw_map_entries: Vec<(StorageMapKey, Word)> =
                 Vec::from_iter(map_delta.entries().iter().filter_map(|(&key, &value)| {
@@ -740,7 +769,7 @@ impl AccountStateForest {
         slot_name: &StorageSlotName,
     ) -> Word {
         let lineage = Self::storage_lineage_id(account_id, slot_name);
-        self.forest.latest_root(lineage).unwrap_or_else(Self::empty_smt_root)
+        self.forest.latest_root(lineage).unwrap_or_else(empty_smt_root)
     }
 
     /// Updates the forest with storage map changes from a delta.

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -546,7 +546,7 @@ impl<B: Backend> AccountStateForest<B> {
 
     /// Retrieves the most recent vault SMT root for an account. If no vault root is found for the
     /// account, returns an empty SMT root.
-    fn get_latest_vault_root(&self, account_id: AccountId) -> Word {
+    pub(crate) fn get_latest_vault_root(&self, account_id: AccountId) -> Word {
         let lineage = Self::vault_lineage_id(account_id);
         self.forest.latest_root(lineage).unwrap_or_else(empty_smt_root)
     }
@@ -763,7 +763,7 @@ impl<B: Backend> AccountStateForest<B> {
     // --------------------------------------------------------------------------------------------
 
     /// Retrieves the most recent storage map SMT root for an account slot.
-    fn get_latest_storage_map_root(
+    pub(crate) fn get_latest_storage_map_root(
         &self,
         account_id: AccountId,
         slot_name: &StorageSlotName,

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -35,6 +35,7 @@ pub use crate::db::models::queries::{
     AccountCommitmentsPage,
     NullifiersPage,
     PublicAccountIdsPage,
+    PublicAccountStateRootsPage,
 };
 use crate::db::models::queries::{BlockHeaderCommitment, StorageMapValuesPage};
 use crate::db::models::{Page, queries};
@@ -406,6 +407,19 @@ impl Db {
     ) -> Result<PublicAccountIdsPage> {
         self.transact("read public account IDs paged", move |conn| {
             queries::select_public_account_ids_paged(conn, page_size, after_account_id)
+        })
+        .await
+    }
+
+    /// Returns a page of public account state roots for forest consistency verification.
+    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    pub async fn select_public_account_state_roots_paged(
+        &self,
+        page_size: std::num::NonZeroUsize,
+        after_account_id: Option<AccountId>,
+    ) -> Result<PublicAccountStateRootsPage> {
+        self.transact("read public account state roots paged", move |conn| {
+            queries::select_public_account_state_roots_paged(conn, page_size, after_account_id)
         })
         .await
     }

--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -340,6 +340,24 @@ pub struct PublicAccountIdsPage {
     pub next_cursor: Option<AccountId>,
 }
 
+/// Latest account state forest roots for a public account.
+#[derive(Debug)]
+pub struct PublicAccountStateRoots {
+    pub account_id: AccountId,
+    pub vault_root: Word,
+    pub storage_header: AccountStorageHeader,
+}
+
+/// Page of public account state roots returned by
+/// [`select_public_account_state_roots_paged`].
+#[derive(Debug)]
+pub struct PublicAccountStateRootsPage {
+    /// The public account state roots in this page.
+    pub accounts: Vec<PublicAccountStateRoots>,
+    /// If `Some`, there are more results. Use this as the `after_account_id` for the next page.
+    pub next_cursor: Option<AccountId>,
+}
+
 /// Selects public account IDs with pagination.
 ///
 /// Returns up to `page_size` public account IDs, starting after `after_account_id` if provided.
@@ -398,6 +416,94 @@ pub(crate) fn select_public_account_ids_paged(
     };
 
     Ok(PublicAccountIdsPage { account_ids, next_cursor })
+}
+
+/// Selects public account vault roots and storage headers with pagination.
+///
+/// Returns up to `page_size` public account states, starting after `after_account_id` if provided.
+/// Results are ordered by `account_id` for stable pagination.
+///
+/// Public accounts are those with `AccountStorageMode::Public` or `AccountStorageMode::Network`.
+/// We identify them by checking `code_commitment IS NOT NULL` - public accounts store their full
+/// state (including `code_commitment`), while private accounts only store the `account_commitment`.
+///
+/// # Raw SQL
+///
+/// ```sql
+/// SELECT
+///     account_id,
+///     vault_root,
+///     storage_header
+/// FROM
+///     accounts
+/// WHERE
+///     is_latest = 1
+///     AND code_commitment IS NOT NULL
+///     AND (account_id > :after_account_id OR :after_account_id IS NULL)
+/// ORDER BY
+///     account_id ASC
+/// LIMIT :page_size + 1
+/// ```
+pub(crate) fn select_public_account_state_roots_paged(
+    conn: &mut SqliteConnection,
+    page_size: NonZeroUsize,
+    after_account_id: Option<AccountId>,
+) -> Result<PublicAccountStateRootsPage, DatabaseError> {
+    #[expect(clippy::cast_possible_wrap)]
+    let limit = (page_size.get() + 1) as i64;
+
+    let mut query = SelectDsl::select(
+        schema::accounts::table,
+        (
+            schema::accounts::account_id,
+            schema::accounts::vault_root,
+            schema::accounts::storage_header,
+        ),
+    )
+    .filter(schema::accounts::is_latest.eq(true))
+    .filter(schema::accounts::code_commitment.is_not_null())
+    .order_by(schema::accounts::account_id.asc())
+    .limit(limit)
+    .into_boxed();
+
+    if let Some(cursor) = after_account_id {
+        query = query.filter(schema::accounts::account_id.gt(cursor.to_bytes()));
+    }
+
+    let raw = query.load::<(Vec<u8>, Option<Vec<u8>>, Option<Vec<u8>>)>(conn)?;
+
+    let mut accounts: Vec<PublicAccountStateRoots> = Result::from_iter(raw.into_iter().map(
+        |(account_id_bytes, vault_root_bytes, storage_header_bytes)| {
+            let account_id = AccountId::read_from_bytes(&account_id_bytes)
+                .map_err(DatabaseError::DeserializationError)?;
+            let vault_root_bytes = vault_root_bytes.ok_or_else(|| {
+                DatabaseError::DataCorrupted(format!(
+                    "public account {account_id} is missing a vault root"
+                ))
+            })?;
+            let storage_header_bytes = storage_header_bytes.ok_or_else(|| {
+                DatabaseError::DataCorrupted(format!(
+                    "public account {account_id} is missing a storage header"
+                ))
+            })?;
+
+            Ok::<_, DatabaseError>(PublicAccountStateRoots {
+                account_id,
+                vault_root: Word::read_from_bytes(&vault_root_bytes)?,
+                storage_header: AccountStorageHeader::read_from_bytes(&storage_header_bytes)?,
+            })
+        },
+    ))?;
+
+    // If we got more than page_size, there are more results.
+    let next_cursor = if accounts.len() > page_size.get() {
+        accounts.pop();
+        accounts.last().map(|account| account.account_id)
+    } else {
+        None
+    };
+
+    Ok(PublicAccountStateRootsPage { accounts, next_cursor })
 }
 
 /// Select account vault assets within a block range (inclusive).

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -147,6 +147,17 @@ pub enum StateInitializationError {
         tree_root: Word,
         block_root: Word,
     },
+    #[error(
+        "account state forest root ({forest_root:?}) does not match SQLite root \
+         ({database_root:?}) for account {account_id}, slot {slot_name:?}. Delete the account \
+         state forest storage directory and restart the node to rebuild from the database."
+    )]
+    AccountStateForestStorageDiverged {
+        account_id: AccountId,
+        slot_name: Option<String>,
+        forest_root: Word,
+        database_root: Word,
+    },
     #[error("public account {0} is missing details in database")]
     PublicAccountMissingDetails(AccountId),
     #[error("failed to convert account to delta: {0}")]

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -148,8 +148,8 @@ pub enum StateInitializationError {
         block_root: Word,
     },
     #[error(
-        "account state forest root ({forest_root:?}) does not match SQLite root \
-         ({database_root:?}) for account {account_id}, slot {slot_name:?}. Delete the account \
+        "account state forest root ({forest_root}) does not match SQLite root \
+         ({database_root}) for account {account_id}, slot {slot_name:?}. Delete the account \
          state forest storage directory and restart the node to rebuild from the database."
     )]
     AccountStateForestStorageDiverged {

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -120,6 +120,8 @@ pub enum StateInitializationError {
     AccountTreeIoError(String),
     #[error("nullifier tree IO error: {0}")]
     NullifierTreeIoError(String),
+    #[error("account state forest IO error: {0}")]
+    AccountStateForestIoError(String),
     #[error("database error")]
     DatabaseError(#[from] DatabaseError),
     #[error("failed to create nullifier tree")]

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -573,7 +573,7 @@ pub async fn verify_tree_consistency(
 ///
 /// This check ensures persisted account state forest has not diverged from the latest
 /// account states in SQLite. When the forest is rebuilt from SQLite, it will naturally
-/// match; when loaded from RocksDB, this catches corruption or incomplete shutdown.
+/// match; when loaded from `RocksDB`, this catches corruption or incomplete shutdown.
 #[instrument(target = COMPONENT, skip_all)]
 pub async fn verify_account_state_forest_consistency(
     forest: &AccountStateForest<impl Backend>,

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -571,9 +571,9 @@ pub async fn verify_tree_consistency(
 
 /// Verifies that the account state forest matches latest public account roots from SQLite.
 ///
-/// This check ensures persisted account state forest storage has not diverged from the latest
-/// account states in SQLite. When the forest is rebuilt from the database, it will naturally
-/// match; when loaded from persistent storage, this catches corruption or incomplete shutdown.
+/// This check ensures persisted account state forest has not diverged from the latest
+/// account states in SQLite. When the forest is rebuilt from SQLite, it will naturally
+/// match; when loaded from RocksDB, this catches corruption or incomplete shutdown.
 #[instrument(target = COMPONENT, skip_all)]
 pub async fn verify_account_state_forest_consistency(
     forest: &AccountStateForest<impl Backend>,

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -18,7 +18,9 @@ use miden_crypto::merkle::smt::{Backend, ForestInMemoryBackend};
 use miden_crypto::merkle::smt::{ForestPersistentBackend, PersistentBackendConfig};
 #[cfg(feature = "rocksdb")]
 use miden_large_smt_backend_rocksdb::RocksDbStorage;
+#[cfg(feature = "rocksdb")]
 use miden_node_utils::clap::RocksDbOptions;
+use miden_protocol::account::{AccountId, AccountStorageHeader, StorageSlotType};
 use miden_protocol::block::account_tree::{AccountIdKey, AccountTree};
 use miden_protocol::block::nullifier_tree::NullifierTree;
 use miden_protocol::block::{BlockNumber, Blockchain};
@@ -565,4 +567,160 @@ pub async fn verify_tree_consistency(
     }
 
     Ok(())
+}
+
+/// Verifies that the account state forest matches latest public account roots from SQLite.
+///
+/// This check ensures persisted account state forest storage has not diverged from the latest
+/// account states in SQLite. When the forest is rebuilt from the database, it will naturally
+/// match; when loaded from persistent storage, this catches corruption or incomplete shutdown.
+#[instrument(target = COMPONENT, skip_all)]
+pub async fn verify_account_state_forest_consistency(
+    forest: &AccountStateForest<impl Backend>,
+    db: &mut Db,
+) -> Result<(), StateInitializationError> {
+    let mut cursor = None;
+
+    loop {
+        let page = db
+            .select_public_account_state_roots_paged(PUBLIC_ACCOUNT_IDS_PAGE_SIZE, cursor)
+            .await?;
+
+        if page.accounts.is_empty() {
+            break;
+        }
+
+        for account in page.accounts {
+            verify_account_state_forest_record(
+                forest,
+                account.account_id,
+                account.vault_root,
+                &account.storage_header,
+            )?;
+        }
+
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn verify_account_state_forest_record(
+    forest: &AccountStateForest<impl Backend>,
+    account_id: AccountId,
+    vault_root: Word,
+    storage_header: &AccountStorageHeader,
+) -> Result<(), StateInitializationError> {
+    let forest_vault_root = forest.get_latest_vault_root(account_id);
+    if forest_vault_root != vault_root {
+        return Err(StateInitializationError::AccountStateForestStorageDiverged {
+            account_id,
+            slot_name: None,
+            forest_root: forest_vault_root,
+            database_root: vault_root,
+        });
+    }
+
+    for slot in storage_header.slots() {
+        if slot.slot_type() != StorageSlotType::Map {
+            continue;
+        }
+
+        let forest_root = forest.get_latest_storage_map_root(account_id, slot.name());
+        let database_root = slot.value();
+        if forest_root != database_root {
+            return Err(StateInitializationError::AccountStateForestStorageDiverged {
+                account_id,
+                slot_name: Some(slot.name().to_string()),
+                forest_root,
+                database_root,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::account::{
+        AccountId,
+        AccountStorageHeader,
+        StorageSlotHeader,
+        StorageSlotName,
+        StorageSlotType,
+    };
+    use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
+
+    use super::*;
+
+    #[test]
+    fn account_state_forest_consistency_detects_storage_map_root_mismatch() {
+        let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE)
+            .expect("test account ID should be valid");
+        let slot_name =
+            StorageSlotName::new("account::balances").expect("slot name should be valid");
+        let expected_storage_root = Word::from([1, 0, 0, 0u32]);
+        let storage_header = AccountStorageHeader::new(vec![StorageSlotHeader::new(
+            slot_name.clone(),
+            StorageSlotType::Map,
+            expected_storage_root,
+        )])
+        .expect("storage header should be valid");
+        let forest = AccountStateForest::new();
+
+        let error = verify_account_state_forest_record(
+            &forest,
+            account_id,
+            AccountStateForest::empty_smt_root(),
+            &storage_header,
+        )
+        .expect_err("storage map root mismatch should be detected");
+
+        assert_matches::assert_matches!(
+            error,
+            StateInitializationError::AccountStateForestStorageDiverged {
+                account_id: actual_account_id,
+                slot_name: Some(actual_slot_name),
+                forest_root,
+                database_root,
+            } if actual_account_id == account_id
+                && actual_slot_name == slot_name.to_string()
+                && forest_root == AccountStateForest::empty_smt_root()
+                && database_root == expected_storage_root
+        );
+    }
+
+    #[test]
+    fn account_state_forest_consistency_detects_vault_root_mismatch() {
+        let account_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE)
+            .expect("test account ID should be valid");
+        let expected_vault_root = Word::from([2, 0, 0, 0u32]);
+        let storage_header =
+            AccountStorageHeader::new(Vec::new()).expect("storage header should be valid");
+        let forest = AccountStateForest::new();
+
+        let error = verify_account_state_forest_record(
+            &forest,
+            account_id,
+            expected_vault_root,
+            &storage_header,
+        )
+        .expect_err("vault root mismatch should be detected");
+
+        assert_matches::assert_matches!(
+            error,
+            StateInitializationError::AccountStateForestStorageDiverged {
+                account_id: actual_account_id,
+                slot_name: None,
+                forest_root,
+                database_root,
+            } if actual_account_id == account_id
+                && forest_root == AccountStateForest::empty_smt_root()
+                && database_root == expected_vault_root
+        );
+    }
 }

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -13,6 +13,9 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 
 use miden_crypto::merkle::mmr::Mmr;
+use miden_crypto::merkle::smt::{Backend, ForestInMemoryBackend};
+#[cfg(feature = "rocksdb")]
+use miden_crypto::merkle::smt::{ForestPersistentBackend, PersistentBackendConfig};
 #[cfg(feature = "rocksdb")]
 use miden_large_smt_backend_rocksdb::RocksDbStorage;
 use miden_node_utils::clap::RocksDbOptions;
@@ -41,6 +44,9 @@ pub const ACCOUNT_TREE_STORAGE_DIR: &str = "accounttree";
 
 /// Directory name for the nullifier tree storage within the data directory.
 pub const NULLIFIER_TREE_STORAGE_DIR: &str = "nullifiertree";
+
+/// Directory name for the account state forest storage within the data directory.
+pub const ACCOUNT_STATE_FOREST_STORAGE_DIR: &str = "accountstateforest";
 
 /// Page size for loading account commitments from the database during tree rebuilding.
 /// This limits memory usage when rebuilding trees with millions of accounts.
@@ -90,7 +96,7 @@ fn block_num_to_nullifier_leaf(block_num: BlockNumber) -> Word {
     Word::from([Felt::from(block_num), Felt::ZERO, Felt::ZERO, Felt::ZERO])
 }
 
-// STORAGE LOADER TRAIT
+// TREE STORAGE LOADER TRAIT
 // ================================================================================================
 
 /// Trait for loading trees from storage.
@@ -101,7 +107,7 @@ fn block_num_to_nullifier_leaf(block_num: BlockNumber) -> Word {
 /// Missing or corrupted storage is handled by the `verify_tree_consistency` check after loading,
 /// which detects divergence between persistent storage and the database. If divergence is detected,
 /// the user should manually delete the tree storage directories and restart the node.
-pub trait StorageLoader: SmtStorage + Sized {
+pub trait TreeStorageLoader: SmtStorage + Sized {
     /// A configuration type for the implementation.
     type Config: std::fmt::Debug + std::default::Default;
     /// Creates a storage backend for the given domain.
@@ -124,11 +130,38 @@ pub trait StorageLoader: SmtStorage + Sized {
     ) -> impl Future<Output = Result<NullifierTree<LargeSmt<Self>>, StateInitializationError>> + Send;
 }
 
+// ACCOUNT FOREST LOADER TRAIT
+// ================================================================================================
+
+/// Trait for loading account state forests from storage.
+///
+/// For `ForestInMemoryBackend`, the forest is rebuilt from database entries on each startup. For
+/// `ForestPersistentBackend`, the forest is loaded directly from disk if data exists, otherwise it
+/// is rebuilt from the database and persisted.
+pub trait AccountForestLoader: Backend + Sized {
+    /// A configuration type for the implementation.
+    type Config: std::fmt::Debug + std::default::Default;
+
+    /// Creates a forest backend for the given domain.
+    fn create(
+        data_dir: &Path,
+        storage_options: &Self::Config,
+        domain: &'static str,
+    ) -> Result<Self, StateInitializationError>;
+
+    /// Loads the account state forest, either from persistent storage or by rebuilding from DB.
+    fn load_account_state_forest(
+        self,
+        db: &mut Db,
+        block_num: BlockNumber,
+    ) -> impl Future<Output = Result<AccountStateForest<Self>, StateInitializationError>> + Send;
+}
+
 // MEMORY STORAGE IMPLEMENTATION
 // ================================================================================================
 
 #[cfg(not(feature = "rocksdb"))]
-impl StorageLoader for MemoryStorage {
+impl TreeStorageLoader for MemoryStorage {
     type Config = ();
     fn create(
         _data_dir: &Path,
@@ -221,7 +254,7 @@ impl StorageLoader for MemoryStorage {
 // ================================================================================================
 
 #[cfg(feature = "rocksdb")]
-impl StorageLoader for RocksDbStorage {
+impl TreeStorageLoader for RocksDbStorage {
     type Config = RocksDbOptions;
     fn create(
         data_dir: &Path,
@@ -335,6 +368,83 @@ impl StorageLoader for RocksDbStorage {
     }
 }
 
+// ACCOUNT FOREST BACKEND IMPLEMENTATIONS
+// ================================================================================================
+
+impl AccountForestLoader for ForestInMemoryBackend {
+    type Config = ();
+
+    fn create(
+        _data_dir: &Path,
+        _storage_options: &Self::Config,
+        _domain: &'static str,
+    ) -> Result<Self, StateInitializationError> {
+        Ok(ForestInMemoryBackend::new())
+    }
+
+    #[instrument(target = COMPONENT, skip_all, fields(block.number = %block_num))]
+    async fn load_account_state_forest(
+        self,
+        db: &mut Db,
+        block_num: BlockNumber,
+    ) -> Result<AccountStateForest<Self>, StateInitializationError> {
+        let mut forest = AccountStateForest::from_backend(self)
+            .map_err(|e| StateInitializationError::AccountStateForestIoError(e.to_string()))?;
+        rebuild_account_state_forest(&mut forest, db, block_num).await?;
+        Ok(forest)
+    }
+}
+
+#[cfg(feature = "rocksdb")]
+impl AccountForestLoader for ForestPersistentBackend {
+    type Config = RocksDbOptions;
+
+    fn create(
+        data_dir: &Path,
+        storage_options: &Self::Config,
+        domain: &'static str,
+    ) -> Result<Self, StateInitializationError> {
+        let storage_path = data_dir.join(domain);
+        fs_err::create_dir_all(&storage_path)
+            .map_err(|e| StateInitializationError::AccountStateForestIoError(e.to_string()))?;
+
+        let max_open_files = usize::try_from(storage_options.max_open_fds).map_err(|_| {
+            StateInitializationError::AccountStateForestIoError(format!(
+                "invalid account state forest RocksDB max_open_fds: {}",
+                storage_options.max_open_fds
+            ))
+        })?;
+        let config = PersistentBackendConfig::new(&storage_path)
+            .map_err(|e| StateInitializationError::AccountStateForestIoError(e.to_string()))?
+            .with_cache_size_bytes(storage_options.cache_size_in_bytes)
+            .with_max_open_files(max_open_files);
+
+        ForestPersistentBackend::load(config)
+            .map_err(|e| StateInitializationError::AccountStateForestIoError(e.to_string()))
+    }
+
+    #[instrument(target = COMPONENT, skip_all, fields(block.number = %block_num))]
+    async fn load_account_state_forest(
+        self,
+        db: &mut Db,
+        block_num: BlockNumber,
+    ) -> Result<AccountStateForest<Self>, StateInitializationError> {
+        let mut forest = AccountStateForest::from_backend(self)
+            .map_err(|e| StateInitializationError::AccountStateForestIoError(e.to_string()))?;
+
+        if forest.lineage_count() != 0 {
+            return Ok(forest);
+        }
+
+        info!(
+            target: COMPONENT,
+            "RocksDB account state forest storage is empty, populating from SQLite"
+        );
+        rebuild_account_state_forest(&mut forest, db, block_num).await?;
+        Ok(forest)
+    }
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 
@@ -361,15 +471,15 @@ pub async fn load_mmr(db: &mut Db) -> Result<Blockchain, StateInitializationErro
     Ok(chain_mmr)
 }
 
-/// Loads SMT forest with storage map and vault Merkle paths for all public accounts.
+/// Rebuilds SMT forest with storage map and vault Merkle paths for all public accounts.
 #[instrument(target = COMPONENT, skip_all, fields(block.number = %block_num))]
-pub async fn load_smt_forest(
+pub async fn rebuild_account_state_forest(
+    forest: &mut AccountStateForest<impl Backend>,
     db: &mut Db,
     block_num: BlockNumber,
-) -> Result<AccountStateForest, StateInitializationError> {
+) -> Result<(), StateInitializationError> {
     use miden_protocol::account::delta::AccountDelta;
 
-    let mut forest = AccountStateForest::new();
     let mut cursor = None;
 
     loop {
@@ -402,7 +512,7 @@ pub async fn load_smt_forest(
         }
     }
 
-    Ok(forest)
+    Ok(())
 }
 
 // CONSISTENCY VERIFICATION

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -37,7 +37,12 @@ use miden_protocol::transaction::PartialBlockchain;
 use tokio::sync::{Mutex, RwLock};
 use tracing::{Instrument, info, instrument};
 
-use crate::account_state_forest::{AccountStateForest, AccountStorageMapResult, WitnessError};
+use crate::account_state_forest::{
+    AccountStateForest,
+    AccountStateForestBackend,
+    AccountStorageMapResult,
+    WitnessError,
+};
 use crate::accounts::AccountTreeWithHistory;
 use crate::blocks::BlockStore;
 use crate::db::models::Page;
@@ -57,12 +62,13 @@ use crate::{COMPONENT, DataDirectory};
 mod loader;
 
 use loader::{
+    ACCOUNT_STATE_FOREST_STORAGE_DIR,
     ACCOUNT_TREE_STORAGE_DIR,
+    AccountForestLoader,
     NULLIFIER_TREE_STORAGE_DIR,
-    StorageLoader,
     TreeStorage,
+    TreeStorageLoader,
     load_mmr,
-    load_smt_forest,
     verify_tree_consistency,
 };
 
@@ -117,7 +123,7 @@ pub struct State {
     inner: RwLock<InnerState<TreeStorage>>,
 
     /// Forest-related state `(SmtForest, storage_map_roots, vault_roots)` with its own lock.
-    forest: RwLock<AccountStateForest>,
+    forest: RwLock<AccountStateForest<AccountStateForestBackend>>,
 
     /// To allow readers to access the tree data while an update in being performed, and prevent
     /// TOCTOU issues, there must be no concurrent writers. This locks to serialize the writers.
@@ -154,18 +160,23 @@ impl State {
         let blockchain = load_mmr(&mut db).await?;
         let latest_block_num = blockchain.chain_tip().unwrap_or(BlockNumber::GENESIS);
 
-        let account_storage = TreeStorage::create(
-            data_path,
-            &storage_options.account_tree.into(),
-            ACCOUNT_TREE_STORAGE_DIR,
-        )?;
+        #[cfg(feature = "rocksdb")]
+        let (account_storage_config, nullifier_storage_config, forest_storage_config) = (
+            storage_options.account_tree.into(),
+            storage_options.nullifier_tree.into(),
+            storage_options.account_state_forest.into(),
+        );
+        #[cfg(not(feature = "rocksdb"))]
+        let (account_storage_config, nullifier_storage_config, forest_storage_config) = {
+            let _ = &storage_options;
+            ((), (), ())
+        };
+        let account_storage =
+            TreeStorage::create(data_path, &account_storage_config, ACCOUNT_TREE_STORAGE_DIR)?;
         let account_tree = account_storage.load_account_tree(&mut db).await?;
 
-        let nullifier_storage = TreeStorage::create(
-            data_path,
-            &storage_options.nullifier_tree.into(),
-            NULLIFIER_TREE_STORAGE_DIR,
-        )?;
+        let nullifier_storage =
+            TreeStorage::create(data_path, &nullifier_storage_config, NULLIFIER_TREE_STORAGE_DIR)?;
         let nullifier_tree = nullifier_storage.load_nullifier_tree(&mut db).await?;
 
         // Verify that tree roots match the expected roots from the database.
@@ -175,7 +186,12 @@ impl State {
 
         let account_tree = AccountTreeWithHistory::new(account_tree, latest_block_num);
 
-        let forest = load_smt_forest(&mut db, latest_block_num).await?;
+        let forest_backend = AccountStateForestBackend::create(
+            data_path,
+            &forest_storage_config,
+            ACCOUNT_STATE_FOREST_STORAGE_DIR,
+        )?;
+        let forest = forest_backend.load_account_state_forest(&mut db, latest_block_num).await?;
 
         let inner = RwLock::new(InnerState { nullifier_tree, blockchain, account_tree });
 

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -69,6 +69,7 @@ use loader::{
     TreeStorage,
     TreeStorageLoader,
     load_mmr,
+    verify_account_state_forest_consistency,
     verify_tree_consistency,
 };
 
@@ -192,6 +193,7 @@ impl State {
             ACCOUNT_STATE_FOREST_STORAGE_DIR,
         )?;
         let forest = forest_backend.load_account_state_forest(&mut db, latest_block_num).await?;
+        verify_account_state_forest_consistency(&forest, &mut db).await?;
 
         let inner = RwLock::new(InnerState { nullifier_tree, blockchain, account_tree });
 

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -172,7 +172,6 @@ impl StorageOptions {
             let account_state_forest = AccountStateForestRocksDbOptions {
                 max_open_fds: BENCH_ROCKSDB_MAX_OPEN_FDS,
                 cache_size_in_bytes: DEFAULT_ROCKSDB_CACHE_SIZE,
-                durability_mode: None,
             };
             Self {
                 account_tree,

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -149,6 +149,9 @@ pub struct StorageOptions {
     #[cfg(feature = "rocksdb")]
     #[clap(flatten)]
     pub nullifier_tree: NullifierTreeRocksDbOptions,
+    #[cfg(feature = "rocksdb")]
+    #[clap(flatten)]
+    pub account_state_forest: AccountStateForestRocksDbOptions,
 }
 
 impl StorageOptions {
@@ -166,7 +169,16 @@ impl StorageOptions {
                 max_open_fds: BENCH_ROCKSDB_MAX_OPEN_FDS,
                 cache_size_in_bytes: DEFAULT_ROCKSDB_CACHE_SIZE,
             };
-            Self { account_tree, nullifier_tree }
+            let account_state_forest = AccountStateForestRocksDbOptions {
+                max_open_fds: BENCH_ROCKSDB_MAX_OPEN_FDS,
+                cache_size_in_bytes: DEFAULT_ROCKSDB_CACHE_SIZE,
+                durability_mode: None,
+            };
+            Self {
+                account_tree,
+                nullifier_tree,
+                account_state_forest,
+            }
         }
         #[cfg(not(feature = "rocksdb"))]
         Self::default()

--- a/crates/utils/src/clap/rocksdb.rs
+++ b/crates/utils/src/clap/rocksdb.rs
@@ -75,13 +75,6 @@ pub struct AccountStateForestRocksDbOptions {
         value_name = "ACCOUNT_STATE_FOREST__ROCKSDB__CACHE_SIZE"
     )]
     pub cache_size_in_bytes: usize,
-    #[arg(
-        id = "account_state_forest_rocksdb_durability_mode",
-        long = "account_state_forest.rocksdb.durability_mode",
-        value_enum,
-        value_name = "ACCOUNT_STATE_FOREST__ROCKSDB__DURABILITY_MODE"
-    )]
-    pub durability_mode: Option<CliRocksDbDurabilityMode>,
 }
 
 impl Default for AccountStateForestRocksDbOptions {
@@ -122,16 +115,8 @@ impl From<NullifierTreeRocksDbOptions> for RocksDbOptions {
 
 impl From<AccountStateForestRocksDbOptions> for RocksDbOptions {
     fn from(value: AccountStateForestRocksDbOptions) -> Self {
-        let AccountStateForestRocksDbOptions {
-            max_open_fds,
-            cache_size_in_bytes,
-            durability_mode,
-        } = value;
-        Self {
-            max_open_fds,
-            cache_size_in_bytes,
-            durability_mode,
-        }
+        let AccountStateForestRocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
+        Self { max_open_fds, cache_size_in_bytes }
     }
 }
 
@@ -151,16 +136,8 @@ impl From<RocksDbOptions> for NullifierTreeRocksDbOptions {
 
 impl From<RocksDbOptions> for AccountStateForestRocksDbOptions {
     fn from(value: RocksDbOptions) -> Self {
-        let RocksDbOptions {
-            max_open_fds,
-            cache_size_in_bytes,
-            durability_mode,
-        } = value;
-        Self {
-            max_open_fds,
-            cache_size_in_bytes,
-            durability_mode,
-        }
+        let RocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
+        Self { max_open_fds, cache_size_in_bytes }
     }
 }
 
@@ -181,13 +158,11 @@ mod tests {
         let options = AccountStateForestRocksDbOptions {
             max_open_fds: 123,
             cache_size_in_bytes: 456,
-            durability_mode: Some(CliRocksDbDurabilityMode::Sync),
         };
 
         let general = RocksDbOptions::from(options.clone());
         assert_eq!(general.max_open_fds, options.max_open_fds);
         assert_eq!(general.cache_size_in_bytes, options.cache_size_in_bytes);
-        assert_eq!(general.durability_mode, options.durability_mode);
 
         let roundtrip = AccountStateForestRocksDbOptions::from(general);
         assert_eq!(roundtrip, options);

--- a/crates/utils/src/clap/rocksdb.rs
+++ b/crates/utils/src/clap/rocksdb.rs
@@ -58,6 +58,38 @@ impl Default for AccountTreeRocksDbOptions {
     }
 }
 
+/// Per usage options for rocksdb configuration
+#[derive(clap::Args, Clone, Debug, PartialEq, Eq)]
+pub struct AccountStateForestRocksDbOptions {
+    #[arg(
+        id = "account_state_forest_rocksdb_max_open_fds",
+        long = "account_state_forest.rocksdb.max_open_fds",
+        default_value_t = DEFAULT_ROCKSDB_MAX_OPEN_FDS,
+        value_name = "ACCOUNT_STATE_FOREST__ROCKSDB__MAX_OPEN_FDS"
+    )]
+    pub max_open_fds: i32,
+    #[arg(
+        id = "account_state_forest_rocksdb_max_cache_size",
+        long = "account_state_forest.rocksdb.max_cache_size",
+        default_value_t = DEFAULT_ROCKSDB_CACHE_SIZE,
+        value_name = "ACCOUNT_STATE_FOREST__ROCKSDB__CACHE_SIZE"
+    )]
+    pub cache_size_in_bytes: usize,
+    #[arg(
+        id = "account_state_forest_rocksdb_durability_mode",
+        long = "account_state_forest.rocksdb.durability_mode",
+        value_enum,
+        value_name = "ACCOUNT_STATE_FOREST__ROCKSDB__DURABILITY_MODE"
+    )]
+    pub durability_mode: Option<CliRocksDbDurabilityMode>,
+}
+
+impl Default for AccountStateForestRocksDbOptions {
+    fn default() -> Self {
+        RocksDbOptions::default().into()
+    }
+}
+
 /// General confiration options for rocksdb.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RocksDbOptions {
@@ -88,6 +120,21 @@ impl From<NullifierTreeRocksDbOptions> for RocksDbOptions {
     }
 }
 
+impl From<AccountStateForestRocksDbOptions> for RocksDbOptions {
+    fn from(value: AccountStateForestRocksDbOptions) -> Self {
+        let AccountStateForestRocksDbOptions {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        } = value;
+        Self {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        }
+    }
+}
+
 impl From<RocksDbOptions> for AccountTreeRocksDbOptions {
     fn from(value: RocksDbOptions) -> Self {
         let RocksDbOptions { max_open_fds, cache_size_in_bytes } = value;
@@ -102,10 +149,47 @@ impl From<RocksDbOptions> for NullifierTreeRocksDbOptions {
     }
 }
 
+impl From<RocksDbOptions> for AccountStateForestRocksDbOptions {
+    fn from(value: RocksDbOptions) -> Self {
+        let RocksDbOptions {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        } = value;
+        Self {
+            max_open_fds,
+            cache_size_in_bytes,
+            durability_mode,
+        }
+    }
+}
+
 impl RocksDbOptions {
     pub fn with_path(self, path: &Path) -> RocksDbConfig {
         RocksDbConfig::new(path)
             .with_cache_size(self.cache_size_in_bytes)
             .with_max_open_files(self.max_open_fds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_state_forest_options_roundtrip_general_rocksdb_options() {
+        let options = AccountStateForestRocksDbOptions {
+            max_open_fds: 123,
+            cache_size_in_bytes: 456,
+            durability_mode: Some(CliRocksDbDurabilityMode::Sync),
+        };
+
+        let general = RocksDbOptions::from(options.clone());
+        assert_eq!(general.max_open_fds, options.max_open_fds);
+        assert_eq!(general.cache_size_in_bytes, options.cache_size_in_bytes);
+        assert_eq!(general.durability_mode, options.durability_mode);
+
+        let roundtrip = AccountStateForestRocksDbOptions::from(general);
+        assert_eq!(roundtrip, options);
     }
 }


### PR DESCRIPTION
As described in #1978 we're currently not using a persistent backend for the the AccountStateForest and rebuilding can take a long time (up to 9 minutes on our last testnet).

This PR  implements the RocksDB-based persistent storage backend for the account state forest while keeping the existing logic for reconstructing its state from SQLite.

Upon startup the account state forest is checked. If it's empty we start reconstructing the state from SQLite. For a non-empty account state forest we check if vault and storage map commitments in the forest match data in SQLite for all public accounts.

For reference: I've used the stress test tool to generate a database with 50k public accounts, each with 2 vault assets and 64 storage map entries (in a single slot). Initializing the in-memory account state forest takes about 5 minutes, while initializing the RocksDB backed forest about 10 minutes. Loading and verifying persistent state (once persistent storage has been initialized) takes about 1.3s.
