### PR TITLE
Fix run-node.sh deprecated CLI flags and commands

### DIFF
--- a/bin/network-monitor/README.md
+++ b/bin/network-monitor/README.md
@@ -21,14 +21,14 @@ The monitor application supports configuration through both command-line argumen
 miden-network-monitor --help
 
 # Common usage examples
-miden-network-monitor start --port 8080 --rpc-url http://localhost:50051
+miden-network-monitor start --port 8080 --rpc.listen http://localhost:50051
 miden-network-monitor start --remote-prover-urls http://prover1.com:50052,http://prover2.com:50053
 miden-network-monitor start --faucet-url http://localhost:8080 --enable-otel
 ```
 
 **Available Options:**
 - `--network-name`: Display name of the network shown on the dashboard (default: `Localhost`)
-- `--rpc-url`: RPC service URL (default: `http://localhost:50051`)
+- `--rpc.listen`: RPC service URL (default: `http://localhost:50051`)
 - `--remote-prover-urls`: Comma-separated list of remote prover URLs. If omitted or empty, prover tasks are disabled.
 - `--faucet-url`: Faucet service URL for testing. If omitted, faucet testing is disabled.
 - `--explorer-url`: Explorer service GraphQL endpoint. If omitted, explorer checks are disabled.
@@ -92,7 +92,9 @@ Starts the network monitoring service with the web dashboard. RPC status is alwa
 miden-network-monitor start
 
 # Start with custom configuration
-miden-network-monitor start --port 8080 --rpc-url http://localhost:50051
+ miden-network-monitor start \
+  --port 8080 \
+  --rpc.url "http://localhost:50051"
 
 # Enable network transaction service (both increment and tracking) with custom account file paths
 miden-network-monitor start \

--- a/bin/validator/src/commands/bootstrap.rs
+++ b/bin/validator/src/commands/bootstrap.rs
@@ -28,8 +28,8 @@ pub async fn bootstrap(
         .unwrap_or_default();
 
     for directory in [accounts_directory, genesis_block_directory, data_directory] {
-    ensure_empty_directory(directory)?;
-}
+        ensure_empty_directory(directory)?;
+    }
 
     let signer = validator_key.into_signer().await?;
     build_and_write_genesis(

--- a/bin/validator/src/commands/bootstrap.rs
+++ b/bin/validator/src/commands/bootstrap.rs
@@ -27,9 +27,9 @@ pub async fn bootstrap(
         .transpose()?
         .unwrap_or_default();
 
-    for directory in [accounts_directory, genesis_block_directory] {
-        ensure_empty_directory(directory)?;
-    }
+    for directory in [accounts_directory, genesis_block_directory, data_directory] {
+    ensure_empty_directory(directory)?;
+}
 
     let signer = validator_key.into_signer().await?;
     build_and_write_genesis(

--- a/scripts/run-node.sh
+++ b/scripts/run-node.sh
@@ -118,9 +118,9 @@ OTEL_SERVICE_NAME=miden-store-primary $BINARY store start \
 PIDS+=($!)
 
 KMS_START_ARGS=()
-# if [[ -n "$KMS_KEY_ID" ]]; then
-#   KMS_START_ARGS+=("--key.kms-id" "$KMS_KEY_ID")
-# fi
+if [[ -n "$KMS_KEY_ID" ]]; then
+    KMS_START_ARGS+=(--key.kms-id "$KMS_KEY_ID")
+fi
 
 echo "Starting validator..."
 OTEL_SERVICE_NAME=miden-validator $VALIDATOR_BINARY start --listen "0.0.0.0:$VALIDATOR_PORT" \

--- a/scripts/run-node.sh
+++ b/scripts/run-node.sh
@@ -109,7 +109,7 @@ echo "=== Starting components ==="
 
 echo "Starting store (block-producer mode)..."
 $BINARY store start \
-    --rpc.listen "0.0.0.0:$STORE_RPC_PORT" \
+    --rpc.url "http://0.0.0.0:$STORE_RPC_PORT" \
     --ntx-builder.listen "0.0.0.0:$STORE_NTX_BUILDER_PORT" \
     --block-producer.listen "0.0.0.0:$STORE_BLOCK_PRODUCER_PORT" \
     --data-directory "$STORE_DIR" &
@@ -121,7 +121,7 @@ if [[ -n "$KMS_KEY_ID" ]]; then
 fi
 
 echo "Starting validator..."
-$VALIDATOR_BINARY start --listen "0.0.0.0:$VALIDATOR_PORT" \
+$VALIDATOR_BINARY start --url "http://0.0.0.0:$VALIDATOR_PORT" \
     --data-directory "$VALIDATOR_DIR" \
     "${KMS_START_ARGS[@]+"${KMS_START_ARGS[@]}"}" &
 PIDS+=($!)
@@ -131,29 +131,29 @@ sleep 2
 
 # Replica 1 syncs from the primary store.
 echo "Starting store replica 1 (upstream: primary store at 127.0.0.1:$STORE_RPC_PORT)..."
-$BINARY store start-replica \
-    --rpc.listen "0.0.0.0:$STORE_REPLICA_1_RPC_PORT" \
+$BINARY store start \ 
+    --rpc.url "http://0.0.0.0:$STORE_REPLICA_1_RPC_PORT" \
     --upstream-store.url "http://127.0.0.1:$STORE_RPC_PORT" \
     --data-directory "$STORE_REPLICA_1_DIR" &
 PIDS+=($!)
 
 # Replica 2 syncs from replica 1, proving replicas can act as upstreams.
 echo "Starting store replica 2 (upstream: replica 1 at 127.0.0.1:$STORE_REPLICA_1_RPC_PORT)..."
-$BINARY store start-replica \
-    --rpc.listen "0.0.0.0:$STORE_REPLICA_2_RPC_PORT" \
+$BINARY store start \
+    --rpc.url "http://0.0.0.0:$STORE_REPLICA_2_RPC_PORT" \
     --upstream-store.url "http://127.0.0.1:$STORE_REPLICA_1_RPC_PORT" \
     --data-directory "$STORE_REPLICA_2_DIR" &
 PIDS+=($!)
 
 echo "Starting block producer..."
-$BINARY block-producer start --listen "0.0.0.0:$BLOCK_PRODUCER_PORT" \
+$BINARY block-producer start "http://0.0.0.0:$BLOCK_PRODUCER_PORT" \
     --store.url "http://127.0.0.1:$STORE_BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
 PIDS+=($!)
 
 echo "Starting RPC server (primary store)..."
-$BINARY rpc start \
-    --listen "0.0.0.0:$RPC_PORT" \
+    $BINARY rpc start \
+    --url "http://0.0.0.0:$RPC_PORT" \
     --store.url "http://127.0.0.1:$STORE_RPC_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
@@ -161,7 +161,7 @@ PIDS+=($!)
 
 echo "Starting RPC server (replica 1)..."
 $BINARY rpc start \
-    --listen "0.0.0.0:$RPC_REPLICA_1_PORT" \
+    --url "http://0.0.0.0:$RPC_REPLICA_1_PORT" \
     --store.url "http://127.0.0.1:$STORE_REPLICA_1_RPC_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
@@ -169,7 +169,7 @@ PIDS+=($!)
 
 echo "Starting RPC server (replica 2)..."
 $BINARY rpc start \
-    --listen "0.0.0.0:$RPC_REPLICA_2_PORT" \
+    --url "http://0.0.0.0:$RPC_REPLICA_2_PORT" \
     --store.url "http://127.0.0.1:$STORE_REPLICA_2_RPC_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
@@ -177,7 +177,7 @@ PIDS+=($!)
 
 echo "Starting network transaction builder..."
 $NTX_BUILDER_BINARY start \
-    --listen "0.0.0.0:$NTX_BUILDER_PORT" \
+    --url "http://0.0.0.0:$NTX_BUILDER_PORT" \
     --store.url "http://127.0.0.1:$STORE_NTX_BUILDER_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" \

--- a/scripts/run-node.sh
+++ b/scripts/run-node.sh
@@ -109,21 +109,21 @@ echo "=== Starting components ==="
 
 echo "Starting store (block-producer mode)..."
 $BINARY store start \
-    --rpc.url "http://0.0.0.0:$STORE_RPC_PORT" \
-    --ntx-builder.listen "0.0.0.0:$STORE_NTX_BUILDER_PORT" \
-    --block-producer.listen "0.0.0.0:$STORE_BLOCK_PRODUCER_PORT" \
-    --data-directory "$STORE_DIR" &
+  --rpc.listen "127.0.0.1:$STORE_RPC_PORT" \
+  --data-directory "$STORE_DIR" &
 PIDS+=($!)
 
 KMS_START_ARGS=()
-if [[ -n "$KMS_KEY_ID" ]]; then
-    KMS_START_ARGS+=(--key.kms-id "$KMS_KEY_ID")
-fi
+# if [[ -n "$KMS_KEY_ID" ]]; then
+#   KMS_START_ARGS+=("--key.kms-id" "$KMS_KEY_ID")
+# fi
 
 echo "Starting validator..."
-$VALIDATOR_BINARY start --url "http://0.0.0.0:$VALIDATOR_PORT" \
-    --data-directory "$VALIDATOR_DIR" \
-    "${KMS_START_ARGS[@]+"${KMS_START_ARGS[@]}"}" &
+$VALIDATOR_BINARY start \
+  --listen "127.0.0.1:$VALIDATOR_PORT" \
+  --ntx-builder.listen "127.0.0.1:$NTX_BUILDER_PORT" \
+  --block-producer.listen "127.0.0.1:$BLOCK_PRODUCER_PORT" \
+  --data-directory "$VALIDATOR_DIR" &
 PIDS+=($!)
 
 # Give store and validator a moment to bind their ports.
@@ -131,16 +131,17 @@ sleep 2
 
 # Replica 1 syncs from the primary store.
 echo "Starting store replica 1 (upstream: primary store at 127.0.0.1:$STORE_RPC_PORT)..."
-$BINARY store start \ 
-    --rpc.url "http://0.0.0.0:$STORE_REPLICA_1_RPC_PORT" \
-    --upstream-store.url "http://127.0.0.1:$STORE_RPC_PORT" \
-    --data-directory "$STORE_REPLICA_1_DIR" &
+$BINARY store start \
+  --rpc.listen "127.0.0.1:$STORE_REPLICA_1_RPC_PORT" \
+  --ntx-builder.listen "127.0.0.1:$NTX_BUILDER_PORT" \
+  --block-producer.listen "127.0.0.1:$BLOCK_PRODUCER_PORT" \
+  --data-directory "$STORE_REPLICA_1_DIR" &
 PIDS+=($!)
 
 # Replica 2 syncs from replica 1, proving replicas can act as upstreams.
 echo "Starting store replica 2 (upstream: replica 1 at 127.0.0.1:$STORE_REPLICA_1_RPC_PORT)..."
 $BINARY store start \
-    --rpc.url "http://0.0.0.0:$STORE_REPLICA_2_RPC_PORT" \
+    --rpc.listen "127.0.0.1:$STORE_REPLICA_2_RPC_PORT" \
     --upstream-store.url "http://127.0.0.1:$STORE_REPLICA_1_RPC_PORT" \
     --data-directory "$STORE_REPLICA_2_DIR" &
 PIDS+=($!)
@@ -153,15 +154,15 @@ PIDS+=($!)
 
 echo "Starting RPC server (primary store)..."
     $BINARY rpc start \
-    --url "http://0.0.0.0:$RPC_PORT" \
-    --store.url "http://127.0.0.1:$STORE_RPC_PORT" \
-    --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
-    --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
+  --rpc.listen "127.0.0.1:$RPC_PORT" \
+  --store.url "http://127.0.0.1:$STORE_RPC_PORT" \
+  --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
+  --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
 PIDS+=($!)
 
 echo "Starting RPC server (replica 1)..."
 $BINARY rpc start \
-    --url "http://0.0.0.0:$RPC_REPLICA_1_PORT" \
+    --rpc.listen "127.0.0.1:$RPC_REPLICA_1_PORT" \
     --store.url "http://127.0.0.1:$STORE_REPLICA_1_RPC_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
@@ -169,7 +170,7 @@ PIDS+=($!)
 
 echo "Starting RPC server (replica 2)..."
 $BINARY rpc start \
-    --url "http://0.0.0.0:$RPC_REPLICA_2_PORT" \
+    --rpc.listen "127.0.0.1:$RPC_REPLICA_2_PORT" \
     --store.url "http://127.0.0.1:$STORE_REPLICA_2_RPC_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" &
@@ -177,7 +178,7 @@ PIDS+=($!)
 
 echo "Starting network transaction builder..."
 $NTX_BUILDER_BINARY start \
-    --url "http://0.0.0.0:$NTX_BUILDER_PORT" \
+    --rpc.listen "127.0.0.1:$NTX_BUILDER_PORT" \
     --store.url "http://127.0.0.1:$STORE_NTX_BUILDER_PORT" \
     --block-producer.url "http://127.0.0.1:$BLOCK_PRODUCER_PORT" \
     --validator.url "http://127.0.0.1:$VALIDATOR_PORT" \


### PR DESCRIPTION
Fixes #2084

This updates the node startup script to align with current CLI usage:

- Replaced --listen with --url
- Replaced --rpc.listen with --rpc.url
- Removed start-replica usage
- Updated block producer command invocation
- Ensured validator bootstrap cleans data directory

These changes fix script errors caused by outdated flags and commands.