### PR TITLE
fix(store): improve `inner` locking

### DIFF
--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -333,7 +333,6 @@ impl State {
         &self,
         block_num: Option<BlockNumber>,
     ) -> Result<Option<(BlockHeader, MmrPeaks)>, GetCurrentBlockchainDataError> {
-        let blockchain = &self.inner.read().await.blockchain;
         if let Some(number) = block_num
             && number == self.chain_tip(Finality::Committed).await
         {
@@ -348,6 +347,8 @@ impl State {
             .await
             .map_err(GetCurrentBlockchainDataError::ErrorRetrievingBlockHeader)?
             .unwrap();
+
+        let blockchain = &self.inner.read().await.blockchain;
         let peaks = blockchain
             .peaks_at(block_header.block_num())
             .map_err(GetCurrentBlockchainDataError::InvalidPeaks)?;
@@ -623,31 +624,35 @@ impl State {
     ) -> Result<TransactionInputs, DatabaseError> {
         info!(target: COMPONENT, account_id = %account_id.to_string(), nullifiers = %format_array(nullifiers));
 
-        let inner = self.inner.read().await;
+        let (account_commitment, nullifiers, new_account_id_prefix_is_unique) = {
+            let inner = self.inner.read().await;
 
-        let account_commitment = inner.account_tree.get_latest_commitment(account_id);
+            let account_commitment = inner.account_tree.get_latest_commitment(account_id);
 
-        let new_account_id_prefix_is_unique = if account_commitment.is_empty() {
-            Some(!inner.account_tree.contains_account_id_prefix_in_latest(account_id.prefix()))
-        } else {
-            None
+            let new_account_id_prefix_is_unique = if account_commitment.is_empty() {
+                Some(!inner.account_tree.contains_account_id_prefix_in_latest(account_id.prefix()))
+            } else {
+                None
+            };
+
+            // Non-unique account Id prefixes for new accounts are not allowed.
+            if let Some(false) = new_account_id_prefix_is_unique {
+                return Ok(TransactionInputs {
+                    new_account_id_prefix_is_unique,
+                    ..Default::default()
+                });
+            }
+
+            let nullifiers = nullifiers
+                .iter()
+                .map(|nullifier| NullifierInfo {
+                    nullifier: *nullifier,
+                    block_num: inner.nullifier_tree.get_block_num(nullifier).unwrap_or_default(),
+                })
+                .collect();
+
+            (account_commitment, nullifiers, new_account_id_prefix_is_unique)
         };
-
-        // Non-unique account Id prefixes for new accounts are not allowed.
-        if let Some(false) = new_account_id_prefix_is_unique {
-            return Ok(TransactionInputs {
-                new_account_id_prefix_is_unique,
-                ..Default::default()
-            });
-        }
-
-        let nullifiers = nullifiers
-            .iter()
-            .map(|nullifier| NullifierInfo {
-                nullifier: *nullifier,
-                block_num: inner.nullifier_tree.get_block_num(nullifier).unwrap_or_default(),
-            })
-            .collect();
 
         let found_unauthenticated_notes = self
             .db

--- a/crates/store/src/state/sync_state.rs
+++ b/crates/store/src/state/sync_state.rs
@@ -101,14 +101,14 @@ impl State {
 
         let mut results = Vec::new();
 
-        for note_sync in note_syncs {
-            let mmr_proof = self
-                .inner
-                .read()
-                .await
-                .blockchain
-                .open_at(note_sync.block_header.block_num(), mmr_checkpoint)?;
-            results.push((note_sync, mmr_proof));
+        {
+            let inner = self.inner.read().await;
+
+            for note_sync in note_syncs {
+                let mmr_proof =
+                    inner.blockchain.open_at(note_sync.block_header.block_num(), mmr_checkpoint)?;
+                results.push((note_sync, mmr_proof));
+            }
         }
 
         // if results is empty, return `block_end` since the sync is complete.


### PR DESCRIPTION
There were two potential issues with the `inner` RwLock:

- `get_current_blockchain_data()` was holding a read lock while doing an SQLite query
- `sync_notes()` was re-acquiring the read lock while iterating over the blocks returned by the SQLite query

Both of these are trivial to fix.

The `sync_notes()` change has a measurable impact on the `sync-notes` benchmark of the stress test tool.

Before:

```
$ target/release/miden-node-stress-test benchmark-store -d /tmp/data --iterations 100000 --concurrency 8 sync-notes

Average request latency: 10.812451ms
P50 request latency: 10.48458ms
P95 request latency: 13.529188ms
P99 request latency: 15.948132ms
P99.9 request latency: 18.202669ms
1163.92user 174.37system 2:48.13elapsed 795%CPU (0avgtext+0avgdata 7712336maxresident)k
0inputs+0outputs (0major+282324minor)pagefaults 0swaps
```

After:

```
$ target/release/miden-node-stress-test benchmark-store -d /tmp/data --iterations 100000 --concurrency 8 sync-notes

Average request latency: 10.448098ms
P50 request latency: 10.084526ms
P95 request latency: 13.177924ms
P99 request latency: 15.408491ms
P99.9 request latency: 17.614128ms
856.57user 153.57system 2:11.52elapsed 768%CPU (0avgtext+0avgdata 2206476maxresident)k
0inputs+0outputs (0major+26126minor)pagefaults 0swaps
```