### PR TITLE
feat(store): make sqlite pool size configurable

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2,6 +2,7 @@ mod conv;
 mod errors;
 mod manager;
 
+use std::num::NonZeroUsize;
 use std::path::Path;
 
 pub use conv::{DatabaseTypeConversionError, SqlTypeConvert};
@@ -22,8 +23,18 @@ pub struct Db {
 impl Db {
     /// Creates a new database instance with the provided connection pool.
     pub fn new(database_filepath: &Path) -> Result<Self, DatabaseError> {
+        Self::new_with_pool_size(database_filepath, NonZeroUsize::new(16).expect("non-zero"))
+    }
+
+    /// Creates a new database instance with a configurable SQLite connection pool size.
+    pub fn new_with_pool_size(
+        database_filepath: &Path,
+        sqlite_pool_size: NonZeroUsize,
+    ) -> Result<Self, DatabaseError> {
         let manager = ConnectionManager::new(database_filepath.to_str().unwrap());
-        let pool = deadpool_diesel::Pool::builder(manager).max_size(16).build()?;
+        let pool = deadpool_diesel::Pool::builder(manager)
+            .max_size(sqlite_pool_size.get())
+            .build()?;
         Ok(Self { pool })
     }
 

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::mem::size_of;
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut, RangeInclusive};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -281,8 +282,11 @@ impl Db {
 
     /// Open a connection to the DB and apply any pending migrations.
     #[instrument(target = COMPONENT, skip_all)]
-    pub async fn load(database_filepath: PathBuf) -> Result<Self, DatabaseError> {
-        let db = miden_node_db::Db::new(&database_filepath)?;
+    pub async fn load(
+        database_filepath: PathBuf,
+        sqlite_pool_size: NonZeroUsize,
+    ) -> Result<Self, DatabaseError> {
+        let db = miden_node_db::Db::new_with_pool_size(&database_filepath, sqlite_pool_size)?;
         info!(
             target: COMPONENT,
             sqlite= %database_filepath.display(),

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -1532,7 +1532,12 @@ async fn reconstruct_storage_map_from_db_pages_until_latest() {
     let block2 = BlockNumber::from(2);
     let block3 = BlockNumber::from(3);
 
-    let db = crate::db::Db::load(db_path).await.unwrap();
+    let db = crate::db::Db::load(
+        db_path,
+        miden_node_utils::clap::StorageOptions::default().sqlite_pool_size,
+    )
+    .await
+    .unwrap();
     let slot_name_for_db = slot_name.clone();
     db.query("insert paged values", move |db_conn| {
         db_conn.transaction(|db_conn| {
@@ -1600,7 +1605,12 @@ async fn reconstruct_storage_map_from_db_returns_limit_exceeded_for_single_block
 
     let block5 = BlockNumber::from(5);
 
-    let db = crate::db::Db::load(db_path).await.unwrap();
+    let db = crate::db::Db::load(
+        db_path,
+        miden_node_utils::clap::StorageOptions::default().sqlite_pool_size,
+    )
+    .await
+    .unwrap();
     let slot_name_for_db = slot_name.clone();
     db.query("insert entries in single block", move |db_conn| {
         db_conn.transaction(|db_conn| {

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -154,7 +154,7 @@ impl State {
         );
 
         let database_filepath = data_directory.database_path();
-        let mut db = Db::load(database_filepath.clone())
+        let mut db = Db::load(database_filepath.clone(), storage_options.sqlite_pool_size)
             .await
             .map_err(StateInitializationError::DatabaseLoadError)?;
 

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -1,6 +1,6 @@
 //! Public module for share clap pieces to reduce duplication
 
-use std::num::{NonZeroU32, NonZeroU64};
+use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::time::Duration;
 
 #[cfg(feature = "rocksdb")]
@@ -14,6 +14,7 @@ const DEFAULT_MAX_CONNECTION_AGE: Duration = Duration::from_mins(30);
 const DEFAULT_REPLENISH_N_PER_SECOND_PER_IP: NonZeroU64 = NonZeroU64::new(16).unwrap();
 const DEFAULT_BURST_SIZE: NonZeroU32 = NonZeroU32::new(128).unwrap();
 const DEFAULT_MAX_CONCURRENT_CONNECTIONS: u64 = 1_000;
+const DEFAULT_SQLITE_POOL_SIZE: NonZeroUsize = NonZeroUsize::new(16).unwrap();
 
 // Formats a Duration into a human-readable string for display in clap help text
 // and yields a &'static str by _leaking_ the string deliberately.
@@ -141,8 +142,17 @@ impl GrpcOptionsExternal {
 /// Collection of per usage storage backend configurations.
 ///
 /// Note: Currently only contains `rocksdb` related configuration.
-#[derive(clap::Args, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(clap::Args, Clone, Debug, PartialEq, Eq)]
 pub struct StorageOptions {
+    /// Maximum number of SQLite connections in the async pool.
+    #[arg(
+        long = "sqlite.pool_size",
+        env = "MIDEN_NODE_SQLITE_POOL_SIZE",
+        default_value_t = DEFAULT_SQLITE_POOL_SIZE,
+        value_name = "NUM"
+    )]
+    pub sqlite_pool_size: NonZeroUsize,
+
     #[cfg(feature = "rocksdb")]
     #[clap(flatten)]
     pub account_tree: AccountTreeRocksDbOptions,
@@ -174,6 +184,7 @@ impl StorageOptions {
                 cache_size_in_bytes: DEFAULT_ROCKSDB_CACHE_SIZE,
             };
             Self {
+                sqlite_pool_size: DEFAULT_SQLITE_POOL_SIZE,
                 account_tree,
                 nullifier_tree,
                 account_state_forest,
@@ -181,5 +192,23 @@ impl StorageOptions {
         }
         #[cfg(not(feature = "rocksdb"))]
         Self::default()
+    }
+}
+
+impl Default for StorageOptions {
+    fn default() -> Self {
+        #[cfg(feature = "rocksdb")]
+        {
+            Self {
+                sqlite_pool_size: DEFAULT_SQLITE_POOL_SIZE,
+                account_tree: AccountTreeRocksDbOptions::default(),
+                nullifier_tree: NullifierTreeRocksDbOptions::default(),
+                account_state_forest: AccountStateForestRocksDbOptions::default(),
+            }
+        }
+        #[cfg(not(feature = "rocksdb"))]
+        {
+            Self { sqlite_pool_size: DEFAULT_SQLITE_POOL_SIZE }
+        }
     }
 }


### PR DESCRIPTION
Add a new sqlite pool-size option in shared storage CLI options and thread it through store state initialization so operators can tune database concurrency instead of relying on a hardcoded pool of 16.

## Summary
- add a configurable SQLite pool size option via `--sqlite.pool_size` and `MIDEN_NODE_SQLITE_POOL_SIZE`
- thread the pool size through store initialization and DB construction instead of relying on a hardcoded value
- update affected store DB tests to use the new load signature

## Why
Issue #1928 notes that the default fixed pool size can be too low relative to RPC concurrency. This change preserves the current default while allowing operators to tune DB concurrency for their workloads.

Closes #1928