### PR TITLE
store: remove sqlite table size analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## v0.14.11 (TBD)
 
 - Implement persistent RocksDB backend for `AccountStateForest`, improving startup time ([#2020](https://github.com/0xMiden/node/pull/2020)).
+## v0.15.0 (TBD)
+
+- Removed the `analyze_table_sizes` background task from the store (it held read locks long enough to block concurrent writers for 30s+) and replaced it with a lightweight filesystem-based disk usage monitor that reports sizes via OTel span attributes every 5 minutes ([#2028](https://github.com/0xMiden/node/pull/2028)).
+- Added composite index `idx_transactions_account_block_txid` on `transactions(account_id, block_num, transaction_id)` to speed up `select_transactions_records` queries used by `SyncTransactions` ([#1965](https://github.com/0xMiden/node/issues/1965)).
+- [BREAKING] Changed `GetBlockByNumber` to accept a `BlockRequest` (with optional `include_proof` flag) and returns a response containing the block and an optional block proof ([#1864](https://github.com/0xMiden/node/pull/1864)).
+- Network monitor now auto-regenerates accounts after persistent increment failures instead of staying unhealthy indefinitely ([#1942](https://github.com/0xMiden/node/pull/1942)).
+- [BREAKING] Renamed `GetNoteError` endpoint to `GetNetworkNoteStatus` and extended it to return the full lifecycle status of a network note (`Pending`, `Processed`, `Discarded`, `Committed`) instead of only error information. Consumed notes are now retained in the database after block commit instead of being deleted ([#1892](https://github.com/0xMiden/node/pull/1892)).
+- Extended `ValidatorStatus` proto response with `chain_tip`, `validated_transactions_count`, and `signed_blocks_count`; added Validator card to the network monitor dashboard ([#1900](https://github.com/0xMiden/node/pull/1900)).
+- Updated the RocksDB SMT backend to use budgeted deserialization for bytes read from disk, ported from `0xMiden/crypto` PR [#846](https://github.com/0xMiden/crypto/pull/846) ([#1923](https://github.com/0xMiden/node/pull/1923)).
+- [BREAKING] Network monitor `/status` endpoint now emits a single `RemoteProverStatus` entry per remote prover that bundles status, workers, and test results, instead of separate entries ([#1980](https://github.com/0xMiden/node/pull/1980)).
+- Refactored the validator gRPC API implementation to use the new per-method trait implementations ([#1959](https://github.com/0xMiden/node/pull/1959)).
+- Aligned `SyncNullifiers` list-limit validation in RPC and store with `nullifier_prefix` parameter semantics, extended `GetLimits` test coverage, and documented query parameter limits ([#1986](https://github.com/0xMiden/node/pull/1986)).
 
 ## v0.14.10 (2026-05-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,6 @@
 ## v0.14.11 (TBD)
 
 - Implement persistent RocksDB backend for `AccountStateForest`, improving startup time ([#2020](https://github.com/0xMiden/node/pull/2020)).
-## v0.15.0 (TBD)
-
-- Removed the `analyze_table_sizes` background task from the store (it held read locks long enough to block concurrent writers for 30s+) and replaced it with a lightweight filesystem-based disk usage monitor that reports sizes via OTel span attributes every 5 minutes ([#2028](https://github.com/0xMiden/node/pull/2028)).
-- Added composite index `idx_transactions_account_block_txid` on `transactions(account_id, block_num, transaction_id)` to speed up `select_transactions_records` queries used by `SyncTransactions` ([#1965](https://github.com/0xMiden/node/issues/1965)).
-- [BREAKING] Changed `GetBlockByNumber` to accept a `BlockRequest` (with optional `include_proof` flag) and returns a response containing the block and an optional block proof ([#1864](https://github.com/0xMiden/node/pull/1864)).
-- Network monitor now auto-regenerates accounts after persistent increment failures instead of staying unhealthy indefinitely ([#1942](https://github.com/0xMiden/node/pull/1942)).
-- [BREAKING] Renamed `GetNoteError` endpoint to `GetNetworkNoteStatus` and extended it to return the full lifecycle status of a network note (`Pending`, `Processed`, `Discarded`, `Committed`) instead of only error information. Consumed notes are now retained in the database after block commit instead of being deleted ([#1892](https://github.com/0xMiden/node/pull/1892)).
-- Extended `ValidatorStatus` proto response with `chain_tip`, `validated_transactions_count`, and `signed_blocks_count`; added Validator card to the network monitor dashboard ([#1900](https://github.com/0xMiden/node/pull/1900)).
-- Updated the RocksDB SMT backend to use budgeted deserialization for bytes read from disk, ported from `0xMiden/crypto` PR [#846](https://github.com/0xMiden/crypto/pull/846) ([#1923](https://github.com/0xMiden/node/pull/1923)).
-- [BREAKING] Network monitor `/status` endpoint now emits a single `RemoteProverStatus` entry per remote prover that bundles status, workers, and test results, instead of separate entries ([#1980](https://github.com/0xMiden/node/pull/1980)).
-- Refactored the validator gRPC API implementation to use the new per-method trait implementations ([#1959](https://github.com/0xMiden/node/pull/1959)).
-- Aligned `SyncNullifiers` list-limit validation in RPC and store with `nullifier_prefix` parameter semantics, extended `GetLimits` test coverage, and documented query parameter limits ([#1986](https://github.com/0xMiden/node/pull/1986)).
 
 ## v0.14.10 (2026-05-29)
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context;
-use diesel::{Connection, QueryableByName, RunQueryDsl, SqliteConnection};
+use diesel::{Connection, RunQueryDsl, SqliteConnection};
 use miden_node_proto::domain::account::AccountInfo;
 use miden_node_proto::{BlockProofRequest, generated as proto};
 use miden_node_utils::limiter::MAX_RESPONSE_PAYLOAD_BYTES;
@@ -745,47 +745,6 @@ impl Db {
             slot_name,
             entries: StorageMapEntries::AllEntries(entries),
         })
-    }
-
-    /// Emits size metrics for each table in the database, and the entire database.
-    #[instrument(target = COMPONENT, skip_all, err)]
-    pub async fn analyze_table_sizes(&self) -> Result<(), DatabaseError> {
-        self.transact("db analysis", |conn| {
-            #[derive(QueryableByName)]
-            struct TotalSize {
-                #[diesel(sql_type = diesel::sql_types::BigInt)]
-                size: i64,
-            }
-
-            #[derive(QueryableByName)]
-            struct Table {
-                #[diesel(sql_type = diesel::sql_types::Text)]
-                name: String,
-                #[diesel(sql_type = diesel::sql_types::BigInt)]
-                size: i64,
-            }
-
-            let tables =
-                diesel::sql_query("SELECT name, sum(payload) AS size FROM dbstat GROUP BY name")
-                    .load::<Table>(conn)?;
-
-            let span = tracing::Span::current();
-            for Table { name, size } in tables {
-                span.set_attribute(format!("database.table.{name}.size"), size);
-            }
-
-            let total = diesel::sql_query(
-                "SELECT page_count * page_size as size FROM pragma_page_count(), pragma_page_size()",
-            )
-            .get_result::<TotalSize>(conn)?;
-            span.set_attribute("database.total.size", total.size);
-
-            Result::<_, DatabaseError>::Ok(())
-        })
-        .await
-        .inspect_err(|err| tracing::Span::current().set_error(err))?;
-
-        Ok(())
     }
 
     /// Loads the network notes for an account that are unconsumed by a specified block number.

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -5,11 +5,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context;
-use diesel::{Connection, RunQueryDsl, SqliteConnection};
+use diesel::{Connection, SqliteConnection};
 use miden_node_proto::domain::account::AccountInfo;
 use miden_node_proto::{BlockProofRequest, generated as proto};
 use miden_node_utils::limiter::MAX_RESPONSE_PAYLOAD_BYTES;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::Word;
 use miden_protocol::account::{AccountHeader, AccountId, AccountStorageHeader, StorageMapKey};
 use miden_protocol::asset::{Asset, AssetVaultKey};

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -13,12 +13,13 @@ use miden_node_proto_build::{
 };
 use miden_node_utils::clap::{GrpcOptionsInternal, StorageOptions};
 use miden_node_utils::panic::{CatchPanicLayer, catch_panic_layer_fn};
+use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
 use tokio::net::TcpListener;
 use tokio::task::JoinSet;
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::trace::TraceLayer;
-use tracing::{info, instrument};
+use tracing::{Instrument, info, info_span, instrument};
 use url::Url;
 
 use crate::blocks::BlockStore;
@@ -88,6 +89,7 @@ impl Store {
         let rpc_address = self.rpc_listener.local_addr()?;
         let ntx_builder_address = self.ntx_builder_listener.local_addr()?;
         let block_producer_address = self.block_producer_listener.local_addr()?;
+        let data_directory = self.data_directory.clone();
         info!(target: COMPONENT, rpc_endpoint=?rpc_address, ntx_builder_endpoint=?ntx_builder_address,
             block_producer_endpoint=?block_producer_address, ?self.data_directory, ?self.grpc_options.request_timeout,
             "Loading database");
@@ -143,22 +145,10 @@ impl Store {
 
         info!(target: COMPONENT, "Database loaded");
 
+        // Spawn disk monitor (fire-and-forget; never causes server shutdown).
+        let _disk_monitor_task = Self::spawn_disk_monitor(data_directory);
+
         let mut join_set = JoinSet::new();
-
-        join_set.spawn(async move {
-            // Manual tests on testnet indicate each iteration takes ~2s once things are OS cached.
-            //
-            // 5 minutes seems like a reasonable interval, where this should have minimal database
-            // IO impact while providing a decent view into table growth over time.
-            let mut interval = tokio::time::interval(Duration::from_secs(5 * 60));
-            let database = Arc::clone(&state);
-            loop {
-                interval.tick().await;
-                let _ = database.analyze_table_sizes().await;
-            }
-        });
-
-        // Build the gRPC server with the API services and trace layer.
         join_set.spawn(
             tonic::transport::Server::builder()
                 .timeout(self.grpc_options.request_timeout)
@@ -206,6 +196,38 @@ impl Store {
             }
         }
     }
+
+    /// Spawns a background task that periodically records the on-disk size of every store data
+    /// path as OTel span attributes.
+    ///
+    /// Sizes are measured with [`std::fs::metadata`] (no SQL connections, no lock contention).
+    /// Errors are logged as warnings and never cause the server to stop.
+    fn spawn_disk_monitor(data_directory: PathBuf) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_mins(5));
+            loop {
+                interval.tick().await;
+                let dir = data_directory.clone();
+                let span = info_span!(target: COMPONENT, "measure disk space usage");
+                let result = tokio::task::spawn_blocking(move || measure_disk_usage_bytes(&dir))
+                    .instrument(span.clone())
+                    .await;
+                match result {
+                    Ok(usage) => {
+                        span.set_attribute("db.sqlite.size", usage.sqlite_db);
+                        span.set_attribute("db.sqlite.wal.size", usage.sqlite_wal);
+                        span.set_attribute("db.block_store.size", usage.block_store);
+                        #[cfg(feature = "rocksdb")]
+                        {
+                            span.set_attribute("db.account_tree.size", usage.account_tree);
+                            span.set_attribute("db.nullifier_tree.size", usage.nullifier_tree);
+                        }
+                    },
+                    Err(err) => span.set_error(&err),
+                }
+            }
+        })
+    }
 }
 
 /// Represents the store's data-directory and its content paths.
@@ -237,4 +259,60 @@ impl DataDirectory {
     pub fn display(&self) -> std::path::Display<'_> {
         self.0.display()
     }
+}
+
+// DISK USAGE HELPERS
+// ================================================================================================
+
+/// Byte counts for each on-disk storage component.
+struct DiskUsage {
+    sqlite_db: u64,
+    sqlite_wal: u64,
+    block_store: u64,
+    #[cfg(feature = "rocksdb")]
+    account_tree: u64,
+    #[cfg(feature = "rocksdb")]
+    nullifier_tree: u64,
+}
+
+/// Collects on-disk byte sizes for every store data path under `data_dir`.
+///
+/// Uses only [`std::fs::metadata`] and [`std::fs::read_dir`] — no SQLite connections are opened,
+/// so there is no read-lock contention with concurrent database writers.
+fn measure_disk_usage_bytes(data_dir: &Path) -> DiskUsage {
+    DiskUsage {
+        sqlite_db: path_size_bytes(&data_dir.join("miden-store.sqlite3")),
+        sqlite_wal: path_size_bytes(&data_dir.join("miden-store.sqlite3-wal")),
+        block_store: dir_size_bytes(&data_dir.join("blocks")),
+        #[cfg(feature = "rocksdb")]
+        account_tree: dir_size_bytes(&data_dir.join("accounttree")),
+        #[cfg(feature = "rocksdb")]
+        nullifier_tree: dir_size_bytes(&data_dir.join("nullifiertree")),
+    }
+}
+
+/// Returns the byte length of the file at `path`, or `0` if it does not exist.
+fn path_size_bytes(path: &Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Returns the total byte length of all files in `path` iteratively, or `0` on any error.
+fn dir_size_bytes(path: &Path) -> u64 {
+    let mut to_process = vec![path.to_path_buf()];
+    let mut total = 0u64;
+    while let Some(dir) = to_process.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if let Ok(meta) = entry.metadata() {
+                if meta.is_dir() {
+                    to_process.push(entry.path());
+                } else {
+                    total += meta.len();
+                }
+            }
+        }
+    }
+    total
 }

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -200,7 +200,7 @@ impl Store {
     /// Spawns a background task that periodically records the on-disk size of every store data
     /// path as OTel span attributes.
     ///
-    /// Sizes are measured with [`std::fs::metadata`] (no SQL connections, no lock contention).
+    /// Sizes are measured with [`fs_err::metadata`] (no SQL connections, no lock contention).
     /// Errors are logged as warnings and never cause the server to stop.
     fn spawn_disk_monitor(data_directory: PathBuf) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
@@ -277,7 +277,7 @@ struct DiskUsage {
 
 /// Collects on-disk byte sizes for every store data path under `data_dir`.
 ///
-/// Uses only [`std::fs::metadata`] and [`std::fs::read_dir`] — no SQLite connections are opened,
+/// Uses only [`fs_err::metadata`] and [`fs_err::read_dir`] — no SQLite connections are opened,
 /// so there is no read-lock contention with concurrent database writers.
 fn measure_disk_usage_bytes(data_dir: &Path) -> DiskUsage {
     DiskUsage {
@@ -293,7 +293,7 @@ fn measure_disk_usage_bytes(data_dir: &Path) -> DiskUsage {
 
 /// Returns the byte length of the file at `path`, or `0` if it does not exist.
 fn path_size_bytes(path: &Path) -> u64 {
-    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+    fs_err::metadata(path).map(|m| m.len()).unwrap_or(0)
 }
 
 /// Returns the total byte length of all files in `path` iteratively, or `0` on any error.
@@ -301,7 +301,7 @@ fn dir_size_bytes(path: &Path) -> u64 {
     let mut to_process = vec![path.to_path_buf()];
     let mut total = 0u64;
     while let Some(dir) = to_process.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
+        let Ok(entries) = fs_err::read_dir(&dir) else {
             continue;
         };
         for entry in entries.flatten() {

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -198,7 +198,7 @@ impl Store {
     }
 
     /// Spawns a background task that periodically records the on-disk size of every store data
-    /// path as OTel span attributes.
+    /// path as `OTel` span attributes.
     ///
     /// Sizes are measured with [`fs_err::metadata`] (no SQL connections, no lock contention).
     /// Errors are logged as warnings and never cause the server to stop.

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -937,11 +937,6 @@ impl State {
         self.inner.read().await.latest_block_num()
     }
 
-    /// Emits metrics for each database table's size.
-    pub async fn analyze_table_sizes(&self) -> Result<(), DatabaseError> {
-        self.db.analyze_table_sizes().await
-    }
-
     /// Returns the network notes for an account that are unconsumed by a specified block number,
     /// along with the next pagination token.
     pub async fn get_unconsumed_network_notes_for_account(

--- a/crates/utils/src/tracing/span_ext.rs
+++ b/crates/utils/src/tracing/span_ext.rs
@@ -65,6 +65,12 @@ impl ToValue for usize {
     }
 }
 
+impl ToValue for u64 {
+    fn to_value(&self) -> Value {
+        i64::try_from(*self).unwrap_or(i64::MAX).into()
+    }
+}
+
 /// Generates `impl ToValue` blocks for types that are `ToString`.
 macro_rules! impl_to_string_to_value {
     ($($t:ty),*) => {


### PR DESCRIPTION
Closes #1964

## Summary

Removes the `analyze_table_sizes` periodic background task and its supporting methods.

The task ran on a 5-minute `tokio::time::interval` in `spawn_grpc_servers` and issued two queries against SQLite's `dbstat` virtual table (a per-page scan) plus a `pragma_page_count()`/`pragma_page_size()` query. Under write contention the scan held a read lock long enough to block concurrent writers for 30s+, making it a net negative for the performance it was meant to observe.

## Changes

- `server/mod.rs` — removed the spawned interval task; cleaned up now-unused `Duration` import and updated stale doc comments
- `db/mod.rs` — removed `analyze_table_sizes` method; cleaned up now-unused `QueryableByName` import
- `state/mod.rs` — removed `analyze_table_sizes` wrapper

Disk usage can be inspected on demand via SQLite snapshots or by monitoring the data-directory at the filesystem level (`miden-store.sqlite3`, `blocks/`, proof files).

## Test plan

- [ ] `cargo check -p miden-node-store` passes
- [ ] No remaining references to `analyze_table_sizes`, `dbstat`, or `pragma_page` in the store crate