### PR TITLE
fix(node): add CA certificates to Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.15.0 (TBD)
 
+- Added `ca-certificates` to the node Docker runtime image so outbound `https` connections work in containerized deployments ([#1661](https://github.com/0xMiden/node/issues/1661)).
 - Added composite index `idx_transactions_account_block_txid` on `transactions(account_id, block_num, transaction_id)` to speed up `select_transactions_records` queries used by `SyncTransactions` ([#1965](https://github.com/0xMiden/node/issues/1965)).
 - [BREAKING] Changed `GetBlockByNumber` to accept a `BlockRequest` (with optional `include_proof` flag) and returns a response containing the block and an optional block proof ([#1864](https://github.com/0xMiden/node/pull/1864)).
 - Network monitor now auto-regenerates accounts after persistent increment failures instead of staying unhealthy indefinitely ([#1942](https://github.com/0xMiden/node/pull/1942)).

--- a/bin/node/Dockerfile
+++ b/bin/node/Dockerfile
@@ -31,7 +31,7 @@ RUN cargo build --release --locked --bin miden-node
 FROM debian:bookworm-slim AS runtime-base
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends sqlite3 \
+    apt-get install -y --no-install-recommends sqlite3 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 FROM runtime-base AS runtime


### PR DESCRIPTION
## Summary
- add `ca-certificates` to the node Docker runtime base image
- keep the runtime image minimal while restoring outbound `https` connectivity
- add a changelog entry for the container TLS fix

## Root cause
The node Docker runtime image installed `sqlite3` but omitted the system CA bundle. That prevented the containerized node from establishing outbound `https` connections even though components such as telemetry export and prover connections are expected to use TLS.

## Impact
Containerized node deployments can now use TLS-backed outbound connections without switching to a larger runtime image.

Closes #1661.

## Testing
- `BASE_REF=next NO_CHANGELOG_LABEL=false ./scripts/check-changelog.sh`
- compared the node runtime image against the network-monitor runtime image, which already installs `ca-certificates`
- not run locally: Docker build/test requires a running Docker daemon, which was unavailable in this environment
