### PR TITLE
chore: add actor-level retry for infra errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Replaced blocking-in-async operations in the validator, remote prover, and ntx-builder with `spawn_blocking` to avoid starving the Tokio runtime ([#2041](https://github.com/0xMiden/node/pull/2041)).
 - Implement persistent RocksDB backend for `AccountStateForest`, improving startup time ([#2020](https://github.com/0xMiden/node/pull/2020)).
+- Fixed network transaction builder permanently dropping notes after transient infrastructure failures. These now retry with exponential backoff at the actor level instead of consuming per-note retry budget ([#2052](https://github.com/0xMiden/node/issues/2052)).
 
 ## v0.14.10 (2026-05-29)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +1938,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "governor"
@@ -3242,6 +3265,7 @@ name = "miden-node-ntx-builder"
 version = "0.14.10"
 dependencies = [
  "anyhow",
+ "backon",
  "build-rs",
  "diesel",
  "diesel_migrations",
@@ -4784,7 +4808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4805,7 +4829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ miden-crypto = { version = "0.23" }
 anyhow            = { version = "1.0" }
 assert_matches    = { version = "1.5" }
 async-trait       = { version = "0.1" }
+backon            = { version = "1.6" }
 build-rs          = { version = "0.3" }
 clap              = { features = ["derive"], version = "4.5" }
 deadpool          = { default-features = false, version = "0.12" }

--- a/crates/ntx-builder/Cargo.toml
+++ b/crates/ntx-builder/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 
 [dependencies]
 anyhow                     = { workspace = true }
+backon                     = { workspace = true }
 diesel                     = { features = ["numeric", "sqlite"], workspace = true }
 diesel_migrations          = { features = ["sqlite"], workspace = true }
 futures                    = { workspace = true }

--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -98,14 +98,29 @@ fn is_transient_store_error(err: &StoreError) -> bool {
     matches!(err, StoreError::GrpcClientError(status) if is_transient_status(status))
 }
 
+/// Maximum number of retries applied to a single transient request before the error is
+/// propagated to the actor-level retry.
+const MAX_REQUEST_RETRIES: usize = 20;
+
 /// Builds the [`ExponentialBuilder`] used to back off retries on transient request failures.
 fn request_backoff(initial: Duration, max: Duration) -> ExponentialBuilder {
     ExponentialBuilder::default()
         .with_min_delay(initial)
         .with_max_delay(max)
         .with_factor(2.0)
-        .without_max_times()
+        .with_max_times(MAX_REQUEST_RETRIES)
         .with_jitter()
+}
+
+/// Emits a structured warning for a transient NTX request failure that is about to be retried.
+fn log_transient_retry<E: std::error::Error>(operation: &'static str, err: &E, sleep: Duration) {
+    tracing::warn!(
+        target: COMPONENT,
+        operation,
+        err = %err.as_report(),
+        sleep_ms = sleep.as_millis() as u64,
+        "ntx transient request failure; retrying after backoff",
+    );
 }
 
 /// The result of a successful transaction execution.
@@ -387,11 +402,7 @@ impl NtxContext {
                 .retry(self.request_backoff())
                 .when(|err| matches!(err, TransactionProverError::Other { .. }))
                 .notify(|err, dur| {
-                    tracing::warn!(
-                        err = %err.as_report(),
-                        sleep_ms = dur.as_millis() as u64,
-                        "remote prover request failed transiently; retrying after backoff",
-                    );
+                    log_transient_retry("remote_prover.prove", err, dur);
                 })
                 .await
                 .map_err(NtxError::Proving)
@@ -423,12 +434,7 @@ impl NtxContext {
             .retry(self.request_backoff())
             .when(is_transient_status)
             .notify(|status, dur| {
-                tracing::warn!(
-                    code = ?status.code(),
-                    err = %status,
-                    sleep_ms = dur.as_millis() as u64,
-                    "block producer submit failed transiently; retrying after backoff",
-                );
+                log_transient_retry("block_producer.submit_proven_transaction", status, dur);
             })
             .await
             .map_err(NtxError::Submission)
@@ -447,12 +453,7 @@ impl NtxContext {
             .retry(self.request_backoff())
             .when(is_transient_status)
             .notify(|status, dur| {
-                tracing::warn!(
-                    code = ?status.code(),
-                    err = %status,
-                    sleep_ms = dur.as_millis() as u64,
-                    "validator submit failed transiently; retrying after backoff",
-                );
+                log_transient_retry("validator.submit_proven_transaction", status, dur);
             })
             .await
             .map_err(NtxError::Submission)
@@ -582,11 +583,7 @@ impl DataStore for NtxDataStore {
                     .retry(self.store_backoff())
                     .when(is_transient_store_error)
                     .notify(|err, dur| {
-                        tracing::warn!(
-                            err = %err.as_report(),
-                            sleep_ms = dur.as_millis() as u64,
-                            "store get_account_inputs failed transiently; retrying after backoff",
-                        );
+                        log_transient_retry("store.get_account_inputs", err, dur);
                     })
                     .await
                     .map_err(|err| {
@@ -625,11 +622,7 @@ impl DataStore for NtxDataStore {
             .retry(self.store_backoff())
             .when(is_transient_store_error)
             .notify(|err, dur| {
-                tracing::warn!(
-                    err = %err.as_report(),
-                    sleep_ms = dur.as_millis() as u64,
-                    "store get_vault_asset_witnesses failed transiently; retrying after backoff",
-                );
+                log_transient_retry("store.get_vault_asset_witnesses", err, dur);
             })
             .await
             .map_err(|err| {
@@ -669,11 +662,7 @@ impl DataStore for NtxDataStore {
             .retry(self.store_backoff())
             .when(is_transient_store_error)
             .notify(|err, dur| {
-                tracing::warn!(
-                    err = %err.as_report(),
-                    sleep_ms = dur.as_millis() as u64,
-                    "store get_storage_map_witness failed transiently; retrying after backoff",
-                );
+                log_transient_retry("store.get_storage_map_witness", err, dur);
             })
             .await
             .map_err(|err| {
@@ -713,11 +702,7 @@ impl DataStore for NtxDataStore {
                 .retry(self.store_backoff())
                 .when(is_transient_store_error)
                 .notify(|err, dur| {
-                    tracing::warn!(
-                        err = %err.as_report(),
-                        sleep_ms = dur.as_millis() as u64,
-                        "store get_note_script_by_root failed transiently; retrying after backoff",
-                    );
+                    log_transient_retry("store.get_note_script_by_root", err, dur);
                 })
                 .await
                 .map_err(|err| {

--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -72,6 +72,66 @@ pub enum NtxError {
     Submission(#[source] tonic::Status),
 }
 
+/// Classifies an [`NtxError`] as caused by infrastructure (transient: node, prover, or transport
+/// problem) or intrinsic to the transaction batch.
+///
+/// Infrastructure failures must not consume per-note retry budget, intrinsic failures must.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorKind {
+    /// Transient infrastructure failure: prover unreachable, validator/block-producer down,
+    /// transport error, or our own checker erroring on a store fetch. The note batch is not
+    /// to blame, we need to retry without penalising notes.
+    Infrastructure,
+    /// The note batch itself is the problem: consumability check rejected notes, the executor or
+    /// local prover failed on this specific batch, or the validator/block-producer rejected the
+    /// transaction content. Penalise the notes per the existing retry policy.
+    Intrinsic,
+}
+
+impl NtxError {
+    /// Returns whether this error is caused by infrastructure or by the transaction batch.
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::AllNotesFailed(_) | Self::Execution(_) => ErrorKind::Intrinsic,
+            Self::NoteFilter(_) | Self::InputNotes(_) => ErrorKind::Infrastructure,
+            Self::Proving(err) => match err {
+                // The remote prover client wraps every transport / connection / deserialization
+                // failure in `TransactionProverError::Other`.
+                TransactionProverError::Other { .. } => ErrorKind::Infrastructure,
+                TransactionProverError::AccountDeltaApplyFailed(_)
+                | TransactionProverError::RemoveFeeAssetFromDelta(_)
+                | TransactionProverError::TransactionOutputConstructionFailed(_)
+                | TransactionProverError::OutputNoteShrinkFailed(_)
+                | TransactionProverError::ProvenTransactionBuildFailed(_)
+                | TransactionProverError::TransactionProgramExecutionFailed(_) => {
+                    ErrorKind::Intrinsic
+                },
+            },
+            // gRPC status codes split into transport / server-side hiccups (Infrastructure)
+            // versus content-rejection codes (Intrinsic).
+            Self::Submission(status) => match status.code() {
+                tonic::Code::Unavailable
+                | tonic::Code::DeadlineExceeded
+                | tonic::Code::Cancelled
+                | tonic::Code::Aborted
+                | tonic::Code::Unknown
+                | tonic::Code::Internal
+                | tonic::Code::ResourceExhausted => ErrorKind::Infrastructure,
+                tonic::Code::InvalidArgument
+                | tonic::Code::FailedPrecondition
+                | tonic::Code::OutOfRange
+                | tonic::Code::NotFound
+                | tonic::Code::AlreadyExists
+                | tonic::Code::Unauthenticated
+                | tonic::Code::PermissionDenied
+                | tonic::Code::Unimplemented
+                | tonic::Code::DataLoss
+                | tonic::Code::Ok => ErrorKind::Intrinsic,
+            },
+        }
+    }
+}
+
 type NtxResult<T> = Result<T, NtxError>;
 
 /// The result of a successful transaction execution.
@@ -677,5 +737,85 @@ impl StorageSlotRegistry {
     fn get_slot_name(&self, account_id: AccountId, map_root: Word) -> Option<StorageSlotName> {
         let slots = self.slots.lock().expect("Storage slot registry mutex is poisoned");
         slots.get(&(account_id, map_root)).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::errors::TransactionInputError;
+    use miden_tx::{NoteCheckerError, TransactionExecutorError, TransactionProverError};
+
+    use super::{ErrorKind, NtxError};
+
+    #[test]
+    fn error_kind_matrix() {
+        // Submission: tonic codes mapping to Infrastructure.
+        for (code, ctor) in [
+            ("unavailable", tonic::Status::unavailable as fn(&'static str) -> tonic::Status),
+            ("deadline_exceeded", tonic::Status::deadline_exceeded),
+            ("cancelled", tonic::Status::cancelled),
+            ("aborted", tonic::Status::aborted),
+            ("unknown", tonic::Status::unknown),
+            ("internal", tonic::Status::internal),
+            ("resource_exhausted", tonic::Status::resource_exhausted),
+        ] {
+            assert_eq!(
+                NtxError::Submission(ctor("test")).kind(),
+                ErrorKind::Infrastructure,
+                "expected Submission({code}) to be Infrastructure",
+            );
+        }
+
+        // Submission: tonic codes mapping to Intrinsic.
+        for (code, ctor) in [
+            (
+                "invalid_argument",
+                tonic::Status::invalid_argument as fn(&'static str) -> tonic::Status,
+            ),
+            ("failed_precondition", tonic::Status::failed_precondition),
+            ("out_of_range", tonic::Status::out_of_range),
+            ("not_found", tonic::Status::not_found),
+            ("already_exists", tonic::Status::already_exists),
+            ("unauthenticated", tonic::Status::unauthenticated),
+            ("permission_denied", tonic::Status::permission_denied),
+            ("unimplemented", tonic::Status::unimplemented),
+            ("data_loss", tonic::Status::data_loss),
+        ] {
+            assert_eq!(
+                NtxError::Submission(ctor("test")).kind(),
+                ErrorKind::Intrinsic,
+                "expected Submission({code}) to be Intrinsic",
+            );
+        }
+
+        // Proving: only the catch-all `Other` variant
+        assert_eq!(
+            NtxError::Proving(TransactionProverError::other("remote prover unreachable")).kind(),
+            ErrorKind::Infrastructure,
+        );
+        assert_eq!(
+            NtxError::Proving(TransactionProverError::other_with_source(
+                "wrapped",
+                std::io::Error::other("boom"),
+            ))
+            .kind(),
+            ErrorKind::Infrastructure,
+        );
+
+        // The remaining failure modes are batch-intrinsic.
+        assert_eq!(NtxError::AllNotesFailed(Vec::new()).kind(), ErrorKind::Intrinsic);
+        assert_eq!(
+            NtxError::Execution(TransactionExecutorError::FeeAssetMustBeFungible).kind(),
+            ErrorKind::Intrinsic,
+        );
+
+        assert_eq!(
+            NtxError::NoteFilter(NoteCheckerError::InputNoteCountOutOfRange(0)).kind(),
+            ErrorKind::Infrastructure,
+        );
+        assert_eq!(
+            NtxError::InputNotes(TransactionInputError::TooManyInputNotes(usize::MAX)).kind(),
+            ErrorKind::Infrastructure,
+        );
     }
 }

--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use backon::{ExponentialBuilder, Retryable};
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
@@ -53,7 +55,7 @@ use tracing::{Instrument, instrument};
 
 use crate::COMPONENT;
 use crate::actor::candidate::TransactionCandidate;
-use crate::clients::{BlockProducerClient, StoreClient, ValidatorClient};
+use crate::clients::{BlockProducerClient, StoreClient, StoreError, ValidatorClient};
 use crate::db::Db;
 
 #[derive(Debug, thiserror::Error)]
@@ -72,67 +74,39 @@ pub enum NtxError {
     Submission(#[source] tonic::Status),
 }
 
-/// Classifies an [`NtxError`] as caused by infrastructure (transient: node, prover, or transport
-/// problem) or intrinsic to the transaction batch.
-///
-/// Infrastructure failures must not consume per-note retry budget, intrinsic failures must.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ErrorKind {
-    /// Transient infrastructure failure: prover unreachable, validator/block-producer down,
-    /// transport error, or our own checker erroring on a store fetch. The note batch is not
-    /// to blame, we need to retry without penalising notes.
-    Infrastructure,
-    /// The note batch itself is the problem: consumability check rejected notes, the executor or
-    /// local prover failed on this specific batch, or the validator/block-producer rejected the
-    /// transaction content. Penalise the notes per the existing retry policy.
-    Intrinsic,
-}
-
-impl NtxError {
-    /// Returns whether this error is caused by infrastructure or by the transaction batch.
-    pub fn kind(&self) -> ErrorKind {
-        match self {
-            Self::AllNotesFailed(_) | Self::Execution(_) => ErrorKind::Intrinsic,
-            Self::NoteFilter(_) | Self::InputNotes(_) => ErrorKind::Infrastructure,
-            Self::Proving(err) => match err {
-                // The remote prover client wraps every transport / connection / deserialization
-                // failure in `TransactionProverError::Other`.
-                TransactionProverError::Other { .. } => ErrorKind::Infrastructure,
-                TransactionProverError::AccountDeltaApplyFailed(_)
-                | TransactionProverError::RemoveFeeAssetFromDelta(_)
-                | TransactionProverError::TransactionOutputConstructionFailed(_)
-                | TransactionProverError::OutputNoteShrinkFailed(_)
-                | TransactionProverError::ProvenTransactionBuildFailed(_)
-                | TransactionProverError::TransactionProgramExecutionFailed(_) => {
-                    ErrorKind::Intrinsic
-                },
-            },
-            // gRPC status codes split into transport / server-side hiccups (Infrastructure)
-            // versus content-rejection codes (Intrinsic).
-            Self::Submission(status) => match status.code() {
-                tonic::Code::Unavailable
-                | tonic::Code::DeadlineExceeded
-                | tonic::Code::Cancelled
-                | tonic::Code::Aborted
-                | tonic::Code::Unknown
-                | tonic::Code::Internal
-                | tonic::Code::ResourceExhausted => ErrorKind::Infrastructure,
-                tonic::Code::InvalidArgument
-                | tonic::Code::FailedPrecondition
-                | tonic::Code::OutOfRange
-                | tonic::Code::NotFound
-                | tonic::Code::AlreadyExists
-                | tonic::Code::Unauthenticated
-                | tonic::Code::PermissionDenied
-                | tonic::Code::Unimplemented
-                | tonic::Code::DataLoss
-                | tonic::Code::Ok => ErrorKind::Intrinsic,
-            },
-        }
-    }
-}
-
 type NtxResult<T> = Result<T, NtxError>;
+
+/// Returns `true` for gRPC status codes that indicate a transient transport- or server-side
+/// problem worth retrying. Content-rejection codes (`InvalidArgument`, `FailedPrecondition`, ...)
+/// reflect the batch itself and are not retried.
+fn is_transient_status(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unavailable
+            | tonic::Code::DeadlineExceeded
+            | tonic::Code::Cancelled
+            | tonic::Code::Aborted
+            | tonic::Code::Unknown
+            | tonic::Code::Internal
+            | tonic::Code::ResourceExhausted,
+    )
+}
+
+/// Returns `true` for `StoreError`s that originate from a transient gRPC condition. All other
+/// store errors (deserialization, missing fields) are content errors and are not retried.
+fn is_transient_store_error(err: &StoreError) -> bool {
+    matches!(err, StoreError::GrpcClientError(status) if is_transient_status(status))
+}
+
+/// Builds the [`ExponentialBuilder`] used to back off retries on transient request failures.
+fn request_backoff(initial: Duration, max: Duration) -> ExponentialBuilder {
+    ExponentialBuilder::default()
+        .with_min_delay(initial)
+        .with_max_delay(max)
+        .with_factor(2.0)
+        .without_max_times()
+        .with_jitter()
+}
 
 /// The result of a successful transaction execution.
 ///
@@ -169,10 +143,17 @@ pub struct NtxContext {
 
     /// Maximum number of VM execution cycles for network transactions.
     max_cycles: u32,
+
+    /// Initial sleep applied to per-request retry backoff for transient infrastructure failures.
+    request_backoff_initial: Duration,
+
+    /// Cap on the per-request retry backoff sleep.
+    request_backoff_max: Duration,
 }
 
 impl NtxContext {
     /// Creates a new [`NtxContext`] instance.
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         block_producer: BlockProducerClient,
         validator: ValidatorClient,
@@ -181,6 +162,8 @@ impl NtxContext {
         script_cache: LruCache<Word, NoteScript>,
         db: Db,
         max_cycles: u32,
+        request_backoff_initial: Duration,
+        request_backoff_max: Duration,
     ) -> Self {
         Self {
             block_producer,
@@ -190,7 +173,14 @@ impl NtxContext {
             script_cache,
             db,
             max_cycles,
+            request_backoff_initial,
+            request_backoff_max,
         }
+    }
+
+    /// Returns the [`ExponentialBuilder`] used for per-request retry backoff.
+    fn request_backoff(&self) -> ExponentialBuilder {
+        request_backoff(self.request_backoff_initial, self.request_backoff_max)
     }
 
     /// Creates a [`TransactionExecutor`] configured with the network transaction cycle limit.
@@ -274,6 +264,8 @@ impl NtxContext {
                             ctx.store.clone(),
                             ctx.script_cache.clone(),
                             ctx.db.clone(),
+                            ctx.request_backoff_initial,
+                            ctx.request_backoff_max,
                         );
                         handle.block_on(
                             async {
@@ -389,10 +381,24 @@ impl NtxContext {
 
     /// Delegates the transaction proof to the remote prover if configured, otherwise performs the
     /// proof locally.
+    ///
+    /// Transient transport failures against the remote prover are retried in-place; intrinsic
+    /// proving errors (witness rejected, malformed inputs) escape on the first attempt.
     #[instrument(target = COMPONENT, name = "ntx.execute_transaction.prove", skip_all, err)]
     async fn prove(&self, tx_inputs: &TransactionInputs) -> NtxResult<ProvenTransaction> {
         if let Some(remote) = &self.prover {
-            remote.prove(tx_inputs).await.map_err(NtxError::Proving)
+            (|| async { remote.prove(tx_inputs).await })
+                .retry(self.request_backoff())
+                .when(|err| matches!(err, TransactionProverError::Other { .. }))
+                .notify(|err, dur| {
+                    tracing::warn!(
+                        err = %err.as_report(),
+                        sleep_ms = dur.as_millis() as u64,
+                        "remote prover request failed transiently; retrying after backoff",
+                    );
+                })
+                .await
+                .map_err(NtxError::Proving)
         } else {
             // ZK proof generation is CPU-intensive; run it on a dedicated blocking thread.
             let tx_inputs = tx_inputs.clone();
@@ -412,23 +418,46 @@ impl NtxContext {
     }
 
     /// Submits the transaction to the block producer.
+    ///
+    /// Transient gRPC failures (`Unavailable`, `DeadlineExceeded`, ...) are retried in-place;
+    /// content-rejection codes escape on the first attempt so the actor can mark the batch failed.
     #[instrument(target = COMPONENT, name = "ntx.execute_transaction.submit", skip_all, err)]
     async fn submit(&self, proven_tx: &ProvenTransaction) -> NtxResult<()> {
-        self.block_producer
-            .submit_proven_transaction(proven_tx)
+        (|| async { self.block_producer.submit_proven_transaction(proven_tx).await })
+            .retry(self.request_backoff())
+            .when(is_transient_status)
+            .notify(|status, dur| {
+                tracing::warn!(
+                    code = ?status.code(),
+                    err = %status,
+                    sleep_ms = dur.as_millis() as u64,
+                    "block producer submit failed transiently; retrying after backoff",
+                );
+            })
             .await
             .map_err(NtxError::Submission)
     }
 
     /// Validates the transaction against the Validator.
+    ///
+    /// Transient gRPC failures are retried in-place; content-rejection codes escape immediately.
     #[instrument(target = COMPONENT, name = "ntx.execute_transaction.validate", skip_all, err)]
     async fn validate(
         &self,
         proven_tx: &ProvenTransaction,
         tx_inputs: &TransactionInputs,
     ) -> NtxResult<()> {
-        self.validator
-            .submit_proven_transaction(proven_tx, tx_inputs)
+        (|| async { self.validator.submit_proven_transaction(proven_tx, tx_inputs).await })
+            .retry(self.request_backoff())
+            .when(is_transient_status)
+            .notify(|status, dur| {
+                tracing::warn!(
+                    code = ?status.code(),
+                    err = %status,
+                    sleep_ms = dur.as_millis() as u64,
+                    "validator submit failed transiently; retrying after backoff",
+                );
+            })
             .await
             .map_err(NtxError::Submission)
     }
@@ -462,10 +491,14 @@ struct NtxDataStore {
     fetched_scripts: Arc<FetchedNoteScripts>,
     /// Mapping of storage map roots to storage slot names observed during various calls.
     storage_slots: Arc<StorageSlotRegistry>,
+    /// Per-request retry backoff bounds for transient store failures.
+    request_backoff_initial: Duration,
+    request_backoff_max: Duration,
 }
 
 impl NtxDataStore {
     /// Creates a new `NtxDataStore` with default cache size.
+    #[expect(clippy::too_many_arguments)]
     fn new(
         account: Account,
         reference_block: BlockHeader,
@@ -473,6 +506,8 @@ impl NtxDataStore {
         store: StoreClient,
         script_cache: LruCache<Word, NoteScript>,
         db: Db,
+        request_backoff_initial: Duration,
+        request_backoff_max: Duration,
     ) -> Self {
         let mast_store = TransactionMastStore::new();
         mast_store.load_account_code(account.code());
@@ -487,7 +522,14 @@ impl NtxDataStore {
             db,
             fetched_scripts: Arc::new(FetchedNoteScripts::new()),
             storage_slots: Arc::new(StorageSlotRegistry::new()),
+            request_backoff_initial,
+            request_backoff_max,
         }
+    }
+
+    /// Returns the [`ExponentialBuilder`] used for per-request retry backoff against the store.
+    fn store_backoff(&self) -> ExponentialBuilder {
+        request_backoff(self.request_backoff_initial, self.request_backoff_max)
     }
 
     /// Returns the list of note scripts fetched from the remote store during execution.
@@ -542,11 +584,22 @@ impl DataStore for NtxDataStore {
         async move {
             debug_assert_eq!(ref_block, self.reference_block.block_num());
 
-            // Get foreign account inputs from store.
+            // Get foreign account inputs from store, retrying on transient gRPC failures.
             let account_inputs =
-                self.store.get_account_inputs(foreign_account_id, ref_block).await.map_err(
-                    |err| DataStoreError::other_with_source("failed to get account inputs", err),
-                )?;
+                (|| async { self.store.get_account_inputs(foreign_account_id, ref_block).await })
+                    .retry(self.store_backoff())
+                    .when(is_transient_store_error)
+                    .notify(|err, dur| {
+                        tracing::warn!(
+                            err = %err.as_report(),
+                            sleep_ms = dur.as_millis() as u64,
+                            "store get_account_inputs failed transiently; retrying after backoff",
+                        );
+                    })
+                    .await
+                    .map_err(|err| {
+                        DataStoreError::other_with_source("failed to get account inputs", err)
+                    })?;
 
             // Ensure foreign account procedures are available to the executor via the mast store.
             // This assumes the code was not loaded from before
@@ -568,14 +621,28 @@ impl DataStore for NtxDataStore {
         async move {
             let ref_block = self.reference_block.block_num();
 
-            // Get vault asset witnesses from the store.
-            let witnesses = self
-                .store
-                .get_vault_asset_witnesses(account_id, vault_keys, Some(ref_block))
-                .await
-                .map_err(|err| {
-                    DataStoreError::other_with_source("failed to get vault asset witnesses", err)
-                })?;
+            // Get vault asset witnesses from the store, retrying on transient gRPC failures.
+            let witnesses = (|| {
+                let vault_keys = vault_keys.clone();
+                async move {
+                    self.store
+                        .get_vault_asset_witnesses(account_id, vault_keys, Some(ref_block))
+                        .await
+                }
+            })
+            .retry(self.store_backoff())
+            .when(is_transient_store_error)
+            .notify(|err, dur| {
+                tracing::warn!(
+                    err = %err.as_report(),
+                    sleep_ms = dur.as_millis() as u64,
+                    "store get_vault_asset_witnesses failed transiently; retrying after backoff",
+                );
+            })
+            .await
+            .map_err(|err| {
+                DataStoreError::other_with_source("failed to get vault asset witnesses", err)
+            })?;
 
             Ok(witnesses)
         }
@@ -598,14 +665,28 @@ impl DataStore for NtxDataStore {
 
             let ref_block = self.reference_block.block_num();
 
-            // Get storage map witness from the store.
-            let witness = self
-                .store
-                .get_storage_map_witness(account_id, slot_name.clone(), map_key, Some(ref_block))
-                .await
-                .map_err(|err| {
-                    DataStoreError::other_with_source("failed to get storage map witness", err)
-                })?;
+            // Get storage map witness from the store, retrying on transient gRPC failures.
+            let witness = (|| {
+                let slot_name = slot_name.clone();
+                async move {
+                    self.store
+                        .get_storage_map_witness(account_id, slot_name, map_key, Some(ref_block))
+                        .await
+                }
+            })
+            .retry(self.store_backoff())
+            .when(is_transient_store_error)
+            .notify(|err, dur| {
+                tracing::warn!(
+                    err = %err.as_report(),
+                    sleep_ms = dur.as_millis() as u64,
+                    "store get_storage_map_witness failed transiently; retrying after backoff",
+                );
+            })
+            .await
+            .map_err(|err| {
+                DataStoreError::other_with_source("failed to get storage map witness", err)
+            })?;
 
             Ok(witness)
         }
@@ -635,9 +716,19 @@ impl DataStore for NtxDataStore {
                 return Ok(Some(script));
             }
 
-            // 3. Remote store.
-            let maybe_script =
-                self.store.get_note_script_by_root(script_root).await.map_err(|err| {
+            // 3. Remote store, retrying on transient gRPC failures.
+            let maybe_script = (|| async { self.store.get_note_script_by_root(script_root).await })
+                .retry(self.store_backoff())
+                .when(is_transient_store_error)
+                .notify(|err, dur| {
+                    tracing::warn!(
+                        err = %err.as_report(),
+                        sleep_ms = dur.as_millis() as u64,
+                        "store get_note_script_by_root failed transiently; retrying after backoff",
+                    );
+                })
+                .await
+                .map_err(|err| {
                     DataStoreError::other_with_source(
                         "failed to retrieve note script from store",
                         err,
@@ -742,80 +833,59 @@ impl StorageSlotRegistry {
 
 #[cfg(test)]
 mod tests {
-    use miden_protocol::errors::TransactionInputError;
-    use miden_tx::{NoteCheckerError, TransactionExecutorError, TransactionProverError};
+    use miden_tx::TransactionProverError;
 
-    use super::{ErrorKind, NtxError};
+    use super::{StoreError, is_transient_status, is_transient_store_error};
 
     #[test]
-    fn error_kind_matrix() {
-        // Submission: tonic codes mapping to Infrastructure.
-        for (code, ctor) in [
-            ("unavailable", tonic::Status::unavailable as fn(&'static str) -> tonic::Status),
-            ("deadline_exceeded", tonic::Status::deadline_exceeded),
-            ("cancelled", tonic::Status::cancelled),
-            ("aborted", tonic::Status::aborted),
-            ("unknown", tonic::Status::unknown),
-            ("internal", tonic::Status::internal),
-            ("resource_exhausted", tonic::Status::resource_exhausted),
-        ] {
-            assert_eq!(
-                NtxError::Submission(ctor("test")).kind(),
-                ErrorKind::Infrastructure,
-                "expected Submission({code}) to be Infrastructure",
-            );
+    fn transient_status_classifies_transport_codes() {
+        let transient = [
+            tonic::Status::unavailable("u"),
+            tonic::Status::deadline_exceeded("d"),
+            tonic::Status::cancelled("c"),
+            tonic::Status::aborted("a"),
+            tonic::Status::unknown("u"),
+            tonic::Status::internal("i"),
+            tonic::Status::resource_exhausted("r"),
+        ];
+        for s in &transient {
+            assert!(is_transient_status(s), "{:?} should be transient", s.code());
         }
 
-        // Submission: tonic codes mapping to Intrinsic.
-        for (code, ctor) in [
-            (
-                "invalid_argument",
-                tonic::Status::invalid_argument as fn(&'static str) -> tonic::Status,
-            ),
-            ("failed_precondition", tonic::Status::failed_precondition),
-            ("out_of_range", tonic::Status::out_of_range),
-            ("not_found", tonic::Status::not_found),
-            ("already_exists", tonic::Status::already_exists),
-            ("unauthenticated", tonic::Status::unauthenticated),
-            ("permission_denied", tonic::Status::permission_denied),
-            ("unimplemented", tonic::Status::unimplemented),
-            ("data_loss", tonic::Status::data_loss),
-        ] {
-            assert_eq!(
-                NtxError::Submission(ctor("test")).kind(),
-                ErrorKind::Intrinsic,
-                "expected Submission({code}) to be Intrinsic",
-            );
+        let terminal = [
+            tonic::Status::invalid_argument("ia"),
+            tonic::Status::failed_precondition("fp"),
+            tonic::Status::out_of_range("oor"),
+            tonic::Status::not_found("nf"),
+            tonic::Status::already_exists("ae"),
+            tonic::Status::unauthenticated("ua"),
+            tonic::Status::permission_denied("pd"),
+            tonic::Status::unimplemented("ui"),
+            tonic::Status::data_loss("dl"),
+        ];
+        for s in &terminal {
+            assert!(!is_transient_status(s), "{:?} should be terminal", s.code());
         }
+    }
 
-        // Proving: only the catch-all `Other` variant
-        assert_eq!(
-            NtxError::Proving(TransactionProverError::other("remote prover unreachable")).kind(),
-            ErrorKind::Infrastructure,
-        );
-        assert_eq!(
-            NtxError::Proving(TransactionProverError::other_with_source(
-                "wrapped",
-                std::io::Error::other("boom"),
-            ))
-            .kind(),
-            ErrorKind::Infrastructure,
-        );
+    #[test]
+    fn transient_store_error_only_for_transient_grpc() {
+        let transient = StoreError::GrpcClientError(tonic::Status::unavailable("down"));
+        assert!(is_transient_store_error(&transient));
 
-        // The remaining failure modes are batch-intrinsic.
-        assert_eq!(NtxError::AllNotesFailed(Vec::new()).kind(), ErrorKind::Intrinsic);
-        assert_eq!(
-            NtxError::Execution(TransactionExecutorError::FeeAssetMustBeFungible).kind(),
-            ErrorKind::Intrinsic,
-        );
+        let terminal_grpc =
+            StoreError::GrpcClientError(tonic::Status::invalid_argument("bad input"));
+        assert!(!is_transient_store_error(&terminal_grpc));
 
-        assert_eq!(
-            NtxError::NoteFilter(NoteCheckerError::InputNoteCountOutOfRange(0)).kind(),
-            ErrorKind::Infrastructure,
-        );
-        assert_eq!(
-            NtxError::InputNotes(TransactionInputError::TooManyInputNotes(usize::MAX)).kind(),
-            ErrorKind::Infrastructure,
-        );
+        let malformed = StoreError::MalformedResponse("bad".into());
+        assert!(!is_transient_store_error(&malformed));
+    }
+
+    /// Smoke-test that the predicates used by the request-level retry wrappers compile and select
+    /// the expected variants. Prover transport failures live behind `Other` only.
+    #[test]
+    fn prover_other_is_the_retried_variant() {
+        let err = TransactionProverError::other("remote prover unreachable");
+        assert!(matches!(err, TransactionProverError::Other { .. }));
     }
 }

--- a/crates/ntx-builder/src/actor/execute.rs
+++ b/crates/ntx-builder/src/actor/execute.rs
@@ -144,11 +144,8 @@ pub struct NtxContext {
     /// Maximum number of VM execution cycles for network transactions.
     max_cycles: u32,
 
-    /// Initial sleep applied to per-request retry backoff for transient infrastructure failures.
-    request_backoff_initial: Duration,
-
-    /// Cap on the per-request retry backoff sleep.
-    request_backoff_max: Duration,
+    /// [`ExponentialBuilder`] used to back off retries on transient request failures.
+    request_backoff: ExponentialBuilder,
 }
 
 impl NtxContext {
@@ -165,6 +162,7 @@ impl NtxContext {
         request_backoff_initial: Duration,
         request_backoff_max: Duration,
     ) -> Self {
+        let request_backoff = request_backoff(request_backoff_initial, request_backoff_max);
         Self {
             block_producer,
             validator,
@@ -173,14 +171,13 @@ impl NtxContext {
             script_cache,
             db,
             max_cycles,
-            request_backoff_initial,
-            request_backoff_max,
+            request_backoff,
         }
     }
 
     /// Returns the [`ExponentialBuilder`] used for per-request retry backoff.
     fn request_backoff(&self) -> ExponentialBuilder {
-        request_backoff(self.request_backoff_initial, self.request_backoff_max)
+        self.request_backoff
     }
 
     /// Creates a [`TransactionExecutor`] configured with the network transaction cycle limit.
@@ -264,8 +261,7 @@ impl NtxContext {
                             ctx.store.clone(),
                             ctx.script_cache.clone(),
                             ctx.db.clone(),
-                            ctx.request_backoff_initial,
-                            ctx.request_backoff_max,
+                            ctx.request_backoff,
                         );
                         handle.block_on(
                             async {
@@ -491,14 +487,12 @@ struct NtxDataStore {
     fetched_scripts: Arc<FetchedNoteScripts>,
     /// Mapping of storage map roots to storage slot names observed during various calls.
     storage_slots: Arc<StorageSlotRegistry>,
-    /// Per-request retry backoff bounds for transient store failures.
-    request_backoff_initial: Duration,
-    request_backoff_max: Duration,
+    /// Per-request retry backoff for transient store failures.
+    request_backoff: ExponentialBuilder,
 }
 
 impl NtxDataStore {
     /// Creates a new `NtxDataStore` with default cache size.
-    #[expect(clippy::too_many_arguments)]
     fn new(
         account: Account,
         reference_block: BlockHeader,
@@ -506,8 +500,7 @@ impl NtxDataStore {
         store: StoreClient,
         script_cache: LruCache<Word, NoteScript>,
         db: Db,
-        request_backoff_initial: Duration,
-        request_backoff_max: Duration,
+        request_backoff: ExponentialBuilder,
     ) -> Self {
         let mast_store = TransactionMastStore::new();
         mast_store.load_account_code(account.code());
@@ -522,14 +515,13 @@ impl NtxDataStore {
             db,
             fetched_scripts: Arc::new(FetchedNoteScripts::new()),
             storage_slots: Arc::new(StorageSlotRegistry::new()),
-            request_backoff_initial,
-            request_backoff_max,
+            request_backoff,
         }
     }
 
     /// Returns the [`ExponentialBuilder`] used for per-request retry backoff against the store.
     fn store_backoff(&self) -> ExponentialBuilder {
-        request_backoff(self.request_backoff_initial, self.request_backoff_max)
+        self.request_backoff
     }
 
     /// Returns the list of note scripts fetched from the remote store during execution.

--- a/crates/ntx-builder/src/actor/mod.rs
+++ b/crates/ntx-builder/src/actor/mod.rs
@@ -6,14 +6,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
 use candidate::TransactionCandidate;
 use futures::FutureExt;
 use miden_node_proto::domain::account::NetworkAccountId;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
 use miden_protocol::Word;
-use miden_protocol::account::{Account, AccountDelta, AccountId};
+use miden_protocol::account::{Account, AccountDelta};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{NoteScript, Nullifier};
 use miden_protocol::transaction::TransactionId;
@@ -23,11 +22,9 @@ use tokio::sync::{Notify, Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::NoteError;
-use crate::actor::execute::ErrorKind;
 use crate::chain_state::{ChainState, SharedChainState};
 use crate::clients::{BlockProducerClient, StoreClient, ValidatorClient};
 use crate::db::Db;
-use crate::inflight_note::InflightNetworkNote;
 
 // ACTOR REQUESTS
 // ================================================================================================
@@ -80,11 +77,12 @@ pub struct AccountActorContext {
     pub request_tx: mpsc::Sender<ActorRequest>,
     /// Maximum number of VM execution cycles for network transactions.
     pub max_cycles: u32,
-    /// Initial actor-level sleep after an infrastructure-classified failure. Doubles on each
-    /// consecutive infra failure up to [`Self::infra_failure_backoff_max`] and resets on success.
-    pub infra_failure_backoff_initial: Duration,
-    /// Upper bound on the actor-level infra-failure backoff sleep.
-    pub infra_failure_backoff_max: Duration,
+    /// Initial sleep applied between per-request retries on transient infrastructure failures
+    /// (prover unreachable, validator/block-producer transport error, store gRPC hiccup). Doubles
+    /// each retry up to [`Self::request_backoff_max`].
+    pub request_backoff_initial: Duration,
+    /// Upper bound on the per-request retry backoff sleep.
+    pub request_backoff_max: Duration,
 }
 
 #[cfg(test)]
@@ -120,8 +118,8 @@ impl AccountActorContext {
             db: db.clone(),
             request_tx,
             max_cycles: 1 << 18,
-            infra_failure_backoff_initial: Duration::from_millis(1),
-            infra_failure_backoff_max: Duration::from_millis(10),
+            request_backoff_initial: Duration::from_millis(1),
+            request_backoff_max: Duration::from_millis(10),
         }
     }
 }
@@ -177,22 +175,14 @@ enum ActorMode {
 }
 
 /// Outcome of an `execute_transactions` call.
-///
-/// Distinguishes infrastructure failures (caller should sleep with backoff and retry the same
-/// notes without penalising them) from intrinsic failures (notes were marked failed and the
-/// caller should idle until something changes) and successful submission.
 #[derive(Debug)]
 enum ExecutionOutcome {
     /// Transaction was submitted, the actor should wait for mempool confirmation.
     Inflight(TransactionId),
-    /// The transaction batch is intrinsically bad (notes failed consumability, executor or local
-    /// prover rejected the witness, validator/block-producer rejected the content). Notes have
-    /// already been marked failed and the actor should idle.
-    IntrinsicFailure,
-    /// An infrastructure-level component failed (prover unreachable, validator/block-producer
-    /// transport error, our own checker erroring). Notes were *not* penalised and the actor should
-    /// sleep for the configured backoff and retry the same candidate.
-    InfrastructureFailure,
+    /// Transaction execution failed. Transient infrastructure failures have already been retried
+    /// inside `execute_transaction`, so any error reaching the actor is terminal for this
+    /// candidate.
+    Failure,
 }
 
 // ACCOUNT ACTOR
@@ -250,15 +240,10 @@ pub struct AccountActor {
     request_tx: mpsc::Sender<ActorRequest>,
     /// Maximum number of VM execution cycles for network transactions.
     max_cycles: u32,
-    /// Initial sleep after an infrastructure-classified failure. Used to rebuild the backoff
-    /// iterator on success.
-    infra_failure_backoff_initial: Duration,
-    /// Upper bound on the actor-level infra-failure backoff sleep.
-    infra_failure_backoff_max: Duration,
-    /// Exponential backoff applied at the actor level after consecutive infrastructure-classified
-    /// failures. Rebuilt on every successful submission / intrinsic failure so the next infra
-    /// outage starts from `infra_failure_backoff_initial` again.
-    infra_backoff: ExponentialBackoff,
+    /// Initial sleep applied between per-request retries on transient infrastructure failures.
+    request_backoff_initial: Duration,
+    /// Upper bound on the per-request retry backoff sleep.
+    request_backoff_max: Duration,
 }
 
 impl AccountActor {
@@ -286,12 +271,8 @@ impl AccountActor {
             idle_timeout: actor_context.idle_timeout,
             request_tx: actor_context.request_tx.clone(),
             max_cycles: actor_context.max_cycles,
-            infra_failure_backoff_initial: actor_context.infra_failure_backoff_initial,
-            infra_failure_backoff_max: actor_context.infra_failure_backoff_max,
-            infra_backoff: build_infra_backoff(
-                actor_context.infra_failure_backoff_initial,
-                actor_context.infra_failure_backoff_max,
-            ),
+            request_backoff_initial: actor_context.request_backoff_initial,
+            request_backoff_max: actor_context.request_backoff_max,
         }
     }
 
@@ -373,24 +354,12 @@ impl AccountActor {
                     if let Some(tx_candidate) = tx_candidate {
                         match self.execute_transactions(account_id, tx_candidate).await {
                             ExecutionOutcome::Inflight(tx_id) => {
-                                self.reset_infra_backoff();
                                 self.mode = ActorMode::TransactionInflight(tx_id);
                             },
-                            ExecutionOutcome::IntrinsicFailure => {
-                                self.reset_infra_backoff();
-                                self.mode = ActorMode::NoViableNotes;
-                            },
-                            ExecutionOutcome::InfrastructureFailure => {
-                                let sleep = self
-                                    .infra_backoff
-                                    .next()
-                                    .unwrap_or(self.infra_failure_backoff_max);
-                                tracing::warn!(
-                                    %account_id,
-                                    sleep_ms = sleep.as_millis() as u64,
-                                    "sleeping after infrastructure failure before retrying",
-                                );
-                                tokio::time::sleep(sleep).await;
+                            // The batch failed terminally: offending notes have been marked
+                            // failed; let the next loop iteration re-query the DB to decide
+                            // whether anything remains to consume for this account.
+                            ExecutionOutcome::Failure => {
                                 self.mode = ActorMode::NotesAvailable;
                             },
                         }
@@ -444,9 +413,10 @@ impl AccountActor {
 
     /// Execute a transaction candidate and mark notes as failed as required.
     ///
-    /// Returns an [`ExecutionOutcome`] which the caller maps to the next [`ActorMode`].
-    /// Infrastructure failures do *not* mark notes as failed and request the caller to sleep
-    /// before retrying the same candidate.
+    /// Transient infrastructure failures (prover unreachable, validator/block-producer transport
+    /// hiccup, store gRPC error) are retried inside [`execute::NtxContext::execute_transaction`].
+    /// Any error reaching this method is therefore terminal for the candidate: the batch's notes
+    /// are marked failed and the actor moves on.
     #[tracing::instrument(name = "ntx.actor.execute_transactions", skip(self, tx_candidate))]
     async fn execute_transactions(
         &mut self,
@@ -464,6 +434,8 @@ impl AccountActor {
             self.script_cache.clone(),
             self.db.clone(),
             self.max_cycles,
+            self.request_backoff_initial,
+            self.request_backoff_max,
         );
 
         let notes = tx_candidate.notes.clone();
@@ -492,24 +464,38 @@ impl AccountActor {
                 }
                 ExecutionOutcome::Inflight(tx_id)
             },
-            Err(err) => match classify_failure(account_id, &notes, err) {
-                FailureOutcome::Infrastructure => ExecutionOutcome::InfrastructureFailure,
-                FailureOutcome::Intrinsic(failed_notes) => {
-                    if !failed_notes.is_empty() {
-                        self.mark_notes_failed(&failed_notes, block_num).await;
-                    }
-                    ExecutionOutcome::IntrinsicFailure
-                },
+            Err(err) => {
+                let error_msg = err.as_report();
+                tracing::error!(
+                    %account_id,
+                    ?note_ids,
+                    err = %error_msg,
+                    "network transaction failed",
+                );
+                let failed_notes: Vec<_> = match err {
+                    execute::NtxError::AllNotesFailed(per_note) => log_failed_notes(per_note),
+                    other => {
+                        let error: NoteError = Arc::new(other);
+                        notes
+                            .iter()
+                            .map(|note| {
+                                tracing::info!(
+                                    note.id = %note.to_inner().as_note().id(),
+                                    nullifier = %note.nullifier(),
+                                    err = %error_msg,
+                                    "note failed: transaction execution error",
+                                );
+                                (note.nullifier(), error.clone())
+                            })
+                            .collect()
+                    },
+                };
+                if !failed_notes.is_empty() {
+                    self.mark_notes_failed(&failed_notes, block_num).await;
+                }
+                ExecutionOutcome::Failure
             },
         }
-    }
-
-    /// Rebuilds the actor-local infra-failure backoff iterator so the next infra outage starts
-    /// from `infra_failure_backoff_initial`. Called after any successful submission or any
-    /// intrinsic failure.
-    fn reset_infra_backoff(&mut self) {
-        self.infra_backoff =
-            build_infra_backoff(self.infra_failure_backoff_initial, self.infra_failure_backoff_max);
     }
 
     /// Sends requests to the coordinator to cache note scripts fetched from the remote store.
@@ -567,193 +553,4 @@ fn log_failed_notes(failed: Vec<FailedNote>) -> Vec<(Nullifier, NoteError)> {
             (f.note.nullifier(), Arc::new(f.error) as NoteError)
         })
         .collect()
-}
-
-/// What the actor should do with a failed [`execute::NtxError`].
-#[derive(Debug)]
-enum FailureOutcome {
-    /// An infrastructure-level component failed (prover unreachable, validator/block-producer
-    /// transport error, our own checker erroring). Notes are *not* penalised and caller should
-    /// sleep for the configured backoff and retry the same candidate.
-    Infrastructure,
-    /// The transaction batch is intrinsically bad (notes failed consumability, executor or local
-    /// prover rejected the witness, validator/block-producer rejected the content). Caller should
-    /// mark the carried notes failed and idle.
-    Intrinsic(Vec<(Nullifier, NoteError)>),
-}
-
-/// Decides what to do with a failed [`execute::NtxError`]: which notes to mark failed, and the
-/// resulting [`FailureOutcome`].
-///
-/// - Infrastructure errors return `Infrastructure`: caller sleeps and retries.
-/// - Intrinsic `AllNotesFailed` returns per-note errors carried in the variant.
-/// - Any other intrinsic variant attributes the wrapped batch-level error to every note in the
-///   batch.
-fn classify_failure(
-    account_id: AccountId,
-    notes: &[InflightNetworkNote],
-    err: execute::NtxError,
-) -> FailureOutcome {
-    let error_msg = err.as_report();
-    let note_ids: Vec<_> = notes.iter().map(|n| n.to_inner().as_note().id()).collect();
-    match err.kind() {
-        ErrorKind::Infrastructure => {
-            tracing::warn!(
-                %account_id,
-                ?note_ids,
-                err = %error_msg,
-                "network transaction failed due to infrastructure error; notes not penalised, \
-                 will retry after backoff",
-            );
-            FailureOutcome::Infrastructure
-        },
-        ErrorKind::Intrinsic => {
-            tracing::error!(
-                %account_id,
-                ?note_ids,
-                err = %error_msg,
-                "network transaction failed",
-            );
-            let failed_notes: Vec<_> = match err {
-                execute::NtxError::AllNotesFailed(per_note) => log_failed_notes(per_note),
-                other => {
-                    let error: NoteError = Arc::new(other);
-                    notes
-                        .iter()
-                        .map(|note| {
-                            tracing::info!(
-                                note.id = %note.to_inner().as_note().id(),
-                                nullifier = %note.nullifier(),
-                                err = %error_msg,
-                                "note failed: transaction execution error",
-                            );
-                            (note.nullifier(), error.clone())
-                        })
-                        .collect()
-                },
-            };
-            FailureOutcome::Intrinsic(failed_notes)
-        },
-    }
-}
-
-/// Builds the [`ExponentialBackoff`] used at the actor level after infrastructure-classified
-/// failures.
-fn build_infra_backoff(initial: Duration, max: Duration) -> ExponentialBackoff {
-    ExponentialBuilder::default()
-        .with_min_delay(initial)
-        .with_max_delay(max)
-        .with_factor(2.0)
-        .without_max_times()
-        .with_jitter()
-        .build()
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use miden_tx::{TransactionExecutorError, TransactionProverError};
-
-    use super::{FailureOutcome, build_infra_backoff, classify_failure, execute};
-    use crate::inflight_note::InflightNetworkNote;
-    use crate::test_utils::{mock_network_account_id, mock_single_target_note};
-
-    #[test]
-    fn infra_backoff_is_bounded_and_unbounded_in_length() {
-        let initial = Duration::from_secs(1);
-        let max = Duration::from_secs(30);
-        let upper_with_jitter = max.saturating_mul(2);
-        let mut backoff = build_infra_backoff(initial, max);
-
-        for _ in 0..50 {
-            let delay = backoff.next().expect("backoff should be unbounded");
-            assert!(
-                delay <= upper_with_jitter,
-                "delay {delay:?} exceeds {upper_with_jitter:?} (max + jitter)",
-            );
-        }
-    }
-
-    /// Returns 3 distinct mock notes targeting the same account.
-    fn mock_notes() -> Vec<InflightNetworkNote> {
-        let account = mock_network_account_id();
-        (0u8..3)
-            .map(|seed| InflightNetworkNote::new(mock_single_target_note(account, seed)))
-            .collect()
-    }
-
-    fn mock_account_id() -> miden_protocol::account::AccountId {
-        mock_network_account_id().inner()
-    }
-
-    /// Infrastructure errors return `Infrastructure`, no notes are penalised.
-    #[test]
-    fn classify_failure_infra_skips_marking_notes() {
-        let notes = mock_notes();
-        let cases: Vec<execute::NtxError> = vec![
-            execute::NtxError::Submission(tonic::Status::unavailable("bp down")),
-            execute::NtxError::Submission(tonic::Status::deadline_exceeded("timeout")),
-            execute::NtxError::Submission(tonic::Status::internal("internal")),
-            execute::NtxError::Proving(TransactionProverError::other("remote prover unreachable")),
-            execute::NtxError::NoteFilter(miden_tx::NoteCheckerError::InputNoteCountOutOfRange(0)),
-            execute::NtxError::InputNotes(
-                miden_protocol::errors::TransactionInputError::TooManyInputNotes(usize::MAX),
-            ),
-        ];
-        for err in cases {
-            let display = format!("{err:?}");
-            let outcome = classify_failure(mock_account_id(), &notes, err);
-            assert!(
-                matches!(outcome, FailureOutcome::Infrastructure),
-                "expected Infrastructure for `{display}`, got {outcome:?}",
-            );
-        }
-    }
-
-    /// `Submission` with a content-rejection code (`InvalidArgument`) is intrinsic, every note
-    /// in the batch is marked failed with the same wrapped error.
-    #[test]
-    fn classify_failure_submission_invalid_argument_marks_all_notes() {
-        let notes = mock_notes();
-        let err = execute::NtxError::Submission(tonic::Status::invalid_argument("bad tx"));
-        let outcome = classify_failure(mock_account_id(), &notes, err);
-        let FailureOutcome::Intrinsic(failed) = outcome else {
-            panic!("expected Intrinsic, got {outcome:?}");
-        };
-        assert_eq!(failed.len(), notes.len(), "all notes should be marked failed");
-        for note in &notes {
-            assert!(
-                failed.iter().any(|(n, _)| *n == note.nullifier()),
-                "missing nullifier {} in failed list",
-                note.nullifier(),
-            );
-        }
-    }
-
-    /// A structured (non-`Other`) `Execution` variant is intrinsic, the local execution rejected
-    /// the batch, so all notes are marked failed.
-    #[test]
-    fn classify_failure_local_execution_marks_all_notes() {
-        let notes = mock_notes();
-        let err = execute::NtxError::Execution(TransactionExecutorError::FeeAssetMustBeFungible);
-        let outcome = classify_failure(mock_account_id(), &notes, err);
-        let FailureOutcome::Intrinsic(failed) = outcome else {
-            panic!("expected Intrinsic, got {outcome:?}");
-        };
-        assert_eq!(failed.len(), notes.len());
-    }
-
-    /// `AllNotesFailed` carries its own per-note attribution, so an empty per-note vec produces
-    /// no DB updates while still being intrinsic.
-    #[test]
-    fn classify_failure_all_notes_failed_uses_per_note_attribution() {
-        let notes = mock_notes();
-        let err = execute::NtxError::AllNotesFailed(Vec::new());
-        let outcome = classify_failure(mock_account_id(), &notes, err);
-        let FailureOutcome::Intrinsic(failed) = outcome else {
-            panic!("expected Intrinsic, got {outcome:?}");
-        };
-        assert!(failed.is_empty());
-    }
 }

--- a/crates/ntx-builder/src/actor/mod.rs
+++ b/crates/ntx-builder/src/actor/mod.rs
@@ -6,13 +6,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
+use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
 use candidate::TransactionCandidate;
 use futures::FutureExt;
 use miden_node_proto::domain::account::NetworkAccountId;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
 use miden_protocol::Word;
-use miden_protocol::account::{Account, AccountDelta};
+use miden_protocol::account::{Account, AccountDelta, AccountId};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{NoteScript, Nullifier};
 use miden_protocol::transaction::TransactionId;
@@ -22,9 +23,11 @@ use tokio::sync::{Notify, Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::NoteError;
+use crate::actor::execute::ErrorKind;
 use crate::chain_state::{ChainState, SharedChainState};
 use crate::clients::{BlockProducerClient, StoreClient, ValidatorClient};
 use crate::db::Db;
+use crate::inflight_note::InflightNetworkNote;
 
 // ACTOR REQUESTS
 // ================================================================================================
@@ -77,6 +80,11 @@ pub struct AccountActorContext {
     pub request_tx: mpsc::Sender<ActorRequest>,
     /// Maximum number of VM execution cycles for network transactions.
     pub max_cycles: u32,
+    /// Initial actor-level sleep after an infrastructure-classified failure. Doubles on each
+    /// consecutive infra failure up to [`Self::infra_failure_backoff_max`] and resets on success.
+    pub infra_failure_backoff_initial: Duration,
+    /// Upper bound on the actor-level infra-failure backoff sleep.
+    pub infra_failure_backoff_max: Duration,
 }
 
 #[cfg(test)]
@@ -112,6 +120,8 @@ impl AccountActorContext {
             db: db.clone(),
             request_tx,
             max_cycles: 1 << 18,
+            infra_failure_backoff_initial: Duration::from_millis(1),
+            infra_failure_backoff_max: Duration::from_millis(10),
         }
     }
 }
@@ -164,6 +174,25 @@ enum ActorMode {
     NoViableNotes,
     NotesAvailable,
     TransactionInflight(TransactionId),
+}
+
+/// Outcome of an `execute_transactions` call.
+///
+/// Distinguishes infrastructure failures (caller should sleep with backoff and retry the same
+/// notes without penalising them) from intrinsic failures (notes were marked failed and the
+/// caller should idle until something changes) and successful submission.
+#[derive(Debug)]
+enum ExecutionOutcome {
+    /// Transaction was submitted, the actor should wait for mempool confirmation.
+    Inflight(TransactionId),
+    /// The transaction batch is intrinsically bad (notes failed consumability, executor or local
+    /// prover rejected the witness, validator/block-producer rejected the content). Notes have
+    /// already been marked failed and the actor should idle.
+    IntrinsicFailure,
+    /// An infrastructure-level component failed (prover unreachable, validator/block-producer
+    /// transport error, our own checker erroring). Notes were *not* penalised and the actor should
+    /// sleep for the configured backoff and retry the same candidate.
+    InfrastructureFailure,
 }
 
 // ACCOUNT ACTOR
@@ -221,6 +250,15 @@ pub struct AccountActor {
     request_tx: mpsc::Sender<ActorRequest>,
     /// Maximum number of VM execution cycles for network transactions.
     max_cycles: u32,
+    /// Initial sleep after an infrastructure-classified failure. Used to rebuild the backoff
+    /// iterator on success.
+    infra_failure_backoff_initial: Duration,
+    /// Upper bound on the actor-level infra-failure backoff sleep.
+    infra_failure_backoff_max: Duration,
+    /// Exponential backoff applied at the actor level after consecutive infrastructure-classified
+    /// failures. Rebuilt on every successful submission / intrinsic failure so the next infra
+    /// outage starts from `infra_failure_backoff_initial` again.
+    infra_backoff: ExponentialBackoff,
 }
 
 impl AccountActor {
@@ -248,6 +286,12 @@ impl AccountActor {
             idle_timeout: actor_context.idle_timeout,
             request_tx: actor_context.request_tx.clone(),
             max_cycles: actor_context.max_cycles,
+            infra_failure_backoff_initial: actor_context.infra_failure_backoff_initial,
+            infra_failure_backoff_max: actor_context.infra_failure_backoff_max,
+            infra_backoff: build_infra_backoff(
+                actor_context.infra_failure_backoff_initial,
+                actor_context.infra_failure_backoff_max,
+            ),
         }
     }
 
@@ -327,7 +371,29 @@ impl AccountActor {
                     ).await?;
 
                     if let Some(tx_candidate) = tx_candidate {
-                        self.execute_transactions(account_id, tx_candidate).await;
+                        match self.execute_transactions(account_id, tx_candidate).await {
+                            ExecutionOutcome::Inflight(tx_id) => {
+                                self.reset_infra_backoff();
+                                self.mode = ActorMode::TransactionInflight(tx_id);
+                            },
+                            ExecutionOutcome::IntrinsicFailure => {
+                                self.reset_infra_backoff();
+                                self.mode = ActorMode::NoViableNotes;
+                            },
+                            ExecutionOutcome::InfrastructureFailure => {
+                                let sleep = self
+                                    .infra_backoff
+                                    .next()
+                                    .unwrap_or(self.infra_failure_backoff_max);
+                                tracing::warn!(
+                                    %account_id,
+                                    sleep_ms = sleep.as_millis() as u64,
+                                    "sleeping after infrastructure failure before retrying",
+                                );
+                                tokio::time::sleep(sleep).await;
+                                self.mode = ActorMode::NotesAvailable;
+                            },
+                        }
                     } else {
                         // No transactions to execute, wait for events.
                         self.mode = ActorMode::NoViableNotes;
@@ -378,13 +444,15 @@ impl AccountActor {
 
     /// Execute a transaction candidate and mark notes as failed as required.
     ///
-    /// Updates the state of the actor based on the execution result.
+    /// Returns an [`ExecutionOutcome`] which the caller maps to the next [`ActorMode`].
+    /// Infrastructure failures do *not* mark notes as failed and request the caller to sleep
+    /// before retrying the same candidate.
     #[tracing::instrument(name = "ntx.actor.execute_transactions", skip(self, tx_candidate))]
     async fn execute_transactions(
         &mut self,
         account_id: NetworkAccountId,
         tx_candidate: TransactionCandidate,
-    ) {
+    ) -> ExecutionOutcome {
         let block_num = tx_candidate.chain_tip_header.block_num();
 
         // Execute the selected transaction.
@@ -422,42 +490,26 @@ impl AccountActor {
                     let failed_notes = log_failed_notes(failed);
                     self.mark_notes_failed(&failed_notes, block_num).await;
                 }
-                self.mode = ActorMode::TransactionInflight(tx_id);
+                ExecutionOutcome::Inflight(tx_id)
             },
-            // Transaction execution failed.
-            Err(err) => {
-                let error_msg = err.as_report();
-                tracing::error!(
-                    %account_id,
-                    ?note_ids,
-                    err = %error_msg,
-                    "network transaction failed",
-                );
-                self.mode = ActorMode::NoViableNotes;
-
-                // For `AllNotesFailed`, use the per-note errors which contain the
-                // specific reason each note failed (e.g. consumability check details).
-                let failed_notes: Vec<_> = match err {
-                    execute::NtxError::AllNotesFailed(per_note) => log_failed_notes(per_note),
-                    other => {
-                        let error: NoteError = Arc::new(other);
-                        notes
-                            .iter()
-                            .map(|note| {
-                                tracing::info!(
-                                    note.id = %note.to_inner().as_note().id(),
-                                    nullifier = %note.nullifier(),
-                                    err = %error_msg,
-                                    "note failed: transaction execution error",
-                                );
-                                (note.nullifier(), error.clone())
-                            })
-                            .collect()
-                    },
-                };
-                self.mark_notes_failed(&failed_notes, block_num).await;
+            Err(err) => match classify_failure(account_id, &notes, err) {
+                FailureOutcome::Infrastructure => ExecutionOutcome::InfrastructureFailure,
+                FailureOutcome::Intrinsic(failed_notes) => {
+                    if !failed_notes.is_empty() {
+                        self.mark_notes_failed(&failed_notes, block_num).await;
+                    }
+                    ExecutionOutcome::IntrinsicFailure
+                },
             },
         }
+    }
+
+    /// Rebuilds the actor-local infra-failure backoff iterator so the next infra outage starts
+    /// from `infra_failure_backoff_initial`. Called after any successful submission or any
+    /// intrinsic failure.
+    fn reset_infra_backoff(&mut self) {
+        self.infra_backoff =
+            build_infra_backoff(self.infra_failure_backoff_initial, self.infra_failure_backoff_max);
     }
 
     /// Sends requests to the coordinator to cache note scripts fetched from the remote store.
@@ -515,4 +567,193 @@ fn log_failed_notes(failed: Vec<FailedNote>) -> Vec<(Nullifier, NoteError)> {
             (f.note.nullifier(), Arc::new(f.error) as NoteError)
         })
         .collect()
+}
+
+/// What the actor should do with a failed [`execute::NtxError`].
+#[derive(Debug)]
+enum FailureOutcome {
+    /// An infrastructure-level component failed (prover unreachable, validator/block-producer
+    /// transport error, our own checker erroring). Notes are *not* penalised and caller should
+    /// sleep for the configured backoff and retry the same candidate.
+    Infrastructure,
+    /// The transaction batch is intrinsically bad (notes failed consumability, executor or local
+    /// prover rejected the witness, validator/block-producer rejected the content). Caller should
+    /// mark the carried notes failed and idle.
+    Intrinsic(Vec<(Nullifier, NoteError)>),
+}
+
+/// Decides what to do with a failed [`execute::NtxError`]: which notes to mark failed, and the
+/// resulting [`FailureOutcome`].
+///
+/// - Infrastructure errors return `Infrastructure`: caller sleeps and retries.
+/// - Intrinsic `AllNotesFailed` returns per-note errors carried in the variant.
+/// - Any other intrinsic variant attributes the wrapped batch-level error to every note in the
+///   batch.
+fn classify_failure(
+    account_id: AccountId,
+    notes: &[InflightNetworkNote],
+    err: execute::NtxError,
+) -> FailureOutcome {
+    let error_msg = err.as_report();
+    let note_ids: Vec<_> = notes.iter().map(|n| n.to_inner().as_note().id()).collect();
+    match err.kind() {
+        ErrorKind::Infrastructure => {
+            tracing::warn!(
+                %account_id,
+                ?note_ids,
+                err = %error_msg,
+                "network transaction failed due to infrastructure error; notes not penalised, \
+                 will retry after backoff",
+            );
+            FailureOutcome::Infrastructure
+        },
+        ErrorKind::Intrinsic => {
+            tracing::error!(
+                %account_id,
+                ?note_ids,
+                err = %error_msg,
+                "network transaction failed",
+            );
+            let failed_notes: Vec<_> = match err {
+                execute::NtxError::AllNotesFailed(per_note) => log_failed_notes(per_note),
+                other => {
+                    let error: NoteError = Arc::new(other);
+                    notes
+                        .iter()
+                        .map(|note| {
+                            tracing::info!(
+                                note.id = %note.to_inner().as_note().id(),
+                                nullifier = %note.nullifier(),
+                                err = %error_msg,
+                                "note failed: transaction execution error",
+                            );
+                            (note.nullifier(), error.clone())
+                        })
+                        .collect()
+                },
+            };
+            FailureOutcome::Intrinsic(failed_notes)
+        },
+    }
+}
+
+/// Builds the [`ExponentialBackoff`] used at the actor level after infrastructure-classified
+/// failures.
+fn build_infra_backoff(initial: Duration, max: Duration) -> ExponentialBackoff {
+    ExponentialBuilder::default()
+        .with_min_delay(initial)
+        .with_max_delay(max)
+        .with_factor(2.0)
+        .without_max_times()
+        .with_jitter()
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use miden_tx::{TransactionExecutorError, TransactionProverError};
+
+    use super::{FailureOutcome, build_infra_backoff, classify_failure, execute};
+    use crate::inflight_note::InflightNetworkNote;
+    use crate::test_utils::{mock_network_account_id, mock_single_target_note};
+
+    #[test]
+    fn infra_backoff_is_bounded_and_unbounded_in_length() {
+        let initial = Duration::from_secs(1);
+        let max = Duration::from_secs(30);
+        let upper_with_jitter = max.saturating_mul(2);
+        let mut backoff = build_infra_backoff(initial, max);
+
+        for _ in 0..50 {
+            let delay = backoff.next().expect("backoff should be unbounded");
+            assert!(
+                delay <= upper_with_jitter,
+                "delay {delay:?} exceeds {upper_with_jitter:?} (max + jitter)",
+            );
+        }
+    }
+
+    /// Returns 3 distinct mock notes targeting the same account.
+    fn mock_notes() -> Vec<InflightNetworkNote> {
+        let account = mock_network_account_id();
+        (0u8..3)
+            .map(|seed| InflightNetworkNote::new(mock_single_target_note(account, seed)))
+            .collect()
+    }
+
+    fn mock_account_id() -> miden_protocol::account::AccountId {
+        mock_network_account_id().inner()
+    }
+
+    /// Infrastructure errors return `Infrastructure`, no notes are penalised.
+    #[test]
+    fn classify_failure_infra_skips_marking_notes() {
+        let notes = mock_notes();
+        let cases: Vec<execute::NtxError> = vec![
+            execute::NtxError::Submission(tonic::Status::unavailable("bp down")),
+            execute::NtxError::Submission(tonic::Status::deadline_exceeded("timeout")),
+            execute::NtxError::Submission(tonic::Status::internal("internal")),
+            execute::NtxError::Proving(TransactionProverError::other("remote prover unreachable")),
+            execute::NtxError::NoteFilter(miden_tx::NoteCheckerError::InputNoteCountOutOfRange(0)),
+            execute::NtxError::InputNotes(
+                miden_protocol::errors::TransactionInputError::TooManyInputNotes(usize::MAX),
+            ),
+        ];
+        for err in cases {
+            let display = format!("{err:?}");
+            let outcome = classify_failure(mock_account_id(), &notes, err);
+            assert!(
+                matches!(outcome, FailureOutcome::Infrastructure),
+                "expected Infrastructure for `{display}`, got {outcome:?}",
+            );
+        }
+    }
+
+    /// `Submission` with a content-rejection code (`InvalidArgument`) is intrinsic, every note
+    /// in the batch is marked failed with the same wrapped error.
+    #[test]
+    fn classify_failure_submission_invalid_argument_marks_all_notes() {
+        let notes = mock_notes();
+        let err = execute::NtxError::Submission(tonic::Status::invalid_argument("bad tx"));
+        let outcome = classify_failure(mock_account_id(), &notes, err);
+        let FailureOutcome::Intrinsic(failed) = outcome else {
+            panic!("expected Intrinsic, got {outcome:?}");
+        };
+        assert_eq!(failed.len(), notes.len(), "all notes should be marked failed");
+        for note in &notes {
+            assert!(
+                failed.iter().any(|(n, _)| *n == note.nullifier()),
+                "missing nullifier {} in failed list",
+                note.nullifier(),
+            );
+        }
+    }
+
+    /// A structured (non-`Other`) `Execution` variant is intrinsic, the local execution rejected
+    /// the batch, so all notes are marked failed.
+    #[test]
+    fn classify_failure_local_execution_marks_all_notes() {
+        let notes = mock_notes();
+        let err = execute::NtxError::Execution(TransactionExecutorError::FeeAssetMustBeFungible);
+        let outcome = classify_failure(mock_account_id(), &notes, err);
+        let FailureOutcome::Intrinsic(failed) = outcome else {
+            panic!("expected Intrinsic, got {outcome:?}");
+        };
+        assert_eq!(failed.len(), notes.len());
+    }
+
+    /// `AllNotesFailed` carries its own per-note attribution, so an empty per-note vec produces
+    /// no DB updates while still being intrinsic.
+    #[test]
+    fn classify_failure_all_notes_failed_uses_per_note_attribution() {
+        let notes = mock_notes();
+        let err = execute::NtxError::AllNotesFailed(Vec::new());
+        let outcome = classify_failure(mock_account_id(), &notes, err);
+        let FailureOutcome::Intrinsic(failed) = outcome else {
+            panic!("expected Intrinsic, got {outcome:?}");
+        };
+        assert!(failed.is_empty());
+    }
 }

--- a/crates/ntx-builder/src/actor/mod.rs
+++ b/crates/ntx-builder/src/actor/mod.rs
@@ -174,17 +174,6 @@ enum ActorMode {
     TransactionInflight(TransactionId),
 }
 
-/// Outcome of an `execute_transactions` call.
-#[derive(Debug)]
-enum ExecutionOutcome {
-    /// Transaction was submitted, the actor should wait for mempool confirmation.
-    Inflight(TransactionId),
-    /// Transaction execution failed. Transient infrastructure failures have already been retried
-    /// inside `execute_transaction`, so any error reaching the actor is terminal for this
-    /// candidate.
-    Failure,
-}
-
 // ACCOUNT ACTOR
 // ================================================================================================
 
@@ -353,13 +342,13 @@ impl AccountActor {
 
                     if let Some(tx_candidate) = tx_candidate {
                         match self.execute_transactions(account_id, tx_candidate).await {
-                            ExecutionOutcome::Inflight(tx_id) => {
+                            Ok(tx_id) => {
                                 self.mode = ActorMode::TransactionInflight(tx_id);
                             },
                             // The batch failed terminally: offending notes have been marked
                             // failed; let the next loop iteration re-query the DB to decide
                             // whether anything remains to consume for this account.
-                            ExecutionOutcome::Failure => {
+                            Err(_) => {
                                 self.mode = ActorMode::NotesAvailable;
                             },
                         }
@@ -422,7 +411,7 @@ impl AccountActor {
         &mut self,
         account_id: NetworkAccountId,
         tx_candidate: TransactionCandidate,
-    ) -> ExecutionOutcome {
+    ) -> Result<TransactionId, ()> {
         let block_num = tx_candidate.chain_tip_header.block_num();
 
         // Execute the selected transaction.
@@ -462,7 +451,7 @@ impl AccountActor {
                     let failed_notes = log_failed_notes(failed);
                     self.mark_notes_failed(&failed_notes, block_num).await;
                 }
-                ExecutionOutcome::Inflight(tx_id)
+                Ok(tx_id)
             },
             Err(err) => {
                 let error_msg = err.as_report();
@@ -493,7 +482,7 @@ impl AccountActor {
                 if !failed_notes.is_empty() {
                     self.mark_notes_failed(&failed_notes, block_num).await;
                 }
-                ExecutionOutcome::Failure
+                Err(())
             },
         }
     }

--- a/crates/ntx-builder/src/clients/mod.rs
+++ b/crates/ntx-builder/src/clients/mod.rs
@@ -3,5 +3,5 @@ mod store;
 mod validator;
 
 pub use block_producer::BlockProducerClient;
-pub use store::StoreClient;
+pub use store::{StoreClient, StoreError};
 pub use validator::ValidatorClient;

--- a/crates/ntx-builder/src/lib.rs
+++ b/crates/ntx-builder/src/lib.rs
@@ -70,7 +70,7 @@ const DEFAULT_MAX_ACCOUNT_CRASHES: usize = 10;
 /// Default initial sleep applied between per-request retries on transient infrastructure failures
 /// (downed prover, transport error, validator/block-producer crash, store gRPC hiccup). Doubles
 /// on each retry up to [`DEFAULT_REQUEST_BACKOFF_MAX`].
-const DEFAULT_REQUEST_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+const DEFAULT_REQUEST_BACKOFF_INITIAL: Duration = Duration::from_millis(100);
 
 /// Default upper bound on the per-request retry backoff sleep.
 const DEFAULT_REQUEST_BACKOFF_MAX: Duration = Duration::from_secs(30);

--- a/crates/ntx-builder/src/lib.rs
+++ b/crates/ntx-builder/src/lib.rs
@@ -67,6 +67,15 @@ const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// Default maximum number of crashes an account actor is allowed before being deactivated.
 const DEFAULT_MAX_ACCOUNT_CRASHES: usize = 10;
 
+/// Default initial sleep applied at the actor level after an infrastructure-classified failure
+/// (downed prover, transport error, validator/block-producer crash). Doubles on each consecutive
+/// infra failure up to [`DEFAULT_INFRA_FAILURE_BACKOFF_MAX`]. Resets on the next successful
+/// transaction.
+const DEFAULT_INFRA_FAILURE_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+
+/// Default upper bound on the actor-level infra-failure backoff sleep.
+const DEFAULT_INFRA_FAILURE_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
 /// Default maximum number of VM execution cycles allowed for a network transaction.
 ///
 /// This limits the computational cost of network transactions. The protocol maximum is
@@ -131,6 +140,15 @@ pub struct NtxBuilderConfig {
     /// Defaults to 2^18 cycles.
     pub max_cycles: u32,
 
+    /// Initial actor-level sleep after an infrastructure-classified failure (e.g. prover
+    /// unreachable, validator/block-producer crash, transport error). Doubles on each consecutive
+    /// infra failure up to [`Self::infra_failure_backoff_max`] and resets on success. Per-note
+    /// `attempt_count` is *not* advanced for infra failures.
+    pub infra_failure_backoff_initial: Duration,
+
+    /// Upper bound on the actor-level infra-failure backoff sleep.
+    pub infra_failure_backoff_max: Duration,
+
     /// Path to the SQLite database file used for persistent state.
     pub database_filepath: PathBuf,
 }
@@ -156,6 +174,8 @@ impl NtxBuilderConfig {
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             max_account_crashes: DEFAULT_MAX_ACCOUNT_CRASHES,
             max_cycles: DEFAULT_MAX_TX_CYCLES,
+            infra_failure_backoff_initial: DEFAULT_INFRA_FAILURE_BACKOFF_INITIAL,
+            infra_failure_backoff_max: DEFAULT_INFRA_FAILURE_BACKOFF_MAX,
             database_filepath,
         }
     }
@@ -244,6 +264,14 @@ impl NtxBuilderConfig {
         self
     }
 
+    /// Sets the actor-level infra-failure backoff bounds (initial sleep and cap).
+    #[must_use]
+    pub fn with_infra_failure_backoff(mut self, initial: Duration, max: Duration) -> Self {
+        self.infra_failure_backoff_initial = initial;
+        self.infra_failure_backoff_max = max;
+        self
+    }
+
     /// Builds and initializes the network transaction builder.
     ///
     /// This method connects to the store and block producer services, fetches the current
@@ -307,6 +335,8 @@ impl NtxBuilderConfig {
             db: db.clone(),
             request_tx,
             max_cycles: self.max_cycles,
+            infra_failure_backoff_initial: self.infra_failure_backoff_initial,
+            infra_failure_backoff_max: self.infra_failure_backoff_max,
         };
 
         Ok(NetworkTransactionBuilder::new(

--- a/crates/ntx-builder/src/lib.rs
+++ b/crates/ntx-builder/src/lib.rs
@@ -67,14 +67,13 @@ const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// Default maximum number of crashes an account actor is allowed before being deactivated.
 const DEFAULT_MAX_ACCOUNT_CRASHES: usize = 10;
 
-/// Default initial sleep applied at the actor level after an infrastructure-classified failure
-/// (downed prover, transport error, validator/block-producer crash). Doubles on each consecutive
-/// infra failure up to [`DEFAULT_INFRA_FAILURE_BACKOFF_MAX`]. Resets on the next successful
-/// transaction.
-const DEFAULT_INFRA_FAILURE_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+/// Default initial sleep applied between per-request retries on transient infrastructure failures
+/// (downed prover, transport error, validator/block-producer crash, store gRPC hiccup). Doubles
+/// on each retry up to [`DEFAULT_REQUEST_BACKOFF_MAX`].
+const DEFAULT_REQUEST_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
 
-/// Default upper bound on the actor-level infra-failure backoff sleep.
-const DEFAULT_INFRA_FAILURE_BACKOFF_MAX: Duration = Duration::from_secs(30);
+/// Default upper bound on the per-request retry backoff sleep.
+const DEFAULT_REQUEST_BACKOFF_MAX: Duration = Duration::from_secs(30);
 
 /// Default maximum number of VM execution cycles allowed for a network transaction.
 ///
@@ -140,14 +139,14 @@ pub struct NtxBuilderConfig {
     /// Defaults to 2^18 cycles.
     pub max_cycles: u32,
 
-    /// Initial actor-level sleep after an infrastructure-classified failure (e.g. prover
-    /// unreachable, validator/block-producer crash, transport error). Doubles on each consecutive
-    /// infra failure up to [`Self::infra_failure_backoff_max`] and resets on success. Per-note
-    /// `attempt_count` is *not* advanced for infra failures.
-    pub infra_failure_backoff_initial: Duration,
+    /// Initial sleep applied between per-request retries on transient infrastructure failures
+    /// (e.g. prover unreachable, validator/block-producer crash, transport error, store gRPC
+    /// hiccup). Doubles on each retry up to [`Self::request_backoff_max`]. Per-note
+    /// `attempt_count` is *not* advanced while retries are in progress.
+    pub request_backoff_initial: Duration,
 
-    /// Upper bound on the actor-level infra-failure backoff sleep.
-    pub infra_failure_backoff_max: Duration,
+    /// Upper bound on the per-request retry backoff sleep.
+    pub request_backoff_max: Duration,
 
     /// Path to the SQLite database file used for persistent state.
     pub database_filepath: PathBuf,
@@ -174,8 +173,8 @@ impl NtxBuilderConfig {
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
             max_account_crashes: DEFAULT_MAX_ACCOUNT_CRASHES,
             max_cycles: DEFAULT_MAX_TX_CYCLES,
-            infra_failure_backoff_initial: DEFAULT_INFRA_FAILURE_BACKOFF_INITIAL,
-            infra_failure_backoff_max: DEFAULT_INFRA_FAILURE_BACKOFF_MAX,
+            request_backoff_initial: DEFAULT_REQUEST_BACKOFF_INITIAL,
+            request_backoff_max: DEFAULT_REQUEST_BACKOFF_MAX,
             database_filepath,
         }
     }
@@ -264,11 +263,12 @@ impl NtxBuilderConfig {
         self
     }
 
-    /// Sets the actor-level infra-failure backoff bounds (initial sleep and cap).
+    /// Sets the per-request retry backoff bounds (initial sleep and cap) used when retrying
+    /// transient infrastructure failures inside a single transaction attempt.
     #[must_use]
-    pub fn with_infra_failure_backoff(mut self, initial: Duration, max: Duration) -> Self {
-        self.infra_failure_backoff_initial = initial;
-        self.infra_failure_backoff_max = max;
+    pub fn with_request_backoff(mut self, initial: Duration, max: Duration) -> Self {
+        self.request_backoff_initial = initial;
+        self.request_backoff_max = max;
         self
     }
 
@@ -335,8 +335,8 @@ impl NtxBuilderConfig {
             db: db.clone(),
             request_tx,
             max_cycles: self.max_cycles,
-            infra_failure_backoff_initial: self.infra_failure_backoff_initial,
-            infra_failure_backoff_max: self.infra_failure_backoff_max,
+            request_backoff_initial: self.request_backoff_initial,
+            request_backoff_max: self.request_backoff_max,
         };
 
         Ok(NetworkTransactionBuilder::new(


### PR DESCRIPTION
closes #2052.

The NTX builder was permanently dropping notes after a run of unrelated infrastructure failures because every error type counted against the per-note `max_note_attempts` cap.

This PR classifies `NtxError` into infrastructure vs. intrinsic. Infra failures now retry the same candidate after a exponential backoff (using `backon`) without touching per-note state. Intrinsic failures keep the existing behaviour.

This PR also introduces a dependency for backoff, `backon`, and note that I didn't used the `retry` feature (probably the most important part) because we use a `tokio::select!` that needs to interleave several other things around each retry. Making use of retry will require further "plumbing" changes. 