### PR TITLE
docs: fix broken OpenTelemetry URL in monitoring configuration

### DIFF
--- a/docs/external/src/operator/monitoring.md
+++ b/docs/external/src/operator/monitoring.md
@@ -138,7 +138,7 @@ miden-node rpc start --enable-otel
 ```
 
 The exporter can be configured using environment variables as specified in the official
-[documents](httpthes://opentelemetry.io/docs/specs/otel/protocol/exporter/).
+[documents](https://opentelemetry.io/docs/specs/otel/protocol/exporter/).
 
 <div class="warning">
 Not all options are fully supported. We are limited to what the Rust OpenTelemetry implementation supports. If you have any problems please open an issue and we'll do our best to resolve it.


### PR DESCRIPTION
Fix a typo in the OpenTelemetry exporter documentation URL.

Changes:

* monitoring.md: `httpthes://opentelemetry.io/...` → `https://opentelemetry.io/docs/specs/otel/protocol/exporter/`

Test plan: Documentation-only change; no code paths affected.