### PR TITLE
docs: fix grammar errors and typos in node documentation

### DIFF
--- a/docs/external/src/operator/architecture.md
+++ b/docs/external/src/operator/architecture.md
@@ -49,7 +49,7 @@ it is also possible to perform proving in-process. This is useful when running a
 
 The network transaction builder monitors the mempool for network notes, and creates transactions consuming these.
 We call these network transactions and at present this is the only entity that is allowed to create such transactions.
-This restriction is will be lifted in the future, but for now this component _must_ be enabled to have support for
+This restriction will be lifted in the future, but for now this component _must_ be enabled to have support for
 network transactions.
 
 The mempool is monitored via a gRPC event stream served by the block-producer.

--- a/docs/external/src/operator/installation.md
+++ b/docs/external/src/operator/installation.md
@@ -13,7 +13,7 @@ Both `amd64` and `arm64` packages are available.
 
 Note that the packages include a `systemd` service which is disabled by default.
 
-To install, download the desired releases `.deb` package and checksum files. Install using
+To install, download the desired release's `.deb` package and checksum files. Install using
 
 ```sh
 sudo dpkg -i $package_name.deb
@@ -89,4 +89,4 @@ existing chain will not work with the new version. This will change as our proto
 settle.
 :::
 
-Updating the node to a new version is as simply as re-running the install process and repeating the [bootstrapping](./usage#bootstrapping) instructions.
+Updating the node to a new version is as simple as re-running the install process and repeating the [bootstrapping](./usage#bootstrapping) instructions.

--- a/docs/external/src/operator/monitoring.md
+++ b/docs/external/src/operator/monitoring.md
@@ -13,7 +13,7 @@ OpenTelemetry exporting can be enabled by specifying `--enable-otel` via the com
 We do _not_ export OpenTelemetry logs or metrics. Our end goal is to derive these based off of our tracing information.
 This approach is known as [wide-events](https://isburmistrov.substack.com/p/all-you-need-is-wide-events-not-metrics),
 [structured logs](https://newrelic.com/blog/how-to-relic/structured-logging), and
-[Observibility 2.0](https://www.honeycomb.io/blog/time-to-version-observability-signs-point-to-yes).
+[Observability 2.0](https://www.honeycomb.io/blog/time-to-version-observability-signs-point-to-yes).
 
 What we're exporting are `traces` which consist of `spans` (covering a period of time), and `events` (something happened
 at a specific instance in time). These are extremely useful to debug distributed systems - even though `miden` is still

--- a/docs/external/src/operator/usage.md
+++ b/docs/external/src/operator/usage.md
@@ -33,7 +33,7 @@ miden-node store bootstrap \
 You can also configure the account and asset data in the genesis block by passing in a toml configuration file.
 This is particularly useful for setting up test scenarios without requiring multiple rounds of
 transactions to achieve the desired state. Any account secrets will be written to disk inside the
-the provided `--accounts-directory` path in the process.
+provided `--accounts-directory` path in the process.
 
 ```sh
 miden-validator bootstrap \


### PR DESCRIPTION
Fix grammar errors and typos across node documentation pages.

Changes:
- architecture.md: `"is will be lifted"` → `"will be lifted"`
- installation.md:
  - `"as simply as"` → `"as simple as"`
  - `"the desired releases .deb"` → `"the desired release's .deb"`
- usage.md: `"inside the the provided"` → `"inside the provided"`
- monitoring.md: `"Observibility"` → `"Observability"`

**Test plan**
Documentation-only change; no code paths affected.