### PR TITLE
chore: re-enable SyncState and SyncNullifier traces

### DIFF
--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -21,20 +21,12 @@ pub fn grpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
 
     // Create a span with a generic, static name. Fields to be recorded after needs to be
     // initialized as empty since otherwise the assignment will have no effect.
-    let span = match method {
-        "SyncState" | "SyncNullifiers" => tracing::debug_span!(
-            "rpc",
-            otel.name = field::Empty,
-            rpc.service = service,
-            rpc.method = method
-        ),
-        _ => tracing::info_span!(
-            "rpc",
-            otel.name = field::Empty,
-            rpc.service = service,
-            rpc.method = method
-        ),
-    };
+    let span = tracing::info_span!(
+        "rpc",
+        otel.name = field::Empty,
+        rpc.service = service,
+        rpc.method = method
+    );
 
     // Set the span name via otel.name
     let otel_name = format!("{service}/{method}");


### PR DESCRIPTION
These were extremely noisy and pseudo-disabled by setting them to `debug` level.

We now have samplers available to quieten noisy traces in production, so this is no longer required.