### PR TITLE
fix(block-producer): poison shared mempool lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.15.0 (TBD)
 
 - Added `ca-certificates` to the node Docker runtime image so outbound `https` connections work in containerized deployments ([#1661](https://github.com/0xMiden/node/issues/1661)).
+- Made the block producer abort immediately after a poisoned mempool lock is observed, preventing recovery after mempool corruption ([#2029](https://github.com/0xMiden/node/pull/2029)).
 - Added composite index `idx_transactions_account_block_txid` on `transactions(account_id, block_num, transaction_id)` to speed up `select_transactions_records` queries used by `SyncTransactions` ([#1965](https://github.com/0xMiden/node/issues/1965)).
 - [BREAKING] Changed `GetBlockByNumber` to accept a `BlockRequest` (with optional `include_proof` flag) and returns a response containing the block and an optional block proof ([#1864](https://github.com/0xMiden/node/pull/1864)).
 - Network monitor now auto-regenerates accounts after persistent increment failures instead of staying unhealthy indefinitely ([#1942](https://github.com/0xMiden/node/pull/1942)).

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -191,7 +191,7 @@ impl BatchJob {
 
     #[instrument(target = COMPONENT, name = "batch_builder.select_batch", skip_all)]
     async fn select_batch(&self) -> Option<SelectedBatch> {
-        self.mempool.lock().await.select_batch()
+        self.mempool.lock().select_batch()
     }
 
     #[instrument(target = COMPONENT, name = "batch_builder.get_batch_inputs", skip_all, err)]
@@ -283,12 +283,12 @@ impl BatchJob {
 
     #[instrument(target = COMPONENT, name = "batch_builder.commit_batch", skip_all)]
     async fn commit_batch(&self, batch: Arc<ProvenBatch>) {
-        self.mempool.lock().await.commit_batch(batch);
+        self.mempool.lock().commit_batch(batch);
     }
 
     #[instrument(target = COMPONENT, name = "batch_builder.rollback_batch", skip_all)]
     async fn rollback_batch(&self, batch_id: BatchId) {
-        self.mempool.lock().await.rollback_batch(batch_id);
+        self.mempool.lock().rollback_batch(batch_id);
     }
 }
 

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -128,7 +128,7 @@ impl BlockBuilder {
 
     #[instrument(target = COMPONENT, name = "block_builder.select_block", skip_all)]
     async fn select_block(mempool: &SharedMempool) -> SelectedBlock {
-        mempool.lock().await.select_block()
+        mempool.lock().select_block()
     }
 
     /// Fetches block inputs from the store for the [`SelectedBlock`].
@@ -266,14 +266,14 @@ impl BlockBuilder {
             .map_err(BuildBlockError::StoreApplyBlockFailed)?;
 
         let (header, ..) = signed_block.into_parts();
-        mempool.lock().await.commit_block(header);
+        mempool.lock().commit_block(header);
 
         Ok(())
     }
 
     #[instrument(target = COMPONENT, name = "block_builder.rollback_block", skip_all)]
     async fn rollback_block(&self, mempool: &SharedMempool, block: BlockNumber) {
-        mempool.lock().await.rollback_block(block);
+        mempool.lock().rollback_block(block);
     }
 }
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -153,7 +153,7 @@ impl SharedMempool {
     pub fn lock(&self) -> MutexGuard<'_, Mempool> {
         self.0.lock().unwrap_or_else(|err| {
             tracing::error!(message = %err, "Mempool lock poisoned");
-            panic!("mempool lock poisoned after a previous panic: {err}");
+            std::process::abort();
         })
     }
 }

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -52,7 +52,7 @@
 //! transactions even if the store and block producer momentarily disagree on the chain tip.
 use std::collections::{HashSet, VecDeque};
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use miden_node_proto::domain::mempool::MempoolEvent;
 use miden_node_utils::ErrorReport;
@@ -60,7 +60,7 @@ use miden_protocol::batch::{BatchId, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::transaction::{TransactionHeader, TransactionId};
 use subscription::SubscriptionProvider;
-use tokio::sync::{Mutex, MutexGuard, mpsc};
+use tokio::sync::mpsc;
 use tracing::instrument;
 
 use crate::block_builder::SelectedBlock;
@@ -69,9 +69,7 @@ use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::{MempoolSubmissionError, StateConflict};
 use crate::mempool::budget::BudgetStatus;
 use crate::{
-    COMPONENT,
-    DEFAULT_MEMPOOL_TX_CAPACITY,
-    SERVER_MEMPOOL_EXPIRATION_SLACK,
+    COMPONENT, DEFAULT_MEMPOOL_TX_CAPACITY, SERVER_MEMPOOL_EXPIRATION_SLACK,
     SERVER_MEMPOOL_STATE_RETENTION,
 };
 
@@ -147,13 +145,16 @@ impl Default for MempoolConfig {
 // ================================================================================================
 
 impl SharedMempool {
-    /// Acquires an asynchronous lock on the underlying [`Mempool`].
+    /// Acquires a poisonable lock on the underlying [`Mempool`].
     ///
     /// Callers should minimise the amount of work performed while holding the lock to reduce
     /// contention with other subsystems that need to access the pool.
     #[instrument(target = COMPONENT, name = "mempool.lock", skip_all)]
-    pub async fn lock(&self) -> MutexGuard<'_, Mempool> {
-        self.0.lock().await
+    pub fn lock(&self) -> MutexGuard<'_, Mempool> {
+        self.0.lock().unwrap_or_else(|err| {
+            tracing::error!(message = %err, "Mempool lock poisoned");
+            panic!("mempool lock poisoned after a previous panic: {err}");
+        })
     }
 }
 

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -69,7 +69,9 @@ use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::{MempoolSubmissionError, StateConflict};
 use crate::mempool::budget::BudgetStatus;
 use crate::{
-    COMPONENT, DEFAULT_MEMPOOL_TX_CAPACITY, SERVER_MEMPOOL_EXPIRATION_SLACK,
+    COMPONENT,
+    DEFAULT_MEMPOOL_TX_CAPACITY,
+    SERVER_MEMPOOL_EXPIRATION_SLACK,
     SERVER_MEMPOOL_STATE_RETENTION,
 };
 

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -1,4 +1,6 @@
 use std::env;
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 use std::panic::AssertUnwindSafe;
 use std::process::Command;
 use std::sync::Arc;
@@ -7,9 +9,6 @@ use miden_protocol::Word;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use pretty_assertions::assert_eq;
 use serial_test::serial;
-
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
 
 use super::*;
 use crate::mempool::graph::TransactionGraph;

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -1,10 +1,15 @@
+use std::env;
 use std::panic::AssertUnwindSafe;
+use std::process::Command;
 use std::sync::Arc;
 
 use miden_protocol::Word;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use pretty_assertions::assert_eq;
 use serial_test::serial;
+
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 
 use super::*;
 use crate::mempool::graph::TransactionGraph;
@@ -13,6 +18,8 @@ use crate::test_utils::batch::TransactionBatchConstructor;
 
 mod add_transaction;
 mod add_user_batch;
+
+const POISONED_LOCK_ABORT_HELPER_ENV: &str = "MIDEN_NODE_BLOCK_PRODUCER_POISONED_LOCK_ABORT";
 
 impl Mempool {
     /// Returns an empty [`Mempool`] and a perfect clone intended for use as the Unit Under Test and
@@ -125,8 +132,36 @@ fn failed_batch_transactions_are_requeued() {
 }
 
 #[test]
-#[should_panic(expected = "mempool lock poisoned after a previous panic")]
-fn shared_mempool_lock_is_poisoned_after_panic() {
+fn shared_mempool_lock_aborts_after_poisoning() {
+    let output = Command::new(env::current_exe().expect("test binary path should be available"))
+        .arg("--exact")
+        .arg("mempool::tests::shared_mempool_lock_aborts_after_poisoning_helper")
+        .env(POISONED_LOCK_ABORT_HELPER_ENV, "1")
+        .output()
+        .expect("helper process should execute");
+
+    assert!(
+        !output.status.success(),
+        "expected helper to abort after poisoned lock access, stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    #[cfg(unix)]
+    assert!(
+        output.status.signal().is_some(),
+        "expected helper to terminate via signal, stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn shared_mempool_lock_aborts_after_poisoning_helper() {
+    if env::var_os(POISONED_LOCK_ABORT_HELPER_ENV).is_none() {
+        return;
+    }
+
     let shared = Mempool::shared(BlockNumber::GENESIS, MempoolConfig::default());
     let poisoned = shared.clone();
 

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -1,3 +1,4 @@
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
 use miden_protocol::Word;
@@ -121,6 +122,22 @@ fn failed_batch_transactions_are_requeued() {
         .increment_failure_count(failed_batch.transactions().iter().map(|tx| tx.id()));
 
     assert_eq!(uut, reference);
+}
+
+#[test]
+#[should_panic(expected = "mempool lock poisoned after a previous panic")]
+fn shared_mempool_lock_is_poisoned_after_panic() {
+    let shared = Mempool::shared(BlockNumber::GENESIS, MempoolConfig::default());
+    let poisoned = shared.clone();
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _guard = poisoned.lock();
+        panic!("force mempool corruption");
+    }));
+
+    assert!(result.is_err(), "expected panic while holding mempool lock");
+
+    let _guard = shared.lock();
 }
 
 // BLOCK COMMITTED TESTS

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -272,7 +272,7 @@ impl BlockProducerRpcServer {
                 interval.tick().await;
 
                 let (chain_tip, unbatched_transactions, proposed_batches, proven_batches) = {
-                    let mempool = mempool.lock().await;
+                    let mempool = mempool.lock();
                     (
                         mempool.chain_tip(),
                         mempool.unbatched_transactions_count() as u64,
@@ -336,7 +336,7 @@ impl BlockProducerRpcServer {
             .map(Arc::new)
             .map_err(MempoolSubmissionError::StateConflict)?;
 
-        self.mempool.lock().await.lock().await.add_transaction(tx).map(Into::into)
+        self.mempool.lock().await.lock().add_transaction(tx).map(Into::into)
     }
 
     #[instrument(
@@ -374,7 +374,7 @@ impl BlockProducerRpcServer {
             txs.push(tx);
         }
 
-        self.mempool.lock().await.lock().await.add_user_batch(&txs).map(Into::into)
+        self.mempool.lock().await.lock().add_user_batch(&txs).map(Into::into)
     }
 }
 
@@ -422,7 +422,7 @@ impl api_server::Api for BlockProducerRpcServer {
         &self,
         _request: tonic::Request<()>,
     ) -> Result<tonic::Response<Self::MempoolSubscriptionStream>, tonic::Status> {
-        let subscription = self.mempool.lock().await.lock().await.subscribe();
+        let subscription = self.mempool.lock().await.lock().subscribe();
         let subscription = ReceiverStream::new(subscription);
 
         Ok(tonic::Response::new(MempoolEventSubscription { inner: subscription }))


### PR DESCRIPTION
## Summary
- keep the shared mempool lock poisonable with `std::sync::Mutex`
- abort the process on subsequent mempool access after a prior panic while holding the lock
- add a subprocess regression test that verifies poisoned-lock access terminates the process
- keep the mempool call sites on the synchronous guard API

## Root cause
`SharedMempool` previously wrapped the mempool in `tokio::sync::Mutex`, which does not poison after a panic. The first version of this fix switched to a poisonable mutex, but still surfaced poison as a panic. In the block producer that is not strong enough because some paths can catch panics or run in detached tasks.

## Impact
Once a mempool operation panics while holding the lock, any later mempool access now aborts the block-producer process immediately instead of continuing with potentially corrupted in-memory state or converting the failure into a recoverable gRPC error.

Closes #2016.

## Testing
- `cargo test -p miden-node-block-producer mempool::tests::shared_mempool_lock_aborts_after_poisoning -- --exact --nocapture`
- `cargo test -p miden-node-block-producer mempool::tests::shared_mempool_lock_aborts_after_poisoning_helper -- --exact --nocapture`
- `cargo test -p miden-node-block-producer -- --skip add_transaction_traces_are_correct`
