### PR TITLE
ci: cache each job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Continuous integration jobs.
 #
-# These get run on every pull-request, with github cache updated on push into `next`.
+# These get run on every pull-request, with Warp caches updated on push into `main` or `next`.
 name: CI
 
 permissions:
@@ -23,10 +23,12 @@ on:
       - "docs/**"
 
 env:
-  # Shared prefix key for the rust cache.
+  # Shared prefix key for the Rust caches.
   #
-  # This provides a convenient way to evict old or corrupted cache.
-  RUST_CACHE_KEY: rust-cache-2026.02.02
+  # Cache is trunk specific (next|main).
+  CACHE_PREFIX: rust-cache-${{ github.base_ref || github.ref_name }}
+  # Only trusted branch pushes should update caches; PRs restore from the target branch cache.
+  SAVE_CACHE: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next') }}
   # Reduce cache usage by removing debug information.
   CARGO_PROFILE_DEV_DEBUG: 0
 
@@ -37,10 +39,10 @@ concurrency:
 
 jobs:
   # ===============================================================================================
-  # Conventional builds, lints and tests that re-use a single cache for efficiency
+  # Conventional builds, lints and tests
   # ===============================================================================================
 
-  # Normal cargo build that populates a cache for all subsequent jobs to re-use.
+  # Normal cargo build that verifies the workspace compiles.
   build:
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
@@ -53,9 +55,9 @@ jobs:
         run: rustup update --no-self-update
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
-          shared-key: ${{ github.workflow }}-build
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: ${{ github.ref == 'refs/heads/next' }}
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - name: cargo build
         run: cargo build --workspace --all-targets --locked
       - name: Check static linkage
@@ -99,7 +101,6 @@ jobs:
   clippy:
     name: lint - clippy
     runs-on: warp-ubuntu-latest-x64-8x
-    needs: [build]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -108,15 +109,14 @@ jobs:
         run: rustup update --no-self-update
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
-          shared-key: ${{ github.workflow }}-build
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - name: clippy
         run: cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
 
   tests:
     runs-on: warp-ubuntu-latest-x64-8x
-    needs: [build]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -129,9 +129,9 @@ jobs:
           tool: nextest@0.9.122
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
-          shared-key: ${{ github.workflow }}-build
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - name: Build tests
         run: cargo nextest run --all-features --workspace --no-run
       - name: Run tests
@@ -140,7 +140,6 @@ jobs:
         run: cargo test --doc --workspace --all-features
 
   doc:
-    needs: [build]
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -150,16 +149,15 @@ jobs:
         run: rustup update --no-self-update
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
-          shared-key: ${{ github.workflow }}-build
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - name: Build docs
         run: cargo doc --no-deps --workspace --all-features --locked
 
   # Ensure the stress-test still functions by running some cheap benchmarks.
   stress-test:
     name: stress test
-    needs: [build]
     runs-on: warp-ubuntu-latest-x64-8x
     timeout-minutes: 20
     env:
@@ -172,9 +170,9 @@ jobs:
         run: rustup update --no-self-update
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
-          shared-key: ${{ github.workflow }}-build
-          prefix-key: ${{ env.RUST_CACHE_KEY }}
-          save-if: false
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: nextest@0.9.122
@@ -210,8 +208,7 @@ jobs:
 
   # Tests the miden-remote-prover-client WASM support.
   #
-  # The WASM build is incompatible with the build job's cache, thankfully this compilation is fairly
-  # quick so we don't need a separate cache here.
+  # The WASM build is incompatible with native build caches, so it uses a dedicated cache.
   client-wasm:
     name: wasm targets
     runs-on: warp-ubuntu-latest-x64-8x
@@ -221,6 +218,11 @@ jobs:
           persist-credentials: false
       - name: Rustup
         run: rustup update --no-self-update
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - name: cargo build
         run: |
           cargo build --locked -p miden-remote-prover-client \


### PR DESCRIPTION
With #2013 we now use `warp` for the heavy builds, so we can cache more aggressively.

We now have separate main and next caches for each job.