### PR TITLE
refactor(ntx-builder): use sync mutexes where possible

### DIFF
--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
@@ -48,7 +48,6 @@ use miden_tx::{
     TransactionMastStore,
     TransactionProverError,
 };
-use tokio::sync::Mutex;
 use tracing::{Instrument, instrument};
 
 use crate::COMPONENT;
@@ -213,7 +212,7 @@ impl NtxContext {
                 let executed_tx = Box::pin(self.execute(&data_store, successful_notes)).await?;
 
                 // Collect scripts fetched from the remote store during execution.
-                let scripts_to_cache = data_store.take_fetched_scripts().await;
+                let scripts_to_cache = data_store.take_fetched_scripts();
 
                 // Prove transaction.
                 let tx_inputs: TransactionInputs = executed_tx.into();
@@ -374,29 +373,9 @@ struct NtxDataStore {
     db: Db,
     /// Scripts fetched from the remote store during execution, to be persisted by the
     /// coordinator.
-    fetched_scripts: Arc<Mutex<Vec<(Word, NoteScript)>>>,
+    fetched_scripts: Arc<FetchedNoteScripts>,
     /// Mapping of storage map roots to storage slot names observed during various calls.
-    ///
-    /// The registered slot names are subsequently used to retrieve storage map witnesses from the
-    /// store. We need this because the store interface (and the underling SMT forest) use storage
-    /// slot names, but the `DataStore` interface works with tree roots. To get around this problem
-    /// we populate this map when:
-    /// - The the native account is loaded (in `get_transaction_inputs()`).
-    /// - When a foreign account is loaded (in `get_foreign_account_inputs`).
-    ///
-    /// The assumption here are:
-    /// - Once an account is loaded, the mapping between `(account_id, map_root)` and slot names do
-    ///   not change. This is always the case.
-    /// - New storage slots created during transaction execution will not be accesses in the same
-    ///   transaction. The mechanism for adding new storage slots is not implemented yet, but the
-    ///   plan for it is consistent with this assumption.
-    ///
-    /// One nuance worth mentioning: it is possible that there could be a root collision where an
-    /// account has two storage maps with the same root. In this case, the map will contain only a
-    /// single entry with the storage slot name that was added last. Thus, technically, requests
-    /// to the store could be "wrong", but given that two identical maps have identical witnesses
-    /// this does not cause issues in practice.
-    storage_slots: Arc<Mutex<BTreeMap<(AccountId, Word), StorageSlotName>>>,
+    storage_slots: Arc<StorageSlotRegistry>,
 }
 
 impl NtxDataStore {
@@ -420,30 +399,25 @@ impl NtxDataStore {
             store,
             script_cache,
             db,
-            fetched_scripts: Arc::new(Mutex::new(Vec::new())),
-            storage_slots: Arc::new(Mutex::new(BTreeMap::default())),
+            fetched_scripts: Arc::new(FetchedNoteScripts::new()),
+            storage_slots: Arc::new(StorageSlotRegistry::new()),
         }
     }
 
     /// Returns the list of note scripts fetched from the remote store during execution.
-    async fn take_fetched_scripts(&self) -> Vec<(Word, NoteScript)> {
-        self.fetched_scripts.lock().await.drain(..).collect()
+    fn take_fetched_scripts(&self) -> Vec<(Word, NoteScript)> {
+        self.fetched_scripts.take_all()
     }
 
     /// Registers storage map slot names for the given account ID and storage header.
     ///
     /// These slot names are subsequently used to query for storage map witnesses against the store.
-    async fn register_storage_map_slots(
+    fn register_storage_map_slots(
         &self,
         account_id: AccountId,
         storage_header: &AccountStorageHeader,
     ) {
-        let mut storage_slots = self.storage_slots.lock().await;
-        for slot_header in storage_header.slots() {
-            if let StorageSlotType::Map = slot_header.slot_type() {
-                storage_slots.insert((account_id, slot_header.value()), slot_header.name().clone());
-            }
-        }
+        self.storage_slots.register_slots(account_id, storage_header);
     }
 }
 
@@ -467,8 +441,7 @@ impl DataStore for NtxDataStore {
             }
 
             // Register slot names from the native account for later use.
-            self.register_storage_map_slots(account_id, &self.account.storage().to_header())
-                .await;
+            self.register_storage_map_slots(account_id, &self.account.storage().to_header());
 
             let partial_account = PartialAccount::from(&self.account);
             Ok((partial_account, self.reference_block.clone(), (*self.chain_mmr).clone()))
@@ -494,8 +467,7 @@ impl DataStore for NtxDataStore {
             self.mast_store.load_account_code(account_inputs.code());
 
             // Register slot names from the foreign account for later use.
-            self.register_storage_map_slots(foreign_account_id, account_inputs.storage().header())
-                .await;
+            self.register_storage_map_slots(foreign_account_id, account_inputs.storage().header());
 
             Ok(account_inputs)
         }
@@ -532,8 +504,7 @@ impl DataStore for NtxDataStore {
         async move {
             // The slot name that corresponds to the given account ID and map root must have been
             // registered during previous calls of this data store.
-            let storage_slots = self.storage_slots.lock().await;
-            let Some(slot_name) = storage_slots.get(&(account_id, map_root)) else {
+            let Some(slot_name) = self.storage_slots.get_slot_name(account_id, map_root) else {
                 return Err(DataStoreError::other(
                     "requested storage slot has not been registered",
                 ));
@@ -589,7 +560,7 @@ impl DataStore for NtxDataStore {
 
             if let Some(script) = maybe_script {
                 // Collect for later persistence by the coordinator.
-                self.fetched_scripts.lock().await.push((script_root, script.clone()));
+                self.fetched_scripts.add(script_root, script.clone());
                 self.script_cache.put(script_root, script.clone());
                 Ok(Some(script))
             } else {
@@ -605,5 +576,80 @@ impl MastForestStore for NtxDataStore {
         procedure_hash: &miden_protocol::Word,
     ) -> Option<std::sync::Arc<miden_protocol::MastForest>> {
         self.mast_store.get(procedure_hash)
+    }
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Scripts fetched from the remote store during execution, to be persisted by the
+/// coordinator.
+///
+/// The API guarantees that the mutex is never held across an await point.
+struct FetchedNoteScripts {
+    scripts: Mutex<Vec<(Word, NoteScript)>>,
+}
+
+impl FetchedNoteScripts {
+    fn new() -> Self {
+        Self { scripts: Mutex::new(Vec::new()) }
+    }
+
+    fn add(&self, script_root: Word, script: NoteScript) {
+        self.scripts
+            .lock()
+            .expect("Note scripts mutex is poisoned")
+            .push((script_root, script));
+    }
+
+    fn take_all(&self) -> Vec<(Word, NoteScript)> {
+        self.scripts.lock().expect("Note scripts mutex is poisoned").drain(..).collect()
+    }
+}
+
+/// Mapping of storage map roots to storage slot names observed during various calls.
+///
+/// The registered slot names are subsequently used to retrieve storage map witnesses from the
+/// store. We need this because the store interface (and the underling SMT forest) use storage
+/// slot names, but the `DataStore` interface works with tree roots. To get around this problem
+/// we populate this map when:
+/// - The the native account is loaded (in `get_transaction_inputs()`).
+/// - When a foreign account is loaded (in `get_foreign_account_inputs`).
+///
+/// The assumption here are:
+/// - Once an account is loaded, the mapping between `(account_id, map_root)` and slot names do not
+///   change. This is always the case.
+/// - New storage slots created during transaction execution will not be accesses in the same
+///   transaction. The mechanism for adding new storage slots is not implemented yet, but the plan
+///   for it is consistent with this assumption.
+///
+/// One nuance worth mentioning: it is possible that there could be a root collision where an
+/// account has two storage maps with the same root. In this case, the map will contain only a
+/// single entry with the storage slot name that was added last. Thus, technically, requests
+/// to the store could be "wrong", but given that two identical maps have identical witnesses
+/// this does not cause issues in practice.
+///
+/// The API guarantees that the mutex is never held across an await point.
+struct StorageSlotRegistry {
+    slots: Mutex<BTreeMap<(AccountId, Word), StorageSlotName>>,
+}
+
+impl StorageSlotRegistry {
+    fn new() -> Self {
+        Self { slots: Mutex::new(BTreeMap::default()) }
+    }
+
+    fn register_slots(&self, account_id: AccountId, storage_header: &AccountStorageHeader) {
+        let mut slots = self.slots.lock().expect("Storage slot registry mutex is poisoned");
+        for slot_header in storage_header.slots() {
+            if let StorageSlotType::Map = slot_header.slot_type() {
+                slots.insert((account_id, slot_header.value()), slot_header.name().clone());
+            }
+        }
+    }
+
+    fn get_slot_name(&self, account_id: AccountId, map_root: Word) -> Option<StorageSlotName> {
+        let slots = self.slots.lock().expect("Storage slot registry mutex is poisoned");
+        slots.get(&(account_id, map_root)).cloned()
     }
 }

--- a/crates/ntx-builder/src/actor/mod.rs
+++ b/crates/ntx-builder/src/actor/mod.rs
@@ -18,11 +18,11 @@ use miden_protocol::note::{NoteScript, Nullifier};
 use miden_protocol::transaction::TransactionId;
 use miden_remote_prover_client::RemoteTransactionProver;
 use miden_tx::FailedNote;
-use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
+use tokio::sync::{Notify, Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::NoteError;
-use crate::chain_state::ChainState;
+use crate::chain_state::{ChainState, SharedChainState};
 use crate::clients::{BlockProducerClient, StoreClient, ValidatorClient};
 use crate::db::Db;
 
@@ -61,7 +61,7 @@ pub struct AccountActorContext {
     pub prover: Option<RemoteTransactionProver>,
     /// The latest chain state that account all actors can rely on. A single chain state is shared
     /// among all actors.
-    pub chain_state: Arc<RwLock<ChainState>>,
+    pub chain_state: Arc<SharedChainState>,
     /// Shared LRU cache for storing retrieved note scripts to avoid repeated store calls.
     /// This cache is shared across all account actors to maximize cache efficiency.
     pub script_cache: LruCache<Word, NoteScript>,
@@ -87,17 +87,16 @@ impl AccountActorContext {
     /// but this is sufficient for testing coordinator logic (registry, deactivation, etc.).
     pub fn test(db: &crate::db::Db) -> Self {
         use miden_protocol::crypto::merkle::mmr::{Forest, MmrPeaks, PartialMmr};
-        use tokio::sync::RwLock;
         use url::Url;
 
-        use crate::chain_state::ChainState;
+        use crate::chain_state::SharedChainState;
         use crate::clients::StoreClient;
         use crate::test_utils::mock_block_header;
 
         let url = Url::parse("http://127.0.0.1:1").unwrap();
         let block_header = mock_block_header(0_u32.into());
         let chain_mmr = PartialMmr::from_peaks(MmrPeaks::new(Forest::new(0), vec![]).unwrap());
-        let chain_state = Arc::new(RwLock::new(ChainState::new(block_header, chain_mmr)));
+        let chain_state = Arc::new(SharedChainState::new(block_header, chain_mmr));
         let (request_tx, _request_rx) = mpsc::channel(1);
 
         Self {
@@ -210,7 +209,7 @@ pub struct AccountActor {
     block_producer: BlockProducerClient,
     validator: ValidatorClient,
     prover: Option<RemoteTransactionProver>,
-    chain_state: Arc<RwLock<ChainState>>,
+    chain_state: Arc<SharedChainState>,
     script_cache: LruCache<Word, NoteScript>,
     /// Maximum number of notes per transaction.
     max_notes_per_tx: NonZeroUsize,
@@ -262,7 +261,7 @@ impl AccountActor {
         let account_id = self.origin.id();
 
         // Determine initial mode by checking DB for available notes.
-        let block_num = self.chain_state.read().await.chain_tip_header.block_num();
+        let block_num = self.chain_state.chain_tip_block_number();
         let has_notes = self
             .db
             .has_available_notes(account_id, block_num, self.max_note_attempts)
@@ -319,7 +318,7 @@ impl AccountActor {
                     let _permit = permit.context("semaphore closed")?;
 
                     // Read the chain state.
-                    let chain_state = self.chain_state.read().await.clone();
+                    let chain_state = self.chain_state.get_cloned();
 
                     // Query DB for latest account and available notes.
                     let tx_candidate = self.select_candidate_from_db(

--- a/crates/ntx-builder/src/builder.rs
+++ b/crates/ntx-builder/src/builder.rs
@@ -6,16 +6,15 @@ use futures::Stream;
 use miden_node_proto::domain::account::NetworkAccountId;
 use miden_node_proto::domain::mempool::MempoolEvent;
 use miden_protocol::account::delta::AccountUpdateDetails;
-use miden_protocol::block::BlockHeader;
 use tokio::net::TcpListener;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tonic::Status;
 
 use crate::NtxBuilderConfig;
 use crate::actor::{AccountActorContext, AccountOrigin, ActorRequest};
-use crate::chain_state::ChainState;
+use crate::chain_state::SharedChainState;
 use crate::clients::StoreClient;
 use crate::coordinator::Coordinator;
 use crate::db::Db;
@@ -51,7 +50,7 @@ pub struct NetworkTransactionBuilder {
     /// Database for persistent state.
     db: Db,
     /// Shared chain state updated by the event loop and read by actors.
-    chain_state: Arc<RwLock<ChainState>>,
+    chain_state: Arc<SharedChainState>,
     /// Context shared with all account actors.
     actor_context: AccountActorContext,
     /// Stream of mempool events from the block producer.
@@ -70,7 +69,7 @@ impl NetworkTransactionBuilder {
         coordinator: Coordinator,
         store: StoreClient,
         db: Db,
-        chain_state: Arc<RwLock<ChainState>>,
+        chain_state: Arc<SharedChainState>,
         actor_context: AccountActorContext,
         mempool_events: MempoolEventStream,
         actor_request_rx: mpsc::Receiver<ActorRequest>,
@@ -197,7 +196,7 @@ impl NetworkTransactionBuilder {
             .context("failed to load account from store")?
             .context("account should exist in store")?;
 
-        let block_num = self.chain_state.read().await.chain_tip_header.block_num();
+        let block_num = self.chain_state.chain_tip_block_number();
         let notes = self
             .store
             .get_unconsumed_network_notes(account_id, block_num.as_u32())
@@ -253,7 +252,8 @@ impl NetworkTransactionBuilder {
                     .await
                     .context("failed to write BlockCommitted to DB")?;
 
-                self.update_chain_tip(header.as_ref().clone()).await;
+                self.chain_state
+                    .update_chain_tip(header.as_ref().clone(), self.config.max_block_count);
                 self.coordinator.notify_accounts(&result.accounts_to_notify);
                 Ok(())
             },
@@ -291,38 +291,5 @@ impl NetworkTransactionBuilder {
             },
         }
         Ok(())
-    }
-
-    /// Updates the chain tip and prunes old blocks from the MMR.
-    async fn update_chain_tip(&mut self, tip: BlockHeader) {
-        let mut chain_state = self.chain_state.write().await;
-
-        // Skip blocks already reflected in the chain state. A `BlockCommitted` event may arrive
-        // for a block whose state was already loaded from the store during startup: the mempool
-        // subscription is established first and then the chain tip is fetched, so any block
-        // committed in that window produces an event for state we have already ingested.
-        if tip.block_num() <= chain_state.chain_tip_header.block_num() {
-            tracing::debug!(
-                event_block = %tip.block_num(),
-                current_tip = %chain_state.chain_tip_header.block_num(),
-                "skipping BlockCommitted event for block already in chain state",
-            );
-            return;
-        }
-
-        // Update MMR which lags by one block.
-        let mmr_tip = chain_state.chain_tip_header.clone();
-        Arc::make_mut(&mut chain_state.chain_mmr).add_block(&mmr_tip, true);
-
-        // Set the new tip.
-        chain_state.chain_tip_header = tip;
-
-        // Keep MMR pruned.
-        let pruned_block_height = (chain_state
-            .chain_mmr
-            .chain_length()
-            .as_usize()
-            .saturating_sub(self.config.max_block_count)) as u32;
-        Arc::make_mut(&mut chain_state.chain_mmr).prune_to(..pruned_block_height.into());
     }
 }

--- a/crates/ntx-builder/src/chain_state.rs
+++ b/crates/ntx-builder/src/chain_state.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
-use miden_protocol::block::BlockHeader;
+use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::crypto::merkle::mmr::PartialMmr;
 use miden_protocol::transaction::PartialBlockchain;
 
@@ -45,5 +45,59 @@ impl ChainState {
     /// tuple.
     pub fn into_parts(self) -> (BlockHeader, Arc<PartialBlockchain>) {
         (self.chain_tip_header, self.chain_mmr)
+    }
+
+    /// Updates the chain tip and prunes old blocks from the MMR.
+    fn update_chain_tip(&mut self, tip: BlockHeader, max_block_count: usize) {
+        // Skip blocks already reflected in the chain state. A `BlockCommitted` event may arrive
+        // for a block whose state was already loaded from the store during startup: the mempool
+        // subscription is established first and then the chain tip is fetched, so any block
+        // committed in that window produces an event for state we have already ingested.
+        if tip.block_num() <= self.chain_tip_header.block_num() {
+            tracing::debug!(
+                event_block = %tip.block_num(),
+                current_tip = %self.chain_tip_header.block_num(),
+                "skipping BlockCommitted event for block already in chain state",
+            );
+            return;
+        }
+
+        // Update MMR which lags by one block.
+        let mmr_tip = self.chain_tip_header.clone();
+        Arc::make_mut(&mut self.chain_mmr).add_block(&mmr_tip, true);
+
+        // Set the new tip.
+        self.chain_tip_header = tip;
+
+        // Keep MMR pruned.
+        let pruned_block_height =
+            (self.chain_mmr.chain_length().as_usize().saturating_sub(max_block_count)) as u32;
+        Arc::make_mut(&mut self.chain_mmr).prune_to(..pruned_block_height.into());
+    }
+}
+
+/// A thread-safe wrapper around [`ChainState`] that can be shared across multiple actors.
+///
+/// The API guarantees that the lock cannot be held across await points.
+pub struct SharedChainState(RwLock<ChainState>);
+
+impl SharedChainState {
+    pub fn new(chain_tip_header: BlockHeader, chain_mmr: PartialMmr) -> Self {
+        Self(RwLock::new(ChainState::new(chain_tip_header, chain_mmr)))
+    }
+
+    pub(crate) fn chain_tip_block_number(&self) -> BlockNumber {
+        self.0.read().expect("chain state lock poisoned").chain_tip_header.block_num()
+    }
+
+    pub(crate) fn update_chain_tip(&self, tip: BlockHeader, max_block_count: usize) {
+        self.0
+            .write()
+            .expect("chain state lock poisoned")
+            .update_chain_tip(tip, max_block_count);
+    }
+
+    pub(crate) fn get_cloned(&self) -> ChainState {
+        self.0.read().expect("chain state lock poisoned").clone()
     }
 }

--- a/crates/ntx-builder/src/lib.rs
+++ b/crates/ntx-builder/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use actor::AccountActorContext;
 use anyhow::Context;
 use builder::MempoolEventStream;
-use chain_state::ChainState;
+use chain_state::SharedChainState;
 use clients::{BlockProducerClient, StoreClient, ValidatorClient};
 use coordinator::Coordinator;
 use db::Db;
@@ -14,7 +14,7 @@ use futures::TryStreamExt;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
 use miden_remote_prover_client::RemoteTransactionProver;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::mpsc;
 use url::Url;
 
 pub(crate) type NoteError = Arc<dyn ErrorReport + Send + Sync>;
@@ -290,7 +290,7 @@ impl NtxBuilderConfig {
             .await
             .context("failed to upsert chain state")?;
 
-        let chain_state = Arc::new(RwLock::new(ChainState::new(chain_tip_header, chain_mmr)));
+        let chain_state = Arc::new(SharedChainState::new(chain_tip_header, chain_mmr));
 
         let (request_tx, actor_request_rx) = mpsc::channel(1);
 
@@ -298,7 +298,7 @@ impl NtxBuilderConfig {
             block_producer: block_producer.clone(),
             validator,
             prover,
-            chain_state: chain_state.clone(),
+            chain_state: Arc::clone(&chain_state),
             store: store.clone(),
             script_cache,
             max_notes_per_tx: self.max_notes_per_tx,


### PR DESCRIPTION
The new APIs explicitly guarantee that the locks cannot be held across await points, so we can simplify the implementation by removing the async mutex/rwlock and using a standard mutex/rwlock instead.

See the [Tokio documentation](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use) for a more detailed reasoning why a sync primitives should be used.