### PR TITLE
refactor(store): optimize `account_codes` pruning

### DIFF
--- a/crates/store/src/db/migrations/2026051800000_add_idx_accounts_latest_code_commitment/down.sql
+++ b/crates/store/src/db/migrations/2026051800000_add_idx_accounts_latest_code_commitment/down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_accounts_latest_code_commitment;
+DROP INDEX IF EXISTS idx_accounts_prune_code;
+
+CREATE INDEX idx_accounts_prune_code
+    ON accounts(block_num, is_latest, code_commitment)
+    WHERE code_commitment IS NOT NULL;

--- a/crates/store/src/db/migrations/2026051800000_add_idx_accounts_latest_code_commitment/up.sql
+++ b/crates/store/src/db/migrations/2026051800000_add_idx_accounts_latest_code_commitment/up.sql
@@ -1,0 +1,16 @@
+-- Backfill/reshape the recent-history covering index for prune_account_codes. The old definition
+-- included is_latest, but the split recent-history branch only filters by block_num and projects
+-- code_commitment.
+DROP INDEX IF EXISTS idx_accounts_prune_code;
+CREATE INDEX idx_accounts_prune_code
+    ON accounts(block_num, code_commitment)
+    WHERE code_commitment IS NOT NULL;
+
+-- Covering partial index for prune_account_codes.
+--
+-- prune_account_codes keeps account code rows that are referenced either by recent account history
+-- or by the latest account state. The recent-history branch is covered by idx_accounts_prune_code.
+-- This index covers the latest-state branch without scanning historical public account rows.
+CREATE INDEX idx_accounts_latest_code_commitment
+    ON accounts(code_commitment)
+    WHERE is_latest = 1 AND code_commitment IS NOT NULL;

--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -1635,17 +1635,9 @@ fn prune_account_storage_map_values(
 /// references its `code_commitment`. This covers both active accounts (`is_latest=true`) and
 /// recent historical rows that still fall within the retention window.
 ///
-/// # Raw SQL
-///
-/// ```sql
-/// DELETE FROM account_codes
-/// WHERE code_commitment NOT IN (
-///     SELECT DISTINCT code_commitment
-///     FROM accounts
-///     WHERE code_commitment IS NOT NULL
-///       AND (block_num >= ?1 OR is_latest = 1)
-/// )
-/// ```
+/// The `UNION ALL` shape and explicit index selections avoid SQLite choosing
+/// `idx_accounts_code_commitment` for the whole predicate, which is expensive when the account
+/// history table has millions of public rows.
 #[tracing::instrument(
     target = COMPONENT,
     skip_all,
@@ -1662,9 +1654,17 @@ fn prune_account_codes(
         "DELETE FROM account_codes \
          WHERE code_commitment NOT IN ( \
              SELECT DISTINCT code_commitment \
-             FROM accounts \
-             WHERE code_commitment IS NOT NULL \
-               AND (block_num >= ?1 OR is_latest = 1 ) \
+             FROM ( \
+                 SELECT code_commitment \
+                 FROM accounts INDEXED BY idx_accounts_prune_code \
+                 WHERE code_commitment IS NOT NULL \
+                   AND block_num >= ?1 \
+                 UNION ALL \
+                 SELECT code_commitment \
+                 FROM accounts INDEXED BY idx_accounts_latest_code_commitment \
+                 WHERE code_commitment IS NOT NULL \
+                   AND is_latest = 1 \
+             ) \
          )",
     )
     .bind::<BigInt, _>(cutoff_block)


### PR DESCRIPTION
Analyzing traces for current testnet pointed out that there's a serious bottleneck in how we prune `account_codes` table:

<img width="1792" height="946" alt="image" src="https://github.com/user-attachments/assets/1e00042f-40c0-47d8-98af-4364dd511113" />

It turns out that SQLite was not using the right index for the SQL subquery we were running to get the set of `code_commitment` values that are still required based on account state:

```sql
sqlite> SELECT DISTINCT code_commitment from accounts where code_commitment IS NOT NULL AND (block_num >= 1699000 OR is_latest = 1);
╭─────────────────────────────────────────────────────────────────────╮
│                           code_commitment                           │
╞═════════════════════════════════════════════════════════════════════╡
│ x'002f96792ef149703666adbc840029b96c13b8f1157f32249aa66160fbacfaab' │
[...]
│ x'ffe89f315e3021dde591bdcfb2546cd77b0a4cd8b7271a82d5308b6dd9086fe3' │
╰─────────────────────────────────────────────────────────────────────╯
Run Time: real 1.221431 user 0.993738 sys 0.223425

sqlite> EXPLAIN QUERY PLAN SELECT DISTINCT code_commitment from accounts where code_commitment IS NOT NULL AND (block_num >= 1699000 OR is_latest = 1);
QUERY PLAN
`--SEARCH accounts USING INDEX idx_accounts_code_commitment (code_commitment>?)
```

This PR splits `prune_account_codes` SQL query into indexed recent-history and latest-state branches to avoid SQLite scanning account history via `code_commitment` for the full OR predicate.

To make sure that both branch queries are optimal it also adds a migration that removes `is_latest` from `idx_accounts_prune_code` for the recent-history branch (not needed) and adds `idx_accounts_latest_code_commitment` for latest account rows.

With these changes applied:

```sql
sqlite> SELECT DISTINCT code_commitment
FROM (
    SELECT code_commitment
    FROM accounts INDEXED BY idx_accounts_prune_code
    WHERE code_commitment IS NOT NULL
      AND block_num >= 1699000
    UNION ALL
    SELECT code_commitment
    FROM accounts INDEXED BY idx_accounts_latest_code_commitment
    WHERE code_commitment IS NOT NULL
      AND is_latest = 1
);
╭─────────────────────────────────────────────────────────────────────╮
│                           code_commitment                           │
╞═════════════════════════════════════════════════════════════════════╡
│ x'002f96792ef149703666adbc840029b96c13b8f1157f32249aa66160fbacfaab' │
[...]
│ x'ffe89f315e3021dde591bdcfb2546cd77b0a4cd8b7271a82d5308b6dd9086fe3' │
╰─────────────────────────────────────────────────────────────────────╯
Run Time: real 0.027463 user 0.023466 sys 0.003874

sqlite> EXPLAIN QUERY PLAN SELECT DISTINCT code_commitment
FROM (
    SELECT code_commitment
    FROM accounts INDEXED BY idx_accounts_prune_code
    WHERE code_commitment IS NOT NULL
      AND block_num >= 1699000
    UNION ALL
    SELECT code_commitment
    FROM accounts INDEXED BY idx_accounts_latest_code_commitment
    WHERE code_commitment IS NOT NULL
      AND is_latest = 1
);
QUERY PLAN
|--CO-ROUTINE (subquery-2)
|  `--COMPOUND QUERY
|     |--LEFT-MOST SUBQUERY
|     |  `--SEARCH accounts USING COVERING INDEX idx_accounts_prune_code (block_num>?)
|     `--UNION ALL
|        `--SEARCH accounts USING COVERING INDEX idx_accounts_latest_code_commitment (code_commitment>?)
|--SCAN (subquery-2)
`--USE TEMP B-TREE FOR DISTINCT
```