### PR TITLE
feat: xtask for reflowing comments

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[alias]
+xtask = "run --locked --package xtask --"
+
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,8 +258,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: Rustup
+        run: rustup toolchain install --no-self-update
       - name: Rustup +nightly
         run: rustup toolchain install --no-self-update nightly --component rustfmt
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
+        with:
+          shared-key: ${{ github.job }}
+          prefix-key: ${{ env.CACHE_PREFIX }}
+          save-if: ${{ env.SAVE_CACHE }}
       - name: Fmt
         run: make format-check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,6 +5679,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -5929,6 +5930,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strength_reduce"
@@ -6713,6 +6720,36 @@ checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
 dependencies = [
  "num-integer",
  "strength_reduce",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -7538,6 +7575,18 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xtask"
+version = "0.15.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "fs-err",
+ "toml 1.1.2+spec-1.1.0",
+ "tree-sitter",
+ "tree-sitter-rust",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/test-macro",
   "crates/utils",
   "proto",
+  "xtask",
 ]
 
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,14 @@ fix: ## Runs Fix with configs
 
 
 .PHONY: format
-format: ## Runs Format using nightly toolchain
+format: ## Runs rustfmt and comment reflow
+	cargo xtask fmt-comments --write
 	cargo +nightly fmt --all
 
 
 .PHONY: format-check
-format-check: ## Runs Format using nightly toolchain but only in check mode
+format-check: ## Checks rustfmt and comment reflow
+	cargo xtask fmt-comments --check
 	cargo +nightly fmt --all --check
 
 

--- a/bin/genesis/src/main.rs
+++ b/bin/genesis/src/main.rs
@@ -23,8 +23,8 @@ use rand::Rng;
 use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::SeedableRng;
 
-/// Generate canonical Miden genesis accounts (bridge, bridge admin, GER manager)
-/// and a genesis.toml configuration file.
+/// Generate canonical Miden genesis accounts (bridge, bridge admin, GER manager) and a genesis.toml
+/// configuration file.
 #[derive(Parser)]
 #[command(name = "miden-genesis")]
 struct Cli {
@@ -32,13 +32,13 @@ struct Cli {
     #[arg(long, default_value = "./genesis")]
     output_dir: PathBuf,
 
-    /// Hex-encoded Falcon512 public key for the bridge admin account.
-    /// If omitted, a new keypair is generated and the secret key is included in the .mac file.
+    /// Hex-encoded Falcon512 public key for the bridge admin account. If omitted, a new keypair is
+    /// generated and the secret key is included in the .mac file.
     #[arg(long, value_name = "HEX", requires = "ger_manager_public_key")]
     bridge_admin_public_key: Option<String>,
 
-    /// Hex-encoded Falcon512 public key for the GER manager account.
-    /// If omitted, a new keypair is generated and the secret key is included in the .mac file.
+    /// Hex-encoded Falcon512 public key for the GER manager account. If omitted, a new keypair is
+    /// generated and the secret key is included in the .mac file.
     #[arg(long, value_name = "HEX", requires = "bridge_admin_public_key")]
     ger_manager_public_key: Option<String>,
 }
@@ -97,9 +97,8 @@ fn run(
     let bridge_seed = Word::from(bridge_seed.map(Felt::new));
     let bridge = create_bridge_account(bridge_seed, bridge_admin_id, ger_manager_id);
 
-    // Bump bridge nonce to 1 (required for genesis accounts).
-    // File-loaded accounts via [[account]] in genesis.toml are included as-is,
-    // so we must set nonce=1 before writing the .mac file.
+    // Bump bridge nonce to 1 (required for genesis accounts). File-loaded accounts via [[account]]
+    // in genesis.toml are included as-is, so we must set nonce=1 before writing the .mac file.
     let bridge = bump_nonce_to_one(bridge).context("failed to bump bridge account nonce")?;
 
     // Write .mac files.
@@ -203,8 +202,8 @@ mod tests {
 
     use super::*;
 
-    /// Parses the generated genesis.toml, builds a genesis block, and asserts the bridge account
-    /// is included with nonce=1.
+    /// Parses the generated genesis.toml, builds a genesis block, and asserts the bridge account is
+    /// included with nonce=1.
     fn assert_valid_genesis_block(dir: &Path) {
         let bridge_id = AccountFile::read(dir.join("bridge.mac")).unwrap().account.id();
 

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -156,8 +156,8 @@ impl IncrementService {
         })
     }
 
-    /// Applies a successful increment: updates the wallet nonce, bumps counters, and returns
-    /// the next expected counter value.
+    /// Applies a successful increment: updates the wallet nonce, bumps counters, and returns the
+    /// next expected counter value.
     fn handle_increment_success(&mut self, final_account: &AccountHeader, tx_id: String) -> u64 {
         let updated_wallet = Account::new(
             self.tx.wallet_account.id(),
@@ -407,9 +407,9 @@ impl CounterTrackingService {
         })
     }
 
-    /// The increment service regenerates accounts on persistent failure and rewrites the
-    /// counter account file. If the file's account ID has changed, switch to the new account
-    /// and reset tracking state.
+    /// The increment service regenerates accounts on persistent failure and rewrites the counter
+    /// account file. If the file's account ID has changed, switch to the new account and reset
+    /// tracking state.
     async fn reload_counter_account_if_changed(&mut self) {
         let reloaded = match load_counter_account(&self.config.counter_filepath) {
             Ok(account) => account,
@@ -523,8 +523,8 @@ impl Service for CounterTrackingService {
     }
 
     fn interval(&self) -> Duration {
-        // Tracking polls twice per increment cadence so it catches freshly-incremented values
-        // soon after submission.
+        // Tracking polls twice per increment cadence so it catches freshly-incremented values soon
+        // after submission.
         self.config.counter_increment_interval / 2
     }
 
@@ -542,8 +542,8 @@ impl Service for CounterTrackingService {
 // SETUP
 // ================================================================================================
 
-/// Load wallet + counter accounts, fetch the genesis block header, and build the data store
-/// and increment script needed to produce network notes.
+/// Load wallet + counter accounts, fetch the genesis block header, and build the data store and
+/// increment script needed to produce network notes.
 async fn setup_increment_task(
     config: MonitorConfig,
     rpc_client: &mut RpcClient,

--- a/bin/network-monitor/src/deploy/mod.rs
+++ b/bin/network-monitor/src/deploy/mod.rs
@@ -38,15 +38,14 @@ use crate::deploy::wallet::{create_wallet_account, save_wallet_account};
 pub mod counter;
 pub mod wallet;
 
-/// Create an RPC client configured with the correct genesis metadata in the
-/// `Accept` header so that write RPCs such as `SubmitProvenTx` are
-/// accepted by the node.
+/// Create an RPC client configured with the correct genesis metadata in the `Accept` header so that
+/// write RPCs such as `SubmitProvenTx` are accepted by the node.
 pub async fn create_genesis_aware_rpc_client(
     rpc_url: &Url,
     timeout: Duration,
 ) -> Result<RpcClient> {
-    // First, create a temporary client without genesis metadata to discover the
-    // genesis block header and its commitment.
+    // First, create a temporary client without genesis metadata to discover the genesis block
+    // header and its commitment.
     let mut rpc: RpcClient = Builder::new(rpc_url.clone())
         .with_tls()
         .context("Failed to configure TLS for RPC client")?
@@ -78,8 +77,8 @@ pub async fn create_genesis_aware_rpc_client(
     let genesis_commitment = genesis_header.commitment();
     let genesis = genesis_commitment.to_hex();
 
-    // Rebuild the client, this time including the required genesis metadata so that
-    // write RPCs like SubmitProvenTx are accepted by the node.
+    // Rebuild the client, this time including the required genesis metadata so that write RPCs like
+    // SubmitProvenTx are accepted by the node.
     let rpc_client = Builder::new(rpc_url.clone())
         .with_tls()
         .context("Failed to configure TLS for RPC client")?

--- a/bin/network-monitor/src/explorer.rs
+++ b/bin/network-monitor/src/explorer.rs
@@ -244,8 +244,8 @@ mod tests {
 
     #[test]
     fn truncate_json_multibyte_chars_are_handled() {
-        // Each 'é' is 2 bytes in UTF-8. Build a string whose serialized JSON form
-        // exceeds 60 characters, ensuring truncation lands on a char boundary.
+        // Each 'é' is 2 bytes in UTF-8. Build a string whose serialized JSON form exceeds 60
+        // characters, ensuring truncation lands on a char boundary.
         let multibyte_string = "é".repeat(80);
         let value = json!(multibyte_string);
         // Should not panic and should still truncate correctly.
@@ -255,8 +255,8 @@ mod tests {
 
     #[test]
     fn truncate_json_exactly_60_chars_is_not_truncated() {
-        // Build a JSON string whose serialized form is exactly 60 characters.
-        // json!("x".repeat(58)) serializes as `"xxx...xxx"` (58 chars + 2 quotes = 60).
+        // Build a JSON string whose serialized form is exactly 60 characters. json!("x".repeat(58))
+        // serializes as `"xxx...xxx"` (58 chars + 2 quotes = 60).
         let value = json!("x".repeat(58));
         let result = truncate_json(&value);
         assert_eq!(result.chars().count(), 60);

--- a/bin/network-monitor/src/remote_prover.rs
+++ b/bin/network-monitor/src/remote_prover.rs
@@ -96,8 +96,8 @@ pub struct ProbeSnapshot {
 // PROVER STATUS SERVICE
 // ================================================================================================
 
-/// Parameters captured at construction time for spawning the probe task lazily, the first
-/// time the status service observes the prover reporting [`ProofType::Transaction`].
+/// Parameters captured at construction time for spawning the probe task lazily, the first time the
+/// status service observes the prover reporting [`ProofType::Transaction`].
 struct ProbeSpawner {
     client: RemoteProverClient,
     payload: proto::remote_prover::ProofRequest,
@@ -106,9 +106,9 @@ struct ProbeSpawner {
     name: String,
 }
 
-/// Polls the remote prover's proxy status endpoint and publishes the combined
-/// [`ServiceStatus`] (status + latest probe outcome). Spawns the probe task the first
-/// time the prover reports Transaction type.
+/// Polls the remote prover's proxy status endpoint and publishes the combined [`ServiceStatus`]
+/// (status + latest probe outcome). Spawns the probe task the first time the prover reports
+/// Transaction type.
 pub struct ProverStatusService {
     name: String,
     url: String,
@@ -154,8 +154,8 @@ impl ProverStatusService {
         }
     }
 
-    /// Spawns the probe task if the prover has just been observed to support Transaction
-    /// proofs and we haven't spawned it yet. No-op in all other cases.
+    /// Spawns the probe task if the prover has just been observed to support Transaction proofs and
+    /// we haven't spawned it yet. No-op in all other cases.
     fn maybe_spawn_probe(&mut self) {
         let Some(status) = &self.last_status else { return };
         if !matches!(status.supported_proof_type, ProofType::Transaction) {
@@ -267,8 +267,8 @@ impl Service for ProverStatusService {
 // ================================================================================================
 
 /// Runs proof-test probes on the configured interval. The task is spawned by
-/// [`ProverStatusService::maybe_spawn_probe`] only after the prover has been observed to
-/// support Transaction proofs.
+/// [`ProverStatusService::maybe_spawn_probe`] only after the prover has been observed to support
+/// Transaction proofs.
 #[instrument(
     parent = None,
     target = COMPONENT,

--- a/bin/network-monitor/src/service.rs
+++ b/bin/network-monitor/src/service.rs
@@ -17,8 +17,8 @@ use url::Url;
 
 use crate::service_status::ServiceStatus;
 
-/// Build a lazily-connected gRPC client using the network monitor's standard settings
-/// (TLS enabled, no metadata, no OTEL propagation).
+/// Build a lazily-connected gRPC client using the network monitor's standard settings (TLS enabled,
+/// no metadata, no OTEL propagation).
 pub fn build_tls_client<C: GrpcClient>(url: Url, timeout: Duration) -> C {
     ClientBuilder::new(url)
         .with_tls()
@@ -44,9 +44,9 @@ pub trait Service: Send + 'static {
     /// Runs a single check iteration.
     fn check(&mut self) -> impl std::future::Future<Output = ServiceStatus> + Send;
 
-    /// Full service lifecycle. The default implementation loops on [`Self::interval`] ticks,
-    /// calls [`Self::check`], and publishes the result. Returns when the channel has no
-    /// receivers (clean shutdown). Services with custom scheduling override this.
+    /// Full service lifecycle. The default implementation loops on [`Self::interval`] ticks, calls
+    /// [`Self::check`], and publishes the result. Returns when the channel has no receivers (clean
+    /// shutdown). Services with custom scheduling override this.
     fn run(
         mut self,
         tx: watch::Sender<ServiceStatus>,

--- a/bin/network-monitor/src/view/cards/explorer.rs
+++ b/bin/network-monitor/src/view/cards/explorer.rs
@@ -1,5 +1,5 @@
-//! Renders the explorer card. Compares the explorer's tip against the RPC's tip (passed in by
-//! the dispatcher) and surfaces a warning banner past `EXPLORER_LAG_TOLERANCE` blocks of drift.
+//! Renders the explorer card. Compares the explorer's tip against the RPC's tip (passed in by the
+//! dispatcher) and surfaces a warning banner past `EXPLORER_LAG_TOLERANCE` blocks of drift.
 
 use maud::{Markup, html};
 

--- a/bin/network-monitor/src/view/cards/faucet.rs
+++ b/bin/network-monitor/src/view/cards/faucet.rs
@@ -1,5 +1,5 @@
-//! Renders the faucet card: HTTP test outcome plus the metadata block (token id, supply,
-//! decimals, …) when the faucet exposed it.
+//! Renders the faucet card: HTTP test outcome plus the metadata block (token id, supply, decimals,
+//! …) when the faucet exposed it.
 
 use maud::{Markup, html};
 

--- a/bin/network-monitor/src/view/cards/remote_prover.rs
+++ b/bin/network-monitor/src/view/cards/remote_prover.rs
@@ -1,5 +1,5 @@
-//! Renders the remote-prover card: proxy info, worker list, and last proof-generation test
-//! outcome. Embeds `data-grpc-url` for `/remote_prover.ProxyStatusApi/Status` browser probes.
+//! Renders the remote-prover card: proxy info, worker list, and last proof-generation test outcome.
+//! Embeds `data-grpc-url` for `/remote_prover.ProxyStatusApi/Status` browser probes.
 
 use maud::{Markup, html};
 

--- a/bin/network-monitor/src/view/helpers.rs
+++ b/bin/network-monitor/src/view/helpers.rs
@@ -19,8 +19,8 @@ pub(super) fn metric_row(label: &str, value: &str) -> Markup {
     }
 }
 
-/// Inline copy-to-clipboard button. `label` appears in the tooltip ("Copy full {label}");
-/// `value` is the literal text written to the clipboard via the JS helper.
+/// Inline copy-to-clipboard button. `label` appears in the tooltip ("Copy full {label}"); `value`
+/// is the literal text written to the clipboard via the JS helper.
 pub(super) fn copy_button(value: &str, label: &str) -> Markup {
     let onclick = format!("copyToClipboard({}, event)", json_string(value));
     html! {

--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -192,8 +192,8 @@ pub struct BlockProducerConfig {
     )]
     pub batch_interval: Duration,
 
-    /// The remote batch prover's gRPC url. If unset, will default to running a prover
-    /// in-process which is expensive.
+    /// The remote batch prover's gRPC url. If unset, will default to running a prover in-process
+    /// which is expensive.
     #[arg(long = "batch-prover.url", env = ENV_BATCH_PROVER_URL, value_name = "URL")]
     pub batch_prover_url: Option<Url>,
 

--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -25,8 +25,8 @@ pub enum RpcCommand {
         #[arg(long = "store.url", env = ENV_STORE_URL, value_name = "URL")]
         store_url: Url,
 
-        /// The block-producer's gRPC url. If unset, will run the RPC in read-only mode,
-        /// i.e. without a block-producer.
+        /// The block-producer's gRPC url. If unset, will run the RPC in read-only mode, i.e.
+        /// without a block-producer.
         #[arg(long = "block-producer.url", env = ENV_BLOCK_PRODUCER_URL, value_name = "URL")]
         block_producer_url: Option<Url>,
 

--- a/bin/ntx-builder/src/actor/execute.rs
+++ b/bin/ntx-builder/src/actor/execute.rs
@@ -400,8 +400,7 @@ struct NtxDataStore {
     script_cache: LruCache<Word, NoteScript>,
     /// Local database for persistent note script.
     db: Db,
-    /// Scripts fetched from the remote store during execution, to be persisted by the
-    /// coordinator.
+    /// Scripts fetched from the remote store during execution, to be persisted by the coordinator.
     fetched_scripts: Arc<Mutex<Vec<(Word, NoteScript)>>>,
     /// Mapping of storage map roots to storage slot names observed during various calls.
     ///

--- a/bin/ntx-builder/src/actor/mod.rs
+++ b/bin/ntx-builder/src/actor/mod.rs
@@ -29,10 +29,10 @@ use crate::db::Db;
 
 /// A request sent from an account actor to the coordinator via a shared mpsc channel.
 pub enum ActorRequest {
-    /// One or more notes failed during transaction execution and should have their attempt
-    /// counters incremented. The actor waits for the coordinator to acknowledge the DB write via
-    /// the oneshot channel, preventing race conditions where the actor could re-select the same
-    /// notes before the failure is persisted.
+    /// One or more notes failed during transaction execution and should have their attempt counters
+    /// incremented. The actor waits for the coordinator to acknowledge the DB write via the oneshot
+    /// channel, preventing race conditions where the actor could re-select the same notes before
+    /// the failure is persisted.
     NotesFailed {
         failed_notes: Vec<(Nullifier, NoteError)>,
         block_num: BlockNumber,
@@ -54,8 +54,8 @@ pub struct GrpcClients {
     pub block_producer: BlockProducerClient,
     /// Client for interacting with the validator.
     pub validator: ValidatorClient,
-    /// Client for remote transaction proving. If `None`, transactions will be proven locally,
-    /// which is undesirable due to the performance impact.
+    /// Client for remote transaction proving. If `None`, transactions will be proven locally, which
+    /// is undesirable due to the performance impact.
     pub prover: Option<RemoteTransactionProver>,
 }
 
@@ -193,8 +193,8 @@ pub struct AccountActor {
     state: State,
     /// Per-actor configuration knobs.
     config: ActorConfig,
-    /// Notification signal from the coordinator indicating that DB state relevant to this actor
-    /// may have changed. The actor re-evaluates its state from the DB on each notification.
+    /// Notification signal from the coordinator indicating that DB state relevant to this actor may
+    /// have changed. The actor re-evaluates its state from the DB on each notification.
     notify: Arc<Notify>,
     /// Channel for sending requests to the coordinator.
     request: mpsc::Sender<ActorRequest>,
@@ -226,8 +226,8 @@ impl AccountActor {
     pub async fn run(self, semaphore: Arc<Semaphore>) -> anyhow::Result<()> {
         let account_id = self.account_id;
 
-        // Wait for the account to be committed to the DB. For newly created accounts,
-        // the creation transaction must be committed before we start processing notes.
+        // Wait for the account to be committed to the DB. For newly created accounts, the creation
+        // transaction must be committed before we start processing notes.
         if !self.wait_for_committed_account(account_id).await? {
             return Ok(());
         }
@@ -258,8 +258,8 @@ impl AccountActor {
                 ActorMode::NotesAvailable => semaphore.acquire().boxed(),
             };
 
-            // Idle timeout timer: only ticks when in NoViableNotes mode.
-            // Mode changes cause the next loop iteration to create a fresh sleep or pending.
+            // Idle timeout timer: only ticks when in NoViableNotes mode. Mode changes cause the
+            // next loop iteration to create a fresh sleep or pending.
             let idle_timeout_sleep = match mode {
                 ActorMode::NoViableNotes => tokio::time::sleep(self.config.idle_timeout).boxed(),
                 _ => std::future::pending().boxed(),
@@ -456,8 +456,8 @@ impl AccountActor {
                     "network transaction failed",
                 );
 
-                // For `AllNotesFailed`, use the per-note errors which contain the
-                // specific reason each note failed (e.g. consumability check details).
+                // For `AllNotesFailed`, use the per-note errors which contain the specific reason
+                // each note failed (e.g. consumability check details).
                 let failed_notes: Vec<_> = match err {
                     execute::NtxError::AllNotesFailed(per_note) => log_failed_notes(per_note),
                     other => {

--- a/bin/ntx-builder/src/builder.rs
+++ b/bin/ntx-builder/src/builder.rs
@@ -115,8 +115,8 @@ impl NetworkTransactionBuilder {
 
         join_set.spawn(self.run_event_loop());
 
-        // Wait for either the event loop or the gRPC server to complete.
-        // Any completion is treated as fatal.
+        // Wait for either the event loop or the gRPC server to complete. Any completion is treated
+        // as fatal.
         if let Some(result) = join_set.join_next().await {
             result.context("ntx-builder task panicked")??;
         }
@@ -126,8 +126,8 @@ impl NetworkTransactionBuilder {
 
     /// Runs the main event loop.
     async fn run_event_loop(mut self) -> anyhow::Result<()> {
-        // Spawn a background task to load network accounts from the store.
-        // Accounts are sent through a channel and processed in the main event loop.
+        // Spawn a background task to load network accounts from the store. Accounts are sent
+        // through a channel and processed in the main event loop.
         let (account_tx, mut account_rx) =
             mpsc::channel::<NetworkAccountId>(self.config.account_channel_capacity);
         let account_loader_store = self.store.clone();
@@ -156,9 +156,9 @@ impl NetworkTransactionBuilder {
 
                     self.handle_mempool_event(event).await?;
                 },
-                // Handle account batches loaded from the store.
-                // Once all accounts are loaded, the channel closes and this branch
-                // becomes inactive (recv returns None and we stop matching).
+                // Handle account batches loaded from the store. Once all accounts are loaded, the
+                // channel closes and this branch becomes inactive (recv returns None and we stop
+                // matching).
                 Some(account_id) = account_rx.recv() => {
                     self.handle_loaded_account(account_id).await?;
                 },
@@ -166,9 +166,9 @@ impl NetworkTransactionBuilder {
                 Some(request) = self.actor_request_rx.recv() => {
                     self.handle_actor_request(request).await?;
                 },
-                // Handle account loader task completion/failure.
-                // If the task fails, we abort since the builder would be in a degraded state
-                // where existing notes against network accounts won't be processed.
+                // Handle account loader task completion/failure. If the task fails, we abort since
+                // the builder would be in a degraded state where existing notes against network
+                // accounts won't be processed.
                 result = &mut account_loader_handle => {
                     result
                         .context("account loader task panicked")
@@ -250,8 +250,8 @@ impl NetworkTransactionBuilder {
                 self.coordinator.notify_accounts(&result.accounts_to_notify);
                 Ok(())
             },
-            // Notify affected actors (reverted account actors will self-cancel when they
-            // detect their account has been removed from the DB).
+            // Notify affected actors (reverted account actors will self-cancel when they detect
+            // their account has been removed from the DB).
             MempoolEvent::TransactionsReverted(_) => {
                 // Write event effects to DB first.
                 let result = self

--- a/bin/ntx-builder/src/chain_state.rs
+++ b/bin/ntx-builder/src/chain_state.rs
@@ -49,8 +49,8 @@ impl ChainState {
 
     /// Updates the chain tip and prunes old blocks from the MMR.
     fn update_chain_tip(&mut self, tip: BlockHeader, max_block_count: usize) {
-        // Skip blocks already reflected in the chain state. A `BlockCommitted` event may arrive
-        // for a block whose state was already loaded from the store during startup: the mempool
+        // Skip blocks already reflected in the chain state. A `BlockCommitted` event may arrive for
+        // a block whose state was already loaded from the store during startup: the mempool
         // subscription is established first and then the chain tip is fetched, so any block
         // committed in that window produces an event for state we have already ingested.
         if tip.block_num() <= self.chain_tip_header.block_num() {

--- a/bin/ntx-builder/src/commands/mod.rs
+++ b/bin/ntx-builder/src/commands/mod.rs
@@ -45,8 +45,8 @@ pub enum NtxBuilderCommand {
         #[arg(long = "validator.url", env = ENV_VALIDATOR_URL, value_name = "URL")]
         validator_url: Url,
 
-        /// The remote transaction prover's gRPC url. If unset, will default to running a
-        /// prover in-process which is expensive.
+        /// The remote transaction prover's gRPC url. If unset, will default to running a prover
+        /// in-process which is expensive.
         #[arg(long = "tx-prover.url", env = ENV_TX_PROVER_URL, value_name = "URL")]
         tx_prover_url: Option<Url>,
 

--- a/bin/ntx-builder/src/coordinator.rs
+++ b/bin/ntx-builder/src/coordinator.rs
@@ -26,8 +26,8 @@ pub struct WriteEventResult {
 /// Handle to an account actor spawned by the coordinator.
 #[derive(Clone)]
 struct ActorHandle {
-    /// [`Notify`] shared with the actor. The coordinator calls [`Notify::notify_one`] when DB
-    /// state relevant to the actor may have changed, the actor awaits [`Notify::notified`] and
+    /// [`Notify`] shared with the actor. The coordinator calls [`Notify::notify_one`] when DB state
+    /// relevant to the actor may have changed, the actor awaits [`Notify::notified`] and
     /// re-evaluates its state on wake-up.
     notify: Arc<Notify>,
 }
@@ -37,8 +37,8 @@ impl ActorHandle {
         Self { notify }
     }
 
-    /// Signals the actor that DB state may have changed. Notifications coalesce when one is
-    /// already pending.
+    /// Signals the actor that DB state may have changed. Notifications coalesce when one is already
+    /// pending.
     fn notify(&self) {
         self.notify.notify_one();
     }
@@ -137,8 +137,8 @@ pub struct Coordinator {
 }
 
 impl Coordinator {
-    /// Creates a new coordinator with the specified maximum number of inflight transactions
-    /// and the crash threshold for account deactivation.
+    /// Creates a new coordinator with the specified maximum number of inflight transactions and the
+    /// crash threshold for account deactivation.
     pub fn new(max_inflight_transactions: usize, max_account_crashes: usize, db: Db) -> Self {
         Self {
             actor_registry: HashMap::new(),
@@ -224,9 +224,9 @@ impl Coordinator {
         let actor_result = self.actor_join_set.join_next().await;
         match actor_result {
             Some(Ok((account_id, Ok(())))) => {
-                // Actor shut down intentionally (idle timeout or account removed).
-                // Remove from registry and check if a notification arrived just as it shut
-                // down. If so, the caller should respawn it.
+                // Actor shut down intentionally (idle timeout or account removed). Remove from
+                // registry and check if a notification arrived just as it shut down. If so, the
+                // caller should respawn it.
                 let should_respawn = self
                     .actor_registry
                     .remove(&account_id)

--- a/bin/ntx-builder/src/db/models/queries/mod.rs
+++ b/bin/ntx-builder/src/db/models/queries/mod.rs
@@ -140,9 +140,9 @@ pub fn add_transaction(
         }
     }
 
-    // Insert notes with created_by = tx_id.
-    // Uses INSERT OR IGNORE to make this idempotent if the same event is delivered twice
-    // (the nullifier PK would otherwise cause a constraint violation).
+    // Insert notes with created_by = tx_id. Uses INSERT OR IGNORE to make this idempotent if the
+    // same event is delivered twice (the nullifier PK would otherwise cause a constraint
+    // violation).
     for note in notes {
         let insert = NoteInsert {
             nullifier: conversions::nullifier_to_bytes(&note.as_note().nullifier()),
@@ -218,8 +218,8 @@ pub fn commit_block(
     for tx_id in tx_ids {
         let tx_id_bytes = conversions::transaction_id_to_bytes(tx_id);
 
-        // Promote inflight account rows: delete old committed, set transaction_id = NULL.
-        // Find accounts that have an inflight row for this tx.
+        // Promote inflight account rows: delete old committed, set transaction_id = NULL. Find
+        // accounts that have an inflight row for this tx.
         let inflight_account_ids: Vec<Vec<u8>> = schema::accounts::table
             .filter(schema::accounts::transaction_id.eq(&tx_id_bytes))
             .select(schema::accounts::account_id)
@@ -236,8 +236,8 @@ pub fn commit_block(
             )
             .execute(conn)?;
 
-            // Promote the inflight row to committed (set transaction_id = NULL).
-            // Only promote the row for this specific tx.
+            // Promote the inflight row to committed (set transaction_id = NULL). Only promote the
+            // row for this specific tx.
             diesel::update(
                 schema::accounts::table
                     .filter(schema::accounts::account_id.eq(account_id_bytes))

--- a/bin/ntx-builder/src/db/models/queries/notes.rs
+++ b/bin/ntx-builder/src/db/models/queries/notes.rs
@@ -120,8 +120,8 @@ pub fn available_notes(
 ) -> Result<Vec<AccountTargetNetworkNote>, DatabaseError> {
     let account_id_bytes = conversions::network_account_id_to_bytes(account_id);
 
-    // Get unconsumed, uncommitted notes for this account that haven't exceeded the max
-    // attempt count.
+    // Get unconsumed, uncommitted notes for this account that haven't exceeded the max attempt
+    // count.
     let rows: Vec<NoteRow> = schema::notes::table
         .filter(schema::notes::account_id.eq(&account_id_bytes))
         .filter(schema::notes::consumed_by.is_null())

--- a/bin/ntx-builder/src/lib.rs
+++ b/bin/ntx-builder/src/lib.rs
@@ -92,19 +92,19 @@ pub struct NtxBuilderConfig {
     /// Address of the remote transaction prover. If `None`, transactions will be proven locally.
     pub tx_prover_url: Option<Url>,
 
-    /// Size of the LRU cache for note scripts. Scripts are fetched from the store and cached
-    /// to avoid repeated gRPC calls.
+    /// Size of the LRU cache for note scripts. Scripts are fetched from the store and cached to
+    /// avoid repeated gRPC calls.
     pub script_cache_size: NonZeroUsize,
 
-    /// Maximum number of network transactions which should be in progress concurrently across
-    /// all account actors.
+    /// Maximum number of network transactions which should be in progress concurrently across all
+    /// account actors.
     pub max_concurrent_txs: usize,
 
     /// Maximum number of network notes a single transaction is allowed to consume.
     pub max_notes_per_tx: NonZeroUsize,
 
-    /// Maximum number of attempts to execute a failing note before dropping it.
-    /// Notes use exponential backoff between attempts.
+    /// Maximum number of attempts to execute a failing note before dropping it. Notes use
+    /// exponential backoff between attempts.
     pub max_note_attempts: usize,
 
     /// Maximum number of blocks to keep in the chain MMR. Older blocks are pruned.
@@ -285,8 +285,8 @@ impl NtxBuilderConfig {
         let validator = ValidatorClient::new(self.validator_url.clone());
         let prover = self.tx_prover_url.clone().map(RemoteTransactionProver::new);
 
-        // Subscribe to mempool first to ensure we don't miss any events. The subscription
-        // replays all inflight transactions, so the subscriber's state is fully reconstructed.
+        // Subscribe to mempool first to ensure we don't miss any events. The subscription replays
+        // all inflight transactions, so the subscriber's state is fully reconstructed.
         let subscription = block_producer
             .subscribe_to_mempool_with_retry()
             .await

--- a/bin/remote-prover/src/server/mod.rs
+++ b/bin/remote-prover/src/server/mod.rs
@@ -34,8 +34,7 @@ pub struct Server {
     /// The proof type that the prover will be handling.
     #[arg(long, value_enum, env = "MIDEN_PROVER_KIND")]
     kind: ProofKind,
-    /// Maximum time allowed for a proof request to complete. Once exceeded, the request is
-    /// aborted.
+    /// Maximum time allowed for a proof request to complete. Once exceeded, the request is aborted.
     #[arg(long, default_value = "60s", env = "MIDEN_PROVER_TIMEOUT", value_parser = humantime::parse_duration)]
     timeout: std::time::Duration,
     /// Maximum number of concurrent proof requests that the prover will allow.

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -30,9 +30,8 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
     }
 
     fn decode(request: grpc::remote_prover::ProofRequest) -> tonic::Result<Self::Input> {
-        // Check that the proof type is supported.
-        // Protobuf enums return a default value if the enum is set to an unknown value.
-        // This round trip checks that the value is valid.
+        // Check that the proof type is supported. Protobuf enums return a default value if the enum
+        // is set to an unknown value. This round trip checks that the value is valid.
         if request.proof_type() as i32 != request.proof_type {
             return Err(tonic::Status::invalid_argument("unknown proof_type value"));
         }

--- a/bin/remote-prover/src/server/tests.rs
+++ b/bin/remote-prover/src/server/tests.rs
@@ -204,8 +204,8 @@ async fn legacy_behaviour_with_capacity_1() {
 
     let (first, second) = tokio::join!(a, b);
 
-    // We cannot know which got served and which got rejected.
-    // We can only assert that one of them is Ok and the other is Err.
+    // We cannot know which got served and which got rejected. We can only assert that one of them
+    // is Ok and the other is Err.
     assert!(first.is_ok() || second.is_ok());
     assert!(first.is_err() || second.is_err());
     // We also expect that the error is a resource exhaustion error.
@@ -240,8 +240,8 @@ async fn capacity_is_respected() {
 
     let (first, second, third) = tokio::join!(a, b, c);
 
-    // We cannot know which got served and which got rejected.
-    // We can only assert that two succeeded and one failed.
+    // We cannot know which got served and which got rejected. We can only assert that two succeeded
+    // and one failed.
     let mut expected = [true, true, false];
     let mut result = [first.is_ok(), second.is_ok(), third.is_ok()];
     expected.sort_unstable();

--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -27,8 +27,8 @@ pub enum Command {
     /// Create and store blocks into the store. Create a given number of accounts, where each
     /// account consumes a note created from a faucet.
     SeedStore {
-        /// Directory in which to store the database and raw block data. If the directory contains
-        /// a database dump file, it will be replaced.
+        /// Directory in which to store the database and raw block data. If the directory contains a
+        /// database dump file, it will be replaced.
         #[arg(short, long, value_name = "DATA_DIRECTORY")]
         data_directory: PathBuf,
 
@@ -36,8 +36,8 @@ pub enum Command {
         #[arg(short, long, value_name = "NUM_ACCOUNTS")]
         num_accounts: usize,
 
-        /// Percentage of accounts that will be created as public accounts. The rest will be
-        /// private accounts.
+        /// Percentage of accounts that will be created as public accounts. The rest will be private
+        /// accounts.
         #[arg(short, long, value_name = "PUBLIC_ACCOUNTS_PERCENTAGE", default_value = "0")]
         public_accounts_percentage: u8,
 
@@ -68,8 +68,8 @@ pub enum Command {
         #[arg(short, long, value_name = "ITERATIONS", default_value = "10000")]
         iterations: usize,
 
-        /// Concurrency level of the sync request. Represents the number of request that
-        /// can be sent in parallel.
+        /// Concurrency level of the sync request. Represents the number of request that can be sent
+        /// in parallel.
         #[arg(short, long, value_name = "CONCURRENCY", default_value = "1")]
         concurrency: usize,
     },

--- a/bin/stress-test/src/seeding/mod.rs
+++ b/bin/stress-test/src/seeding/mod.rs
@@ -181,10 +181,10 @@ async fn generate_blocks(
     asset_faucet_ids: Vec<AccountId>,
 ) -> SeedingMetrics {
     // Each block is composed of [`BATCHES_PER_BLOCK`] batches, and each batch is composed of
-    // [`TRANSACTIONS_PER_BATCH`] txs. The first note of the block is always a send assets tx
-    // from the faucet to (BATCHES_PER_BLOCK * TRANSACTIONS_PER_BATCH) - 1 accounts. The rest of
-    // the notes are consume note txs from the (BATCHES_PER_BLOCK * TRANSACTIONS_PER_BATCH) - 1
-    // accounts that were minted in the previous block.
+    // [`TRANSACTIONS_PER_BATCH`] txs. The first note of the block is always a send assets tx from
+    // the faucet to (BATCHES_PER_BLOCK * TRANSACTIONS_PER_BATCH) - 1 accounts. The rest of the
+    // notes are consume note txs from the (BATCHES_PER_BLOCK * TRANSACTIONS_PER_BATCH) - 1 accounts
+    // that were minted in the previous block.
     let mut metrics = SeedingMetrics::new(data_directory.database_path());
 
     let mut account_ids = vec![];
@@ -744,8 +744,8 @@ fn create_existing_account_delta(
     AccountDelta::new(account.id(), storage_delta, vault_delta, ONE).unwrap()
 }
 
-/// Creates a transaction from the faucet that creates the given output notes.
-/// Updates the faucet account to increase the issuance slot and it's nonce.
+/// Creates a transaction from the faucet that creates the given output notes. Updates the faucet
+/// account to increase the issuance slot and it's nonce.
 fn create_emit_note_tx(
     block_ref: &BlockHeader,
     faucet: &mut Account,

--- a/bin/stress-test/src/store/metrics.rs
+++ b/bin/stress-test/src/store/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-/// Prints a summary of the benchmark results, including the average and various percentile
-/// request latencies to help diagnose performance outliers.
+/// Prints a summary of the benchmark results, including the average and various percentile request
+/// latencies to help diagnose performance outliers.
 pub fn print_summary(timers_accumulator: &[Duration]) {
     let avg_time = timers_accumulator.iter().sum::<Duration>() / timers_accumulator.len() as u32;
     println!("Average request latency: {avg_time:?}");
@@ -27,8 +27,8 @@ fn compute_percentile(times: &[Duration], percentile: f64) -> Duration {
     let mut sorted_times = times.to_vec();
     sorted_times.sort_unstable();
 
-    // Calculate the index for the given percentile
-    // For P99.9 with 10000 samples: index = (99.9 / 100.0) * 10000 = 9990
+    // Calculate the index for the given percentile For P99.9 with 10000 samples: index = (99.9 /
+    // 100.0) * 10000 = 9990
     let index = (percentile / 100.0 * sorted_times.len() as f64).round() as usize;
 
     // Ensure index is within bounds

--- a/bin/stress-test/src/store/mod.rs
+++ b/bin/stress-test/src/store/mod.rs
@@ -257,9 +257,9 @@ pub async fn bench_sync_notes(data_directory: PathBuf, iterations: usize, concur
     print_summary(&timers_accumulator);
 }
 
-/// Sends a single `sync_notes` request to the store and returns the elapsed time.
-/// The note tags are generated from the account ids, so the request will contain a note tag for
-/// each account id, with a block number of 0.
+/// Sends a single `sync_notes` request to the store and returns the elapsed time. The note tags are
+/// generated from the account ids, so the request will contain a note tag for each account id, with
+/// a block number of 0.
 pub async fn sync_notes(
     api_client: &mut RpcClient<InterceptedService<Channel, OtelInterceptor>>,
     account_ids: Vec<AccountId>,

--- a/bin/validator/src/block_validation/mod.rs
+++ b/bin/validator/src/block_validation/mod.rs
@@ -86,8 +86,7 @@ pub async fn validate_block(
             .map_err(BlockValidationError::DatabaseError)?
             .ok_or(BlockValidationError::NoPrevBlockHeader)?
     } else {
-        // Proposed block is a new block.
-        // Block number must be sequential.
+        // Proposed block is a new block. Block number must be sequential.
         let expected_block_num = chain_tip.block_num().child();
         if proposed_header.block_num() != expected_block_num {
             return Err(BlockValidationError::BlockNumberMismatch {

--- a/bin/validator/src/commands/bootstrap.rs
+++ b/bin/validator/src/commands/bootstrap.rs
@@ -45,8 +45,8 @@ pub async fn bootstrap(
     .await
 }
 
-/// Builds the genesis state, writes account secret files, signs the genesis block, writes it
-/// to disk, and initializes the validator's database with the genesis block as the chain tip.
+/// Builds the genesis state, writes account secret files, signs the genesis block, writes it to
+/// disk, and initializes the validator's database with the genesis block as the chain tip.
 async fn build_and_write_genesis(
     config: GenesisConfig,
     signer: ValidatorSigner,

--- a/bin/validator/src/server/sign_block.rs
+++ b/bin/validator/src/server/sign_block.rs
@@ -28,8 +28,8 @@ impl grpc::server::validator_api::SignBlock for ValidatorServer {
     }
 
     async fn handle(&self, proposed_block: Self::Input) -> tonic::Result<Self::Output> {
-        // Serialize sign_block requests to prevent race conditions between loading the
-        // chain tip and persisting the validated block header.
+        // Serialize sign_block requests to prevent race conditions between loading the chain tip
+        // and persisting the validated block header.
         let _permit = self.sign_block_semaphore.acquire().await.map_err(|err| {
             tonic::Status::internal(format!("sign_block semaphore closed: {err}"))
         })?;

--- a/bin/validator/src/server/tests.rs
+++ b/bin/validator/src/server/tests.rs
@@ -16,8 +16,8 @@ use crate::db::{load, load_chain_tip, upsert_block_header};
 // TEST HELPERS
 // ================================================================================================
 
-/// Test harness that wraps a [`ValidatorServer`] and tracks the chain MMR state needed to
-/// construct valid [`ProposedBlock`]s.
+/// Test harness that wraps a [`ValidatorServer`] and tracks the chain MMR state needed to construct
+/// valid [`ProposedBlock`]s.
 struct TestValidator {
     server: ValidatorServer,
     chain: PartialBlockchain,
@@ -101,8 +101,8 @@ impl TestValidator {
     }
 }
 
-/// Builds an empty [`ProposedBlock`] that extends the given parent block header using the
-/// provided partial blockchain state.
+/// Builds an empty [`ProposedBlock`] that extends the given parent block header using the provided
+/// partial blockchain state.
 fn empty_block(parent_header: &BlockHeader, chain: &PartialBlockchain) -> ProposedBlock {
     let block_inputs = BlockInputs::new(
         parent_header.clone(),
@@ -133,15 +133,15 @@ async fn chain_tip_plus_one_succeeds() {
 async fn chain_tip_replacement_succeeds() {
     let mut tv = TestValidator::new().await;
 
-    // The genesis block can never be replaced, so we advance the chain
-    // to block 1, which we can then replace.
+    // The genesis block can never be replaced, so we advance the chain to block 1, which we can
+    // then replace.
     let genesis_header = tv.chain_tip.clone();
     let chain_at_genesis = tv.chain.clone();
     tv.apply_empty_block().await;
     let original_header = tv.chain_tip.clone();
 
-    // Submit a different block at the same height (block 1), which is a replacement.
-    // Use an explicit timestamp far in the future to ensure the replacement block differs.
+    // Submit a different block at the same height (block 1), which is a replacement. Use an
+    // explicit timestamp far in the future to ensure the replacement block differs.
     let block_inputs = BlockInputs::new(
         genesis_header.clone(),
         chain_at_genesis.clone(),
@@ -215,8 +215,8 @@ async fn chain_tip_minus_one_rejected() {
     tv.apply_empty_block().await;
     tv.apply_empty_block().await;
 
-    // Try to submit a block at height 1 (chain tip - 1). This is neither a replacement
-    // (which would need to match tip height 2) nor the next block (which would be 3).
+    // Try to submit a block at height 1 (chain tip - 1). This is neither a replacement (which would
+    // need to match tip height 2) nor the next block (which would be 3).
     let stale_block = empty_block(&genesis_header, &chain_at_genesis);
 
     let result = tv.call_sign_block(&stale_block).await;
@@ -234,8 +234,8 @@ async fn chain_tip_minus_one_rejected() {
 async fn commitment_mismatch_rejected() {
     let tv = TestValidator::new().await;
 
-    // Build a valid ProposedBlock on a *different* genesis so its prev_block_commitment
-    // won't match the validator's actual chain tip.
+    // Build a valid ProposedBlock on a *different* genesis so its prev_block_commitment won't match
+    // the validator's actual chain tip.
     let other_genesis_signer = random_secret_key();
     let other_genesis_state =
         GenesisState::new(vec![], test_fee_params(), 1, 1, other_genesis_signer.public_key());
@@ -313,8 +313,8 @@ async fn unknown_transactions_rejected() {
     let tv = TestValidator::new().await;
     let genesis_header = tv.chain_tip.clone();
 
-    // Build a dummy transaction header with a transaction ID that has NOT been
-    // submitted through `submit_proven_transaction`.
+    // Build a dummy transaction header with a transaction ID that has NOT been submitted through
+    // `submit_proven_transaction`.
     let account_id = ACCOUNT_ID_SENDER.try_into().unwrap();
     let fee = FungibleAsset::new(test_fee_params().fee_faucet_id(), 0).unwrap();
     let tx_header = TransactionHeader::new(
@@ -399,8 +399,8 @@ async fn new_block_after_replacement_with_stale_commitment_rejected() {
     );
     tv.call_sign_block(&replacement).await.unwrap();
 
-    // Now try to submit block 2 built on top of the *original* block 1.
-    // Its prev_block_commitment points to the old block 1, not the replacement.
+    // Now try to submit block 2 built on top of the *original* block 1. Its prev_block_commitment
+    // points to the old block 1, not the replacement.
     let stale_block_2 = empty_block(&original_block_1_header, &chain_after_block_1);
 
     let result = tv.call_sign_block(&stale_block_2).await;

--- a/bin/validator/src/signers/kms.rs
+++ b/bin/validator/src/signers/kms.rs
@@ -76,10 +76,9 @@ impl KmsSigner {
 
     pub async fn sign(&self, commitment: Word) -> Result<Signature, KmsSignerError> {
         // The Validator produces Ethereum-style ECDSA (secp256k1) signatures over Keccak-256
-        // digests. AWS KMS does not support SHA-3 hashing for ECDSA keys
-        // (ECC_SECG_P256K1 being the corresponding AWS key-spec), so we pre-hash the
-        // message and pass MessageType::Digest. KMS signs the provided 32-byte digest
-        // verbatim.
+        // digests. AWS KMS does not support SHA-3 hashing for ECDSA keys (ECC_SECG_P256K1 being the
+        // corresponding AWS key-spec), so we pre-hash the message and pass MessageType::Digest. KMS
+        // signs the provided 32-byte digest verbatim.
         let msg = commitment.to_bytes();
         let digest = Keccak256::hash(&msg);
 

--- a/bin/validator/src/tx_validation/data_store.rs
+++ b/bin/validator/src/tx_validation/data_store.rs
@@ -1,5 +1,5 @@
-/// NOTE: This module contains logic that will eventually be moved to the Validator component
-/// when it is added to this repository.
+/// NOTE: This module contains logic that will eventually be moved to the Validator component when
+/// it is added to this repository.
 use std::collections::BTreeSet;
 
 use miden_protocol::Word;

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -177,8 +177,9 @@ impl BatchJob {
             .inspect_ok(TelemetryInjectorExt::inject_telemetry)
             .and_then(|proposed| self.prove_batch(proposed))
 
-            // Failure must be injected before the final pipeline stage i.e. before commit is called. The system cannot
-            // handle errors after it considers the process complete (which makes sense).
+            // Failure must be injected before the final pipeline stage i.e. before commit is
+            // called. The system cannot handle errors after it considers the process complete
+            // (which makes sense).
             .and_then(|x| self.inject_failure(x))
             .and_then(|proven_batch| async { self.commit_batch(proven_batch).await; Ok(()) })
             // Handle errors by propagating the error to the root span and rolling back the batch.

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -160,10 +160,10 @@ impl BlockBuilder {
         let unauthenticated_notes_iter = batch_iter.clone().flat_map(|batch| {
             // Note: .cloned() shouldn't be necessary but not having it produces an odd lifetime
             // error in BlockProducer::serve. Not sure if there's a better fix. Error:
-            // implementation of `FnOnce` is not general enough
-            // closure with signature `fn(&InputNoteCommitment) -> miden_protocol::note::NoteId`
-            // must implement `FnOnce<(&InputNoteCommitment,)>` ...but it actually
-            // implements `FnOnce<(&InputNoteCommitment,)>`
+            // implementation of `FnOnce` is not general enough closure with signature
+            // `fn(&InputNoteCommitment) -> miden_protocol::note::NoteId` must implement
+            // `FnOnce<(&InputNoteCommitment,)>` ...but it actually implements
+            // `FnOnce<(&InputNoteCommitment,)>`
             batch
                 .input_notes()
                 .iter()
@@ -240,16 +240,16 @@ impl BlockBuilder {
             .map_err(|err| BuildBlockError::other(format!("task join error: {err}")))?
             .map_err(BuildBlockError::ProposeBlockFailed)?;
 
-        // Verify the signature against the built block to ensure that
-        // the validator has provided a valid signature for the relevant block.
+        // Verify the signature against the built block to ensure that the validator has provided a
+        // valid signature for the relevant block.
         if !signature.verify(header.commitment(), header.validator_key()) {
             return Err(BuildBlockError::InvalidSignature);
         }
 
         let (ordered_batches, ..) = proposed_block.into_parts();
         // SAFETY: The header, body, and signature are known to correspond to each other because the
-        // header and body are derived from the proposed block and the signature is verified
-        // against the corresponding commitment.
+        // header and body are derived from the proposed block and the signature is verified against
+        // the corresponding commitment.
         let signed_block = SignedBlock::new_unchecked(header, body, signature);
         Ok((ordered_batches, signed_block))
     }

--- a/crates/block-producer/src/domain/transaction.rs
+++ b/crates/block-producer/src/domain/transaction.rs
@@ -112,8 +112,8 @@ impl AuthenticatedTransaction {
         (self.inner.ref_block_num(), self.inner.ref_block_commitment())
     }
 
-    /// Note commitments which were unauthenticated in the transaction __and__ which were
-    /// not authenticated by the store inputs.
+    /// Note commitments which were unauthenticated in the transaction __and__ which were not
+    /// authenticated by the store inputs.
     pub fn unauthenticated_note_commitments(&self) -> impl Iterator<Item = Word> + '_ {
         self.inner
             .unauthenticated_notes()

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -160,8 +160,7 @@ pub enum BuildBlockError {
 }
 
 impl BuildBlockError {
-    /// Creates a custom error using the [`BuildBlockError::Other`] variant from an
-    /// error message.
+    /// Creates a custom error using the [`BuildBlockError::Other`] variant from an error message.
     pub fn other(message: impl Into<String>) -> Self {
         let message: String = message.into();
         Self::Other { error_msg: message.into(), source: None }

--- a/crates/block-producer/src/mempool/budget.rs
+++ b/crates/block-producer/src/mempool/budget.rs
@@ -60,8 +60,8 @@ impl BatchBudget {
     /// otherwise returns [`BudgetStatus::WithinScope`] and subtracts the resources from the budget.
     #[must_use]
     pub(crate) fn check_then_subtract(&mut self, tx: &AuthenticatedTransaction) -> BudgetStatus {
-        // This type assertion reminds us to update the account check if we ever support
-        // multiple account updates per tx.
+        // This type assertion reminds us to update the account check if we ever support multiple
+        // account updates per tx.
         pub(crate) const ACCOUNT_UPDATES_PER_TX: usize = 1;
         let _: miden_protocol::account::AccountId = tx.account_update().account_id();
 

--- a/crates/block-producer/src/mempool/graph/batch.rs
+++ b/crates/block-producer/src/mempool/graph/batch.rs
@@ -111,8 +111,8 @@ impl BatchGraph {
         reverted
     }
 
-    /// Marks the given batch as proven, making it available for selection in a block
-    /// once it becomes a root.
+    /// Marks the given batch as proven, making it available for selection in a block once it
+    /// becomes a root.
     pub fn submit_proof(&mut self, proof: Arc<ProvenBatch>) {
         if self.inner.contains(&proof.id()) {
             self.proven.insert(proof.id(), proof);

--- a/crates/block-producer/src/mempool/graph/node.rs
+++ b/crates/block-producer/src/mempool/graph/node.rs
@@ -12,16 +12,16 @@ pub trait GraphNode {
 
     fn id(&self) -> Self::Id;
 
-    /// All [`Nullifier`]s created by this node, **including** nullifiers for erased notes. This
-    /// may not be strictly necessary but it removes having to worry about reverting batches and
-    /// blocks with erased notes -- since these would otherwise have different state impact than
-    /// the transactions within them.
-    fn nullifiers(&self) -> Box<dyn Iterator<Item = Nullifier> + '_>;
-
-    /// All output notes created by this node, **including** erased notes. This may not
-    /// be strictly necessary but it removes having to worry about reverting batches and blocks
+    /// All [`Nullifier`]s created by this node, **including** nullifiers for erased notes. This may
+    /// not be strictly necessary but it removes having to worry about reverting batches and blocks
     /// with erased notes -- since these would otherwise have different state impact than the
     /// transactions within them.
+    fn nullifiers(&self) -> Box<dyn Iterator<Item = Nullifier> + '_>;
+
+    /// All output notes created by this node, **including** erased notes. This may not be strictly
+    /// necessary but it removes having to worry about reverting batches and blocks with erased
+    /// notes -- since these would otherwise have different state impact than the transactions
+    /// within them.
     fn output_notes(&self) -> Box<dyn Iterator<Item = Word> + '_>;
 
     /// Input notes which were not authenticated against any committed block thus far.

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -253,9 +253,9 @@ impl TransactionGraph {
                 self.failures.remove(&tx.id());
 
                 // Note that this is a pretty rough shod approach. We just dump the entire batch of
-                // transactions in, which will result in at least the current
-                // transaction being duplicated in `to_revert`. This isn't a concern
-                // though since we skip already processed transactions at the top of the loop.
+                // transactions in, which will result in at least the current transaction being
+                // duplicated in `to_revert`. This isn't a concern though since we skip already
+                // processed transactions at the top of the loop.
                 if let Some(batch) = self.txs_user_batch.remove(&tx.id()) {
                     if let Some(batch) = self.user_batch_txs.remove(&batch) {
                         to_revert.extend(batch);

--- a/crates/block-producer/src/mempool/subscription.rs
+++ b/crates/block-producer/src/mempool/subscription.rs
@@ -165,8 +165,8 @@ struct InflightTransactions {
     /// A reverse lookup index is maintained in `index`.
     txs: BTreeMap<u64, MempoolEvent>,
 
-    /// A reverse lookup index for `txs` which allows for efficient removal of
-    /// committed or reverted events.
+    /// A reverse lookup index for `txs` which allows for efficient removal of committed or reverted
+    /// events.
     index: BTreeMap<TransactionId, u64>,
 }
 

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -63,9 +63,9 @@ async fn add_transaction_traces_are_correct() {
 
 #[test]
 fn children_of_failed_batches_are_ignored() {
-    // Batches are proved concurrently. This makes it possible for a child job to complete after
-    // the parent has been reverted (and therefore reverting the child job). Such a child job
-    // should be ignored.
+    // Batches are proved concurrently. This makes it possible for a child job to complete after the
+    // parent has been reverted (and therefore reverting the child job). Such a child job should be
+    // ignored.
     let txs = MockProvenTxBuilder::sequential();
 
     let (mut uut, _) = Mempool::for_tests();
@@ -354,8 +354,8 @@ fn pass_through_txs_on_an_empty_account() {
     ));
     itertools::assert_equal(batch.account_updates(), expected);
 
-    // Ensure the batch contains a,b and final. Final should also be the last tx since its order
-    // is required.
+    // Ensure the batch contains a,b and final. Final should also be the last tx since its order is
+    // required.
     assert!(batch.transactions().contains(&tx_pass_through_a));
     assert!(batch.transactions().contains(&tx_pass_through_b));
     assert_eq!(batch.transactions().last().unwrap(), &tx_final);

--- a/crates/block-producer/src/mempool/tests/add_transaction.rs
+++ b/crates/block-producer/src/mempool/tests/add_transaction.rs
@@ -53,8 +53,8 @@ fn valid_with_state_from_multiple_parents() {
     }
 }
 
-/// Ensures that transactions that expire before or within the expiration slack of the chain tip
-/// are rejected.
+/// Ensures that transactions that expire before or within the expiration slack of the chain tip are
+/// rejected.
 mod tx_expiration {
     use super::*;
 

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -214,8 +214,8 @@ struct BlockProducerRpcServer {
 
     store: StoreClient,
 
-    /// Cached mempool statistics that are updated periodically to avoid locking the mempool
-    /// for each status request.
+    /// Cached mempool statistics that are updated periodically to avoid locking the mempool for
+    /// each status request.
     cached_mempool_stats: Arc<RwLock<MempoolStats>>,
 }
 

--- a/crates/block-producer/src/server/tests.rs
+++ b/crates/block-producer/src/server/tests.rs
@@ -59,8 +59,8 @@ async fn block_producer_startup_is_robust_to_network_failures() {
         .unwrap();
     });
 
-    // start the block producer BEFORE the store is available
-    // this tests the exponential backoff behavior
+    // start the block producer BEFORE the store is available this tests the exponential backoff
+    // behavior
     let store_url = Url::parse(&format!("http://{store_addr}")).expect("Failed to parse store URL");
     let validator_url =
         Url::parse(&format!("http://{validator_addr}")).expect("Failed to parse validator URL");
@@ -82,8 +82,8 @@ async fn block_producer_startup_is_robust_to_network_failures() {
         .unwrap();
     });
 
-    // test: connecting to the block producer should fail because the store is not yet started
-    // (and therefore the block producer is not yet listening)
+    // test: connecting to the block producer should fail because the store is not yet started (and
+    // therefore the block producer is not yet listening)
     let block_producer_endpoint =
         Endpoint::try_from(format!("http://{block_producer_addr}")).expect("valid url");
     let block_producer_client =
@@ -97,8 +97,8 @@ async fn block_producer_startup_is_robust_to_network_failures() {
     let data_directory = tempfile::tempdir().expect("tempdir should be created");
     let store_runtime = start_store(store_addr, data_directory.path()).await;
 
-    // wait for the block producer's exponential backoff to connect to the store
-    // use a retry loop since CI environments may be slower
+    // wait for the block producer's exponential backoff to connect to the store use a retry loop
+    // since CI environments may be slower
     let block_producer_client = {
         let mut attempts = 0;
         loop {

--- a/crates/block-producer/src/test_utils/account.rs
+++ b/crates/block-producer/src/test_utils/account.rs
@@ -54,8 +54,8 @@ impl<const NUM_STATES: usize> MockPrivateAccount<NUM_STATES> {
 }
 
 impl<const NUM_STATES: usize> From<u32> for MockPrivateAccount<NUM_STATES> {
-    /// Each index gives rise to a different account ID
-    /// Passing index 0 signifies that it's a new account
+    /// Each index gives rise to a different account ID Passing index 0 signifies that it's a new
+    /// account
     fn from(index: u32) -> Self {
         let mut lock = MOCK_ACCOUNTS.lock().expect("Poisoned mutex");
         if let Some(&(account_id, init_state)) = lock.get(&index) {

--- a/crates/block-producer/src/test_utils/mod.rs
+++ b/crates/block-producer/src/test_utils/mod.rs
@@ -23,8 +23,8 @@ pub mod note;
 pub struct Random(RandomCoin);
 
 impl Random {
-    /// Creates a [Random] with a random seed. This seed is logged
-    /// so that it is known for test failures.
+    /// Creates a [Random] with a random seed. This seed is logged so that it is known for test
+    /// failures.
     pub fn with_random_seed() -> Self {
         let seed: [u32; 4] = rand::random();
 

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -56,8 +56,8 @@ fn main() -> miette::Result<()> {
     Ok(())
 }
 
-/// Generates protobuf bindings from the given file descriptor set and stores them in the
-/// given destination directory.
+/// Generates protobuf bindings from the given file descriptor set and stores them in the given
+/// destination directory.
 fn generate_bindings(file_descriptors: FileDescriptorSet, dst_dir: &Path) -> miette::Result<()> {
     let mut prost_config = tonic_prost_build::Config::new();
     prost_config.skip_debug(["AccountId", "Digest"]);
@@ -81,9 +81,9 @@ fn rustfmt_generated(dir: &Path) -> miette::Result<()> {
     }
 
     // Just ignore output and exit status. The `rustfmt` binary is part of the Rust toolchain even
-    // if the `rustfmt` component is not installed, and it will print a warning and exit with
-    // status code 1. We don't actually care about formatting in this case, so we can just ignore
-    // the error.
+    // if the `rustfmt` component is not installed, and it will print a warning and exit with status
+    // code 1. We don't actually care about formatting in this case, so we can just ignore the
+    // error.
     let _output = Command::new("rustfmt")
         .args(["--edition", "2024"])
         .args(&rs_files)

--- a/crates/proto/src/clients/mod.rs
+++ b/crates/proto/src/clients/mod.rs
@@ -403,8 +403,8 @@ impl<State> Builder<State> {
 }
 
 impl Builder<WantsTls> {
-    /// Create a new strict builder from a gRPC endpoint URL such as
-    /// `http://localhost:8080` or `https://api.example.com:443`.
+    /// Create a new strict builder from a gRPC endpoint URL such as `http://localhost:8080` or
+    /// `https://api.example.com:443`.
     pub fn new(url: Url) -> Builder<WantsTls> {
         let endpoint = Endpoint::from_shared(String::from(url))
             .expect("Url type always results in valid endpoint");

--- a/crates/proto/src/decode/mod.rs
+++ b/crates/proto/src/decode/mod.rs
@@ -39,8 +39,8 @@ impl<M: prost::Message> Default for GrpcStructDecoder<M> {
 }
 
 impl<M: prost::Message> GrpcStructDecoder<M> {
-    /// Decode a required optional field: checks for `None`, converts via `TryInto`, and adds
-    /// field context on error.
+    /// Decode a required optional field: checks for `None`, converts via `TryInto`, and adds field
+    /// context on error.
     pub fn decode_field<T, F>(
         &self,
         name: &'static str,

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -334,8 +334,8 @@ impl From<AccountStorageHeader> for proto::account::AccountStorageHeader {
 /// to use the `SyncAccountVault` endpoint instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccountVaultDetails {
-    /// The vault has too many assets to return inline.
-    /// Clients must use `SyncAccountVault` endpoint instead.
+    /// The vault has too many assets to return inline. Clients must use `SyncAccountVault` endpoint
+    /// instead.
     LimitExceeded,
 
     /// The assets in the vault (up to `MAX_RETURN_ENTRIES`).
@@ -343,8 +343,8 @@ pub enum AccountVaultDetails {
 }
 
 impl AccountVaultDetails {
-    /// Maximum number of vault entries that can be returned in a single response.
-    /// Accounts with more assets will have `LimitExceeded` variant.
+    /// Maximum number of vault entries that can be returned in a single response. Accounts with
+    /// more assets will have `LimitExceeded` variant.
     pub const MAX_RETURN_ENTRIES: usize = 1000;
 
     pub fn new(vault: &AssetVault) -> Self {
@@ -419,16 +419,16 @@ pub struct AccountStorageMapDetails {
 /// instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StorageMapEntries {
-    /// The map has too many entries to return inline.
-    /// Clients must use `SyncAccountStorageMaps` endpoint instead.
+    /// The map has too many entries to return inline. Clients must use `SyncAccountStorageMaps`
+    /// endpoint instead.
     LimitExceeded,
 
-    /// All storage map entries (key-value pairs) without proofs.
-    /// Used when all entries are requested for small maps.
+    /// All storage map entries (key-value pairs) without proofs. Used when all entries are
+    /// requested for small maps.
     AllEntries(Vec<(StorageMapKey, Word)>),
 
-    /// Specific entries with their SMT proofs for client-side verification.
-    /// Used when specific keys are requested from the storage map.
+    /// Specific entries with their SMT proofs for client-side verification. Used when specific keys
+    /// are requested from the storage map.
     EntriesWithProofs(Vec<SmtProof>),
 }
 
@@ -926,8 +926,8 @@ impl TryFrom<proto::store::transaction_inputs::AccountTransactionInputRecord> fo
 
         let account_commitment = decode!(decoder, from.account_commitment)?;
 
-        // If the commitment is equal to `Word::empty()`, it signifies that this is a new
-        // account which is not yet present in the Store.
+        // If the commitment is equal to `Word::empty()`, it signifies that this is a new account
+        // which is not yet present in the Store.
         let account_commitment = if account_commitment == Word::empty() {
             None
         } else {
@@ -1039,8 +1039,7 @@ impl From<NetworkAccountId> for AccountId {
 }
 
 impl From<NetworkAccountId> for u32 {
-    /// Returns the 30-bit prefix of the network account ID.
-    /// This is used for note tag matching.
+    /// Returns the 30-bit prefix of the network account ID. This is used for note tag matching.
     fn from(value: NetworkAccountId) -> Self {
         value.prefix()
     }

--- a/crates/proto/src/domain/note.rs
+++ b/crates/proto/src/domain/note.rs
@@ -307,8 +307,8 @@ impl TryFrom<proto::note::NoteScript> for NoteScript {
 
 /// Decodes the `(sender, note_type, tag)` triple from a proto `NoteMetadata` into a
 /// [`PartialNoteMetadata`]. The attachment-related fields on the proto are ignored — when full
-/// attachments are also transmitted, the receiver derives the canonical headers and commitment
-/// from those instead.
+/// attachments are also transmitted, the receiver derives the canonical headers and commitment from
+/// those instead.
 fn partial_note_metadata_from_proto(
     value: proto::note::NoteMetadata,
 ) -> Result<PartialNoteMetadata, ConversionError> {
@@ -322,8 +322,8 @@ fn partial_note_metadata_from_proto(
     Ok(PartialNoteMetadata::new(sender, note_type).with_tag(tag))
 }
 
-/// Decodes a serialized [`NoteAttachments`] payload. Empty bytes are treated as an empty
-/// collection so that proto3's default value round-trips cleanly.
+/// Decodes a serialized [`NoteAttachments`] payload. Empty bytes are treated as an empty collection
+/// so that proto3's default value round-trips cleanly.
 fn decode_attachments(bytes: &[u8]) -> Result<NoteAttachments, ConversionError> {
     if bytes.is_empty() {
         Ok(NoteAttachments::empty())

--- a/crates/remote-prover-client/src/lib.rs
+++ b/crates/remote-prover-client/src/lib.rs
@@ -39,8 +39,7 @@ pub enum RemoteProverClientError {
     #[error("{error_msg}")]
     Other {
         error_msg: Box<str>,
-        // thiserror will return this when calling `Error::source` on
-        // `RemoteProverClientError`.
+        // thiserror will return this when calling `Error::source` on `RemoteProverClientError`.
         source: Option<Box<dyn CoreError + Send + Sync + 'static>>,
     },
 }
@@ -52,15 +51,15 @@ impl From<RemoteProverClientError> for String {
 }
 
 impl RemoteProverClientError {
-    /// Creates a custom error using the [`RemoteProverClientError::Other`] variant from an
-    /// error message.
+    /// Creates a custom error using the [`RemoteProverClientError::Other`] variant from an error
+    /// message.
     pub fn other(message: impl Into<String>) -> Self {
         let message: String = message.into();
         Self::Other { error_msg: message.into(), source: None }
     }
 
-    /// Creates a custom error using the [`RemoteProverClientError::Other`] variant from an
-    /// error message and a source error.
+    /// Creates a custom error using the [`RemoteProverClientError::Other`] variant from an error
+    /// message and a source error.
     pub fn other_with_source(
         message: impl Into<String>,
         source: impl CoreError + Send + Sync + 'static,

--- a/crates/remote-prover-client/src/remote_prover/batch_prover.rs
+++ b/crates/remote-prover-client/src/remote_prover/batch_prover.rs
@@ -40,8 +40,8 @@ pub struct RemoteBatchProver {
 }
 
 impl RemoteBatchProver {
-    /// Creates a new [`RemoteBatchProver`] with the specified gRPC server endpoint. The
-    /// endpoint should be in the format `{protocol}://{hostname}:{port}`.
+    /// Creates a new [`RemoteBatchProver`] with the specified gRPC server endpoint. The endpoint
+    /// should be in the format `{protocol}://{hostname}:{port}`.
     pub fn new(endpoint: impl Into<String>) -> Self {
         RemoteBatchProver {
             endpoint: endpoint.into(),
@@ -65,9 +65,9 @@ impl RemoteBatchProver {
         self
     }
 
-    /// Establishes a connection to the remote batch prover server. The connection is
-    /// maintained for the lifetime of the prover. If the connection is already established, this
-    /// method does nothing.
+    /// Establishes a connection to the remote batch prover server. The connection is maintained for
+    /// the lifetime of the prover. If the connection is already established, this method does
+    /// nothing.
     async fn connect(&self) -> Result<(), RemoteProverClientError> {
         let mut client = self.client.lock().await;
         if client.is_some() {
@@ -165,8 +165,8 @@ impl RemoteBatchProver {
             )));
         }
 
-        // Because we checked the length matches we can zip the iterators up.
-        // We expect the transactions to be in the same order.
+        // Because we checked the length matches we can zip the iterators up. We expect the
+        // transactions to be in the same order.
         for (proposed_header, proven_header) in
             proposed_txs.into_iter().zip(proven_batch.transactions().as_slice())
         {
@@ -204,8 +204,8 @@ impl RemoteBatchProver {
                 )));
             }
 
-            // Because we checked the length matches we can zip the iterators up.
-            // We expect the nullifiers to be in the same order.
+            // Because we checked the length matches we can zip the iterators up. We expect the
+            // nullifiers to be in the same order.
             for (proposed_nullifier, input_note_commitment) in
                 proposed_header.nullifiers().zip(proven_header.input_notes().iter())
             {
@@ -225,8 +225,8 @@ impl RemoteBatchProver {
                 )));
             }
 
-            // Because we checked the length matches we can zip the iterators up.
-            // We expect the note IDs to be in the same order.
+            // Because we checked the length matches we can zip the iterators up. We expect the note
+            // IDs to be in the same order.
             for (proposed_note_id, header_note) in proposed_header
                 .output_notes()
                 .iter()

--- a/crates/remote-prover-client/src/remote_prover/block_prover.rs
+++ b/crates/remote-prover-client/src/remote_prover/block_prover.rs
@@ -36,8 +36,8 @@ pub struct RemoteBlockProver {
 }
 
 impl RemoteBlockProver {
-    /// Creates a new [`RemoteBlockProver`] with the specified gRPC server endpoint. The
-    /// endpoint should be in the format `{protocol}://{hostname}:{port}`.
+    /// Creates a new [`RemoteBlockProver`] with the specified gRPC server endpoint. The endpoint
+    /// should be in the format `{protocol}://{hostname}:{port}`.
     pub fn new(endpoint: impl Into<String>) -> Self {
         RemoteBlockProver {
             endpoint: endpoint.into(),
@@ -61,9 +61,9 @@ impl RemoteBlockProver {
         self
     }
 
-    /// Establishes a connection to the remote block prover server. The connection is
-    /// maintained for the lifetime of the prover. If the connection is already established, this
-    /// method does nothing.
+    /// Establishes a connection to the remote block prover server. The connection is maintained for
+    /// the lifetime of the prover. If the connection is already established, this method does
+    /// nothing.
     async fn connect(&self) -> Result<(), RemoteProverClientError> {
         let mut client = self.client.lock().await;
         if client.is_some() {

--- a/crates/rocksdb-cxx-linkage-fix/src/lib.rs
+++ b/crates/rocksdb-cxx-linkage-fix/src/lib.rs
@@ -16,7 +16,8 @@ pub fn configure() {
 }
 
 fn should_compile() -> bool {
-    // in sync with <https://github.com/rust-rocksdb/rust-rocksdb/blob/master/librocksdb-sys/build.rs#L348-L352>
+    // in sync with
+    // <https://github.com/rust-rocksdb/rust-rocksdb/blob/master/librocksdb-sys/build.rs#L348-L352>
     if let Ok(v) = env::var("ROCKSDB_COMPILE") {
         if v.to_lowercase() == "true" || v == "1" {
             return true;

--- a/crates/rpc/src/server/accept.rs
+++ b/crates/rpc/src/server/accept.rs
@@ -41,9 +41,9 @@ pub enum GenesisNegotiation {
 #[derive(Clone)]
 pub struct AcceptHeaderLayer {
     supported_versions: VersionReq,
-    /// The pre-release label (e.g. `"alpha"` from `"alpha.3"`), or `None` for stable versions.
-    /// Only the label is stored so that different pre-release numbers are accepted
-    /// (e.g. a server at `alpha.3` accepts clients at `alpha.1`).
+    /// The pre-release label (e.g. `"alpha"` from `"alpha.3"`), or `None` for stable versions. Only
+    /// the label is stored so that different pre-release numbers are accepted (e.g. a server at
+    /// `alpha.3` accepts clients at `alpha.1`).
     expected_pre_label: Option<String>,
     /// The patch version of the server. Used to enforce exact patch matching for pre-release
     /// versions (patch flexibility only applies to stable versions).
@@ -107,9 +107,9 @@ impl AcceptHeaderLayer {
     }
 }
 
-/// Extracts the label portion of a semver pre-release identifier, stripping any trailing
-/// numeric segment. For example, `"alpha.3"` returns `Some("alpha")` and `"rc.1"` returns
-/// `Some("rc")`. Returns `None` for empty (stable) pre-release identifiers.
+/// Extracts the label portion of a semver pre-release identifier, stripping any trailing numeric
+/// segment. For example, `"alpha.3"` returns `Some("alpha")` and `"rc.1"` returns `Some("rc")`.
+/// Returns `None` for empty (stable) pre-release identifiers.
 fn pre_release_label(pre: &semver::Prerelease) -> Option<String> {
     if pre.is_empty() {
         return None;
@@ -137,8 +137,8 @@ impl AcceptHeaderLayer {
     const GENESIS: Name<'static> = Name::new_unchecked("genesis");
     const GRPC: Name<'static> = Name::new_unchecked("grpc");
 
-    /// Parses the `Accept` header's contents, searching for any media type compatible with our
-    /// RPC version and genesis commitment, controlling whether `genesis` is optional or mandatory.
+    /// Parses the `Accept` header's contents, searching for any media type compatible with our RPC
+    /// version and genesis commitment, controlling whether `genesis` is optional or mandatory.
     fn negotiate(
         &self,
         accept: &str,
@@ -218,8 +218,8 @@ impl AcceptHeaderLayer {
                 if pre_release_label(&version.pre) != self.expected_pre_label {
                     continue;
                 }
-                // Pre-release versions must also match the patch version exactly
-                // (patch flexibility only applies to stable versions).
+                // Pre-release versions must also match the patch version exactly (patch flexibility
+                // only applies to stable versions).
                 if self.expected_pre_label.is_some() && version.patch != self.expected_patch {
                     continue;
                 }

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -519,8 +519,8 @@ impl api_server::Api for RpcService {
         block_producer.clone().submit_proven_tx(request).await
     }
 
-    /// Deserializes the batch, strips MAST decorators from full output note scripts, rebuilds
-    /// the batch, then forwards it to the block producer.
+    /// Deserializes the batch, strips MAST decorators from full output note scripts, rebuilds the
+    /// batch, then forwards it to the block producer.
     async fn submit_proven_tx_batch(
         &self,
         request: tonic::Request<proto::transaction::TransactionBatch>,

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -95,9 +95,9 @@ impl Rpc {
             .layer(GrpcWebLayer::new())
             .layer(grpc::rate_limit_concurrent_connections(self.grpc_options))
             .layer(grpc::rate_limit_per_ip(self.grpc_options)?)
-            // Note: must come after the CORS layer, as otherwise accept rejections
-            // do _not_ get CORS headers applied, masking the accept error in
-            // web-clients (which would experience CORS rejection).
+            // Note: must come after the CORS layer, as otherwise accept rejections do _not_ get
+            // CORS headers applied, masking the accept error in web-clients (which would experience
+            // CORS rejection).
             .layer(
                 AcceptHeaderLayer::new(&rpc_version, genesis.commitment())
                     .with_genesis_enforced_method("SubmitProvenTx")

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -45,8 +45,8 @@ use url::Url;
 
 use crate::Rpc;
 
-/// Byte offset of the account delta commitment in serialized `ProvenTransaction`.
-/// Layout: `AccountId` (15) + `initial_commitment` (32) + `final_commitment` (32) = 79
+/// Byte offset of the account delta commitment in serialized `ProvenTransaction`. Layout:
+/// `AccountId` (15) + `initial_commitment` (32) + `final_commitment` (32) = 79
 const DELTA_COMMITMENT_BYTE_OFFSET: usize = 15 + 32 + 32;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -217,8 +217,8 @@ async fn rpc_server_rejects_requests_with_accept_header_invalid_version() {
 
 #[tokio::test]
 async fn rpc_startup_is_robust_to_network_failures() {
-    // This test starts the store and RPC components and verifies that they successfully
-    // connect to each other on startup and that they reconnect after the store is restarted.
+    // This test starts the store and RPC components and verifies that they successfully connect to
+    // each other on startup and that they reconnect after the store is restarted.
 
     // Start the RPC.
     let (mut rpc_client, _, store_listener) = start_rpc().await;
@@ -473,8 +473,8 @@ async fn connect_rpc(url: Url, local_address: Option<IpAddr>) -> RpcClient {
     RpcClient::with_interceptor(channel, interceptor)
 }
 
-/// Binds a socket on an available port, runs the RPC server on it, and
-/// returns a client to talk to the server, along with the socket address.
+/// Binds a socket on an available port, runs the RPC server on it, and returns a client to talk to
+/// the server, along with the socket address.
 async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TcpListener) {
     start_rpc_with_options(GrpcOptionsExternal::test()).await
 }
@@ -544,9 +544,8 @@ async fn start_store(store_listener: TcpListener) -> (Runtime, TempDir, Word, So
         .expect("Failed to bind store ntx-builder gRPC endpoint");
     let block_producer_listener =
         TcpListener::bind("127.0.0.1:0").await.expect("store should bind a port");
-    // In order to later kill the store, we need to spawn a new runtime and run the store on
-    // it. That allows us to kill all the tasks spawned by the store when we
-    // kill the runtime.
+    // In order to later kill the store, we need to spawn a new runtime and run the store on it.
+    // That allows us to kill all the tasks spawned by the store when we kill the runtime.
     let store_runtime =
         runtime::Builder::new_multi_thread().enable_time().enable_io().build().unwrap();
     store_runtime.spawn(async move {
@@ -656,8 +655,8 @@ async fn get_limits_endpoint() {
         QueryParamNoteTagLimit::LIMIT
     );
 
-    // SyncAccountVault and SyncAccountStorageMaps accept a singular account_id,
-    // not a repeated list, so they do not have list parameter limits.
+    // SyncAccountVault and SyncAccountStorageMaps accept a singular account_id, not a repeated
+    // list, so they do not have list parameter limits.
     assert!(
         !limits.endpoints.contains_key("SyncAccountVault"),
         "SyncAccountVault should not have list parameter limits"

--- a/crates/store/benches/account_tree.rs
+++ b/crates/store/benches/account_tree.rs
@@ -124,8 +124,8 @@ fn setup_account_tree_with_history(
 // VANILLA ACCOUNTTREE BENCHMARKS
 // ================================================================================================
 
-/// Benchmarks vanilla `AccountTree` open (query) operations.
-/// This provides a baseline for comparison with historical access operations.
+/// Benchmarks vanilla `AccountTree` open (query) operations. This provides a baseline for
+/// comparison with historical access operations.
 fn bench_vanilla_access(c: &mut Criterion) {
     let mut group = c.benchmark_group("account_tree_vanilla_access");
     let base_path = default_storage_path();
@@ -146,8 +146,8 @@ fn bench_vanilla_access(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmarks vanilla `AccountTree` insertion (mutation) performance.
-/// This provides a baseline for comparison with history-tracking insertion.
+/// Benchmarks vanilla `AccountTree` insertion (mutation) performance. This provides a baseline for
+/// comparison with history-tracking insertion.
 fn bench_vanilla_insertion(c: &mut Criterion) {
     let mut group = c.benchmark_group("account_tree_insertion");
     let base_path = default_storage_path();

--- a/crates/store/build.rs
+++ b/crates/store/build.rs
@@ -44,14 +44,13 @@ fn generate_agglayer_sample_accounts() {
     // Create the directory if it doesn't exist
     fs_err::create_dir_all(&samples_dir).expect("Failed to create samples directory");
 
-    // Use deterministic seeds for reproducible builds.
-    // WARNING: DO NOT USE THESE IN PRODUCTION
+    // Use deterministic seeds for reproducible builds. WARNING: DO NOT USE THESE IN PRODUCTION
     let bridge_seed: Word = Word::new([Felt::new(1u64); 4]);
     let eth_faucet_seed: Word = Word::new([Felt::new(2u64); 4]);
     let usdc_faucet_seed: Word = Word::new([Felt::new(3u64); 4]);
 
-    // Create bridge admin and GER manager as proper wallet accounts.
-    // WARNING: DO NOT USE THESE IN PRODUCTION
+    // Create bridge admin and GER manager as proper wallet accounts. WARNING: DO NOT USE THESE IN
+    // PRODUCTION
     let bridge_admin_key =
         SecretKey::with_rng(&mut RandomCoin::new(Word::new([Felt::new(4u64); 4])));
     let ger_manager_key =
@@ -80,19 +79,19 @@ fn generate_agglayer_sample_accounts() {
     let bridge_admin_id = bridge_admin.id();
     let ger_manager_id = ger_manager.id();
 
-    // Create the bridge account first (faucets need to reference it)
-    // Use "existing" variant so accounts have nonce > 0 (required for genesis)
+    // Create the bridge account first (faucets need to reference it) Use "existing" variant so
+    // accounts have nonce > 0 (required for genesis)
     let bridge_account =
         create_existing_bridge_account(bridge_seed, bridge_admin_id, ger_manager_id);
     let bridge_account_id = bridge_account.id();
 
-    // Placeholder Ethereum addresses for sample faucets.
-    // WARNING: DO NOT USE THESE ADDRESSES IN PRODUCTION
+    // Placeholder Ethereum addresses for sample faucets. WARNING: DO NOT USE THESE ADDRESSES IN
+    // PRODUCTION
     let eth_origin_address = EthAddress::new([1u8; 20]);
     let usdc_origin_address = EthAddress::new([2u8; 20]);
 
-    // Create AggLayer faucets using "existing" variant
-    // ETH: 8 decimals (protocol max is 12), max supply of 1 billion tokens
+    // Create AggLayer faucets using "existing" variant ETH: 8 decimals (protocol max is 12), max
+    // supply of 1 billion tokens
     let eth_faucet = create_existing_agglayer_faucet(
         eth_faucet_seed,
         "ETH",

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -88,8 +88,8 @@ pub enum AccountStorageMapResult {
 
 /// Container for forest-related state that needs to be updated atomically.
 pub(crate) struct AccountStateForest<B: Backend = ForestInMemoryBackend> {
-    /// `LargeSmtForest` for efficient account storage reconstruction.
-    /// Populated during block import with storage and vault SMTs.
+    /// `LargeSmtForest` for efficient account storage reconstruction. Populated during block import
+    /// with storage and vault SMTs.
     forest: LargeSmtForest<B>,
 
     /// Reverse lookup from hashed SMT storage keys to raw storage map keys.
@@ -551,8 +551,8 @@ impl<B: Backend> AccountStateForest<B> {
         self.forest.latest_root(lineage).unwrap_or_else(empty_smt_root)
     }
 
-    /// Inserts asset vault data into the forest for the specified account. Assumes that asset
-    /// vault for this account does not yet exist in the forest.
+    /// Inserts asset vault data into the forest for the specified account. Assumes that asset vault
+    /// for this account does not yet exist in the forest.
     fn insert_account_vault(
         &mut self,
         block_num: BlockNumber,

--- a/crates/store/src/account_state_forest/tests.rs
+++ b/crates/store/src/account_state_forest/tests.rs
@@ -1073,9 +1073,9 @@ fn prune_preserves_entries_within_retention_window() {
     assert!(forest.get_vault_root(account_id, BlockNumber::from(100)).is_some());
 }
 
-/// Two accounts start with identical vault roots (same asset amount). When one account changes
-/// in the next block, verify the unchanged account's vault root still works for lookups and
-/// witness generation.
+/// Two accounts start with identical vault roots (same asset amount). When one account changes in
+/// the next block, verify the unchanged account's vault root still works for lookups and witness
+/// generation.
 #[test]
 fn shared_vault_root_retained_when_one_account_changes() {
     let mut forest = AccountStateForest::new();

--- a/crates/store/src/accounts/mod.rs
+++ b/crates/store/src/accounts/mod.rs
@@ -88,9 +88,8 @@ impl HistoricalOverlay {
                 match mutation {
                     NodeMutation::Addition(inner_node) => (*node_index, inner_node.hash()),
                     NodeMutation::Removal => {
-                        // Store the actual empty subtree root for this depth
-                        // depth() is 1-indexed from leaf, so we use it directly for
-                        // EmptySubtreeRoots
+                        // Store the actual empty subtree root for this depth depth() is 1-indexed
+                        // from leaf, so we use it directly for EmptySubtreeRoots
                         let empty_root = *EmptySubtreeRoots::entry(SMT_DEPTH, node_index.depth());
                         (*node_index, empty_root)
                     },
@@ -266,9 +265,9 @@ impl<S: SmtStorage> AccountTreeWithHistory<S> {
 
         let leaf_index = NodeIndex::from(leaf.index());
 
-        // Apply reversion overlays to reconstruct historical state.
-        // We reverse the overlay iteration (newest to oldest) to walk backwards in time
-        // from the latest state to the target block.
+        // Apply reversion overlays to reconstruct historical state. We reverse the overlay
+        // iteration (newest to oldest) to walk backwards in time from the latest state to the
+        // target block.
         let (path, leaf) = Self::apply_reversion_overlays(
             self.overlays.range(block_target..).rev().map(|(_, overlay)| overlay),
             path_nodes,
@@ -319,10 +318,9 @@ impl<S: SmtStorage> AccountTreeWithHistory<S> {
                     .expect("proof_indices should not include root")
                     as usize;
 
-                // Apply reversion mutation if this node was modified.
-                // It's sound since `proof_indices()`` returns siblings on the path from leaf to
-                // root, hence the height is always less than `SMT_DEPTH`, the leaf
-                // and root are not included.
+                // Apply reversion mutation if this node was modified. It's sound since
+                // `proof_indices()`` returns siblings on the path from leaf to root, hence the
+                // height is always less than `SMT_DEPTH`, the leaf and root are not included.
                 if let Some(hash) = overlay.node_mutations.get(&sibling) {
                     path_nodes[height] = *hash;
                 }
@@ -338,8 +336,8 @@ impl<S: SmtStorage> AccountTreeWithHistory<S> {
             }
         }
 
-        // Build the Merkle path directly from the reconstructed nodes
-        // No need for build_dense_path since all nodes have actual values (not sentinels)
+        // Build the Merkle path directly from the reconstructed nodes No need for build_dense_path
+        // since all nodes have actual values (not sentinels)
         let dense: Vec<Word> = path_nodes.iter().rev().copied().collect();
         let path = MerklePath::new(dense);
         let path = SparseMerklePath::try_from(path).ok()?;

--- a/crates/store/src/accounts/tests.rs
+++ b/crates/store/src/accounts/tests.rs
@@ -351,8 +351,7 @@ mod account_tree_with_history_tests {
             .collect();
         hist.compute_and_apply_mutations(updates3).unwrap();
 
-        // Verify states at different blocks
-        // Check genesis - first 50 accounts exist, others don't
+        // Verify states at different blocks Check genesis - first 50 accounts exist, others don't
         for i in 0..50 {
             let witness = hist.open_at(account_ids[i], BlockNumber::GENESIS).unwrap();
             assert_eq!(witness.state_commitment(), Word::from([i as u32, 0, 0, 0]));

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -142,8 +142,8 @@ impl PartialEq<(Nullifier, BlockNumber)> for NullifierInfo {
 pub struct TransactionRecord {
     pub block_num: BlockNumber,
     pub header: TransactionHeader,
-    /// Inclusion proofs for committed output notes. Notes in `header.output_notes()` without
-    /// a corresponding proof here were erased (created and consumed within the same batch).
+    /// Inclusion proofs for committed output notes. Notes in `header.output_notes()` without a
+    /// corresponding proof here were erased (created and consumed within the same batch).
     pub output_note_proofs: Vec<NoteSyncRecord>,
 }
 
@@ -586,8 +586,8 @@ impl Db {
         self.transact("apply block", move |conn| -> Result<()> {
             models::queries::apply_block(conn, &signed_block, &notes)?;
 
-            // XXX FIXME TODO free floating mutex MUST NOT exist
-            // it doesn't bind it properly to the data locked!
+            // XXX FIXME TODO free floating mutex MUST NOT exist it doesn't bind it properly to the
+            // data locked!
             {
                 let _span = tracing::info_span!(target: COMPONENT, "acquire_write_lock").entered();
                 if allow_acquire.send(()).is_err() {
@@ -665,8 +665,8 @@ impl Db {
         values.extend(page.values);
         let mut last_block_included = page.last_block_included;
 
-        // If the first page returned no values, the block at block_range_start has more
-        // entries than the limit allows (e.g. genesis accounts with large storage maps).
+        // If the first page returned no values, the block at block_range_start has more entries
+        // than the limit allows (e.g. genesis accounts with large storage maps).
         if values.is_empty() && last_block_included == block_range_start {
             return Ok(AccountStorageMapDetails::limit_exceeded(slot_name));
         }

--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -145,8 +145,8 @@ pub(crate) fn select_account(
 
     let summary: AccountSummary = raw.try_into()?;
 
-    // Backfill account details from database
-    // For private accounts, we don't store full details in the database
+    // Backfill account details from database For private accounts, we don't store full details in
+    // the database
     let details = if account_id.has_public_state() {
         Some(select_full_account(conn, account_id)?)
     } else {
@@ -348,8 +348,7 @@ pub struct PublicAccountStateRoots {
     pub storage_header: AccountStorageHeader,
 }
 
-/// Page of public account state roots returned by
-/// [`select_public_account_state_roots_paged`].
+/// Page of public account state roots returned by [`select_public_account_state_roots_paged`].
 #[derive(Debug)]
 pub struct PublicAccountStateRootsPage {
     /// The public account state roots in this page.
@@ -539,8 +538,8 @@ pub(crate) fn select_account_vault_assets(
     block_range: RangeInclusive<BlockNumber>,
 ) -> Result<(BlockNumber, Vec<AccountVaultValue>), DatabaseError> {
     use schema::account_vault_assets as t;
-    // TODO: These limits should be given by the protocol.
-    // See miden-protocol/issues/1770 for more details
+    // TODO: These limits should be given by the protocol. See miden-protocol/issues/1770 for more
+    // details
     const ROW_OVERHEAD_BYTES: usize = 2 * size_of::<Word>() + size_of::<u32>(); // key + asset + block_num
     const MAX_ROWS: usize = MAX_RESPONSE_PAYLOAD_BYTES / ROW_OVERHEAD_BYTES;
 
@@ -567,8 +566,8 @@ pub(crate) fn select_account_vault_assets(
             .limit(i64::try_from(MAX_ROWS + 1).expect("should fit within i64"))
             .load::<(i64, Vec<u8>, Option<Vec<u8>>)>(conn)?;
 
-    // If we got more rows than the limit, the last block may be incomplete so we
-    // drop it entirely and derive last_block_included from the remaining rows.
+    // If we got more rows than the limit, the last block may be incomplete so we drop it entirely
+    // and derive last_block_included from the remaining rows.
     let (last_block_included, values) = if let Some(&(last_block_num, ..)) = raw.last()
         && raw.len() > MAX_ROWS
     {
@@ -814,8 +813,8 @@ pub(crate) fn select_account_storage_map_values_paged(
             .limit(i64::try_from(limit + 1).expect("limit fits within i64"))
             .load(conn)?;
 
-    // If we got more rows than the limit, the last block may be incomplete so we
-    // drop it entirely and derive last_block_included from the remaining rows.
+    // If we got more rows than the limit, the last block may be incomplete so we drop it entirely
+    // and derive last_block_included from the remaining rows.
     let (last_block_included, values) = if let Some(&(last_block_num, ..)) = raw.last()
         && raw.len() > limit
     {
@@ -1169,13 +1168,13 @@ fn prepare_partial_account_update(
     account_id: AccountId,
     delta: &miden_protocol::account::delta::AccountDelta,
 ) -> Result<(AccountStateForInsert, PendingStorageInserts, PendingAssetInserts), DatabaseError> {
-    // Build the minimal account state needed for partial delta application.
-    // Only load the storage map entries and vault balances that will receive updates.
-    // The next line fetches the header, which will always change unless the delta is empty.
+    // Build the minimal account state needed for partial delta application. Only load the storage
+    // map entries and vault balances that will receive updates. The next line fetches the header,
+    // which will always change unless the delta is empty.
     let state_headers = select_minimal_account_state_headers(conn, account_id)?;
 
-    // --- Process asset updates. ---------------------------------
-    // Only query balances for faucet_ids that are being updated.
+    // --- Process asset updates. --------------------------------- Only query balances for
+    // faucet_ids that are being updated.
     let faucet_ids =
         Vec::from_iter(delta.vault().fungible().iter().map(|(vault_key, _)| vault_key.faucet_id()));
     let prev_balances = select_vault_balances_by_faucet_ids(conn, account_id, &faucet_ids)?;
@@ -1244,8 +1243,7 @@ fn prepare_partial_account_update(
         vault.root()
     };
 
-    // --- Compute updated account state for the accounts row. ---
-    // Apply nonce delta.
+    // --- Compute updated account state for the accounts row. --- Apply nonce delta.
     let new_nonce_value = state_headers
         .nonce
         .as_canonical_u64()
@@ -1399,8 +1397,7 @@ pub(crate) fn upsert_accounts(
             .set(&account_value)
             .execute(conn)?;
 
-        // insert pending storage map entries
-        // TODO consider batching
+        // insert pending storage map entries TODO consider batching
         for (acc_id, slot_name, key, value) in pending_storage_inserts {
             insert_account_storage_map_value(conn, acc_id, block_num, slot_name, key, value)?;
         }
@@ -1555,8 +1552,8 @@ pub(crate) struct AccountStorageMapRowInsert {
 // ================================================================================================
 
 /// Number of historical blocks to retain for vault assets, storage map values, and account codes.
-/// Entries older than `chain_tip - HISTORICAL_BLOCK_RETENTION` will be deleted,
-/// except for entries marked with `is_latest=true` which are always retained.
+/// Entries older than `chain_tip - HISTORICAL_BLOCK_RETENTION` will be deleted, except for entries
+/// marked with `is_latest=true` which are always retained.
 pub const HISTORICAL_BLOCK_RETENTION: u32 = 50;
 
 /// Clean up old entries for all accounts, deleting entries older than the retention window.

--- a/crates/store/src/db/models/queries/accounts/delta.rs
+++ b/crates/store/src/db/models/queries/accounts/delta.rs
@@ -46,8 +46,8 @@ struct AccountStateDeltaRow {
     storage_header: Option<Vec<u8>>,
 }
 
-/// Data needed for applying a delta update to an existing account.
-/// Fetches only the minimal data required, avoiding loading full code and storage.
+/// Data needed for applying a delta update to an existing account. Fetches only the minimal data
+/// required, avoiding loading full code and storage.
 #[derive(Debug, Clone)]
 pub(super) struct AccountStateHeadersForDelta {
     pub nonce: Felt,
@@ -55,8 +55,8 @@ pub(super) struct AccountStateHeadersForDelta {
     pub storage_header: AccountStorageHeader,
 }
 
-/// Minimal account state computed from a partial delta update.
-/// Contains only the fields needed for the accounts table row insert.
+/// Minimal account state computed from a partial delta update. Contains only the fields needed for
+/// the accounts table row insert.
 #[derive(Debug, Clone)]
 pub(super) struct PartialAccountState {
     pub nonce: Felt,
@@ -65,8 +65,8 @@ pub(super) struct PartialAccountState {
     pub vault_root: Word,
 }
 
-/// Represents the account state to be inserted, either from a full account
-/// or from a partial delta update.
+/// Represents the account state to be inserted, either from a full account or from a partial delta
+/// update.
 pub(super) enum AccountStateForInsert {
     /// Private account - no public state stored
     Private,

--- a/crates/store/src/db/models/queries/accounts/tests.rs
+++ b/crates/store/src/db/models/queries/accounts/tests.rs
@@ -677,8 +677,8 @@ fn test_upsert_accounts_with_multiple_storage_slots() {
         "Expected 5 storage slots (3 component + 2 auth)"
     );
 
-    // The storage commitment matching proves that all values are correctly preserved.
-    // We don't check individual slot values by index since slot ordering may vary.
+    // The storage commitment matching proves that all values are correctly preserved. We don't
+    // check individual slot values by index since slot ordering may vary.
 }
 
 #[test]
@@ -1087,8 +1087,8 @@ fn test_select_account_vault_at_block_exponential_updates() {
     }
 }
 
-/// Tests that deleted vault assets (asset = None) are correctly excluded from results,
-/// and that the deduplication handles deletion entries properly.
+/// Tests that deleted vault assets (asset = None) are correctly excluded from results, and that the
+/// deduplication handles deletion entries properly.
 #[test]
 fn test_select_account_vault_at_block_with_deletion() {
     use assert_matches::assert_matches;
@@ -1274,8 +1274,8 @@ fn test_prune_account_code_retains_latest_after_code_change() {
 
     assert_eq!(count_account_codes(&mut conn), 2, "both codes must exist before pruning");
 
-    // Advance past retention window and prune.
-    // cutoff = block_prunable - RETENTION = 2*RETENTION+1 - RETENTION = RETENTION+1 = block_code_b
+    // Advance past retention window and prune. cutoff = block_prunable - RETENTION = 2*RETENTION+1
+    // - RETENTION = RETENTION+1 = block_code_b
     let (_, _, codes_deleted) =
         prune_history(&mut conn, block_prunable).expect("prune_history failed");
 
@@ -1299,8 +1299,8 @@ fn test_prune_account_code_retains_latest_after_code_change() {
     );
 }
 
-/// Prune test 3: code A → code B → code A; after the retention window, code B must be pruned
-/// but code A must be retained because it is still the latest.
+/// Prune test 3: code A → code B → code A; after the retention window, code B must be pruned but
+/// code A must be retained because it is still the latest.
 #[test]
 fn test_prune_account_code_retains_revisited_code() {
     let mut conn = setup_test_db();
@@ -1354,8 +1354,8 @@ fn test_prune_account_code_retains_revisited_code() {
     let (_, _, codes_deleted) =
         prune_history(&mut conn, block_prunable).expect("prune_history failed");
 
-    // Code B is no longer referenced by any account row within the retention window → pruned.
-    // Code A is still referenced by the block_code_a_again accounts row (within cutoff) → retained.
+    // Code B is no longer referenced by any account row within the retention window → pruned. Code
+    // A is still referenced by the block_code_a_again accounts row (within cutoff) → retained.
     assert_eq!(codes_deleted, 1, "exactly one code (B) must be pruned");
     assert!(account_code_exists(&mut conn, code_commitment_a), "code A must be retained");
     assert!(!account_code_exists(&mut conn, code_commitment_b), "code B must be pruned");

--- a/crates/store/src/db/models/queries/block_headers.rs
+++ b/crates/store/src/db/models/queries/block_headers.rs
@@ -51,8 +51,8 @@ pub(crate) fn select_block_header_by_block_num(
         sel.filter(schema::block_headers::block_num.eq(block_num.to_raw_sql()))
             .get_result::<BlockHeaderRawRow>(conn)
             .optional()?
-        // invariant: only one block exists with the given block header, so the length is
-        // always zero or one
+        // invariant: only one block exists with the given block header, so the length is always
+        // zero or one
     } else {
         sel.order(schema::block_headers::block_num.desc())
             .limit(1)

--- a/crates/store/src/db/models/queries/notes.rs
+++ b/crates/store/src/db/models/queries/notes.rs
@@ -632,10 +632,8 @@ pub struct NoteDetailsRawRow {
     pub serial_num: Option<Vec<u8>>,
 }
 
-// Note: One cannot use `#[diesel(embed)]` to structure
-// this, it will yield a significant amount of errors
-// when used with join and debugging is painful to put it
-// mildly.
+// Note: One cannot use `#[diesel(embed)]` to structure this, it will yield a significant amount of
+// errors when used with join and debugging is painful to put it mildly.
 #[derive(Debug, Clone, PartialEq, Queryable)]
 pub struct NoteRecordWithScriptRawJoined {
     pub committed_at: i64,
@@ -721,7 +719,7 @@ impl TryInto<NoteRecord> for NoteRecordWithScriptRawJoined {
             assets,
             storage,
             serial_num,
-            //details ^^^,
+            // details ^^^,
             inclusion_path,
             script,
             ..

--- a/crates/store/src/db/models/queries/transactions.rs
+++ b/crates/store/src/db/models/queries/transactions.rs
@@ -219,8 +219,8 @@ pub fn select_transactions_records(
 
     let desired_account_ids = serialize_vec(account_ids);
 
-    // Read transactions in chunks to prevent loading excessive data and to stop
-    // as soon as we approach the size limit
+    // Read transactions in chunks to prevent loading excessive data and to stop as soon as we
+    // approach the size limit
     let mut all_transactions = Vec::new();
     let mut total_size = 0i64;
     let mut last_block_num: Option<i64> = None;
@@ -276,8 +276,8 @@ pub fn select_transactions_records(
         }
     }
 
-    // Ensure block consistency: remove the last block if it's incomplete
-    // (we may have stopped loading mid-block due to size constraints)
+    // Ensure block consistency: remove the last block if it's incomplete (we may have stopped
+    // loading mid-block due to size constraints)
     if total_size >= max_payload_bytes {
         // SAFETY: We're guaranteed to have at least one transaction since total_size > 0
         let last_block_num = last_block_num.expect(
@@ -291,9 +291,9 @@ pub fn select_transactions_records(
                 .collect(),
         )?;
 
-        // SAFETY: block_num came from the database and was previously validated.
-        // Subtraction is safe under the assumption that genesis block (where it could fail) does
-        // not have any transactions.
+        // SAFETY: block_num came from the database and was previously validated. Subtraction is
+        // safe under the assumption that genesis block (where it could fail) does not have any
+        // transactions.
         let last_included_block = BlockNumber::from_raw_sql(last_block_num.saturating_sub(1))?;
         Ok((last_included_block, filtered_transactions))
     } else {
@@ -328,8 +328,8 @@ fn with_output_note_proofs(
         .zip(tx_output_notes)
         .map(|(raw, output_notes)| {
             let transaction_id = TransactionId::read_from_bytes(&raw.transaction_id)?;
-            // Collect inclusion proofs for committed output notes. Notes not found in
-            // the `notes` table were erased (created and consumed in the same batch).
+            // Collect inclusion proofs for committed output notes. Notes not found in the `notes`
+            // table were erased (created and consumed in the same batch).
             let output_note_proofs = output_notes
                 .iter()
                 .filter_map(|note| output_notes_by_id.get(&note.id()).cloned())

--- a/crates/store/src/db/models/utils.rs
+++ b/crates/store/src/db/models/utils.rs
@@ -4,8 +4,8 @@ use miden_protocol::utils::serde::Serializable;
 
 use crate::errors::DatabaseError;
 
-/// Utility to convert an iterable container of containing `R`-typed values
-/// to a `Vec<D>` and bail at the first failing conversion
+/// Utility to convert an iterable container of containing `R`-typed values to a `Vec<D>` and bail
+/// at the first failing conversion
 pub(crate) fn vec_raw_try_into<D, R: TryInto<D>>(
     raw: impl IntoIterator<Item = R>,
 ) -> std::result::Result<Vec<D>, <R as TryInto<D>>::Error> {

--- a/crates/store/src/db/schema.rs
+++ b/crates/store/src/db/schema.rs
@@ -107,8 +107,8 @@ diesel::table! {
 diesel::joinable!(accounts -> account_codes (code_commitment));
 diesel::joinable!(accounts -> block_headers (block_num));
 // Note: Cannot use diesel::joinable! with accounts table due to composite primary key
-// diesel::joinable!(notes -> accounts (sender));
-// diesel::joinable!(transactions -> accounts (account_id));
+// diesel::joinable!(notes -> accounts (sender)); diesel::joinable!(transactions -> accounts
+// (account_id));
 diesel::joinable!(notes -> block_headers (committed_at));
 diesel::joinable!(notes -> note_scripts (script_root));
 diesel::joinable!(nullifiers -> block_headers (block_num));

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -908,8 +908,8 @@ fn notes() {
     assert_eq!(note_1.details, None);
 }
 
-/// Creates notes across 3 blocks, then calls `get_note_sync_multi` once and verifies
-/// all 3 blocks' notes are returned in a single query, ordered by block number.
+/// Creates notes across 3 blocks, then calls `get_note_sync_multi` once and verifies all 3 blocks'
+/// notes are returned in a single query, ordered by block number.
 #[test]
 #[miden_node_test_macro::enable_logging]
 fn note_sync_across_multiple_blocks() {
@@ -1233,8 +1233,8 @@ fn select_storage_map_sync_values() {
             .unwrap();
     }
 
-    // Insert data across multiple blocks using individual inserts
-    // Block 1: key1 -> value1, key2 -> value2
+    // Insert data across multiple blocks using individual inserts Block 1: key1 -> value1, key2 ->
+    // value2
     queries::insert_account_storage_map_value(
         &mut conn,
         account_id,
@@ -1418,8 +1418,8 @@ fn select_storage_map_sync_values_paginates_until_last_block() {
     assert_eq!(page.values.len(), 1, "should include block 1 only");
 }
 
-/// Tests that `select_account_storage_map_values_paged` does not panic when all entries
-/// exceed the limit and are in genesis block (block 0). Previously, this caused
+/// Tests that `select_account_storage_map_values_paged` does not panic when all entries exceed the
+/// limit and are in genesis block (block 0). Previously, this caused
 /// `last_block_num.saturating_sub(1) = -1` which failed `BlockNumber::from_raw_sql`.
 #[test]
 fn select_storage_map_sync_values_all_entries_in_genesis_block() {
@@ -1446,9 +1446,9 @@ fn select_storage_map_sync_values_all_entries_in_genesis_block() {
         .unwrap();
     }
 
-    // Query with limit=1 so that raw.len() (3) > limit (1), triggering the
-    // pagination branch. All entries are in block 0, so take_while produces
-    // nothing and last_block_num.saturating_sub(1) = -1.
+    // Query with limit=1 so that raw.len() (3) > limit (1), triggering the pagination branch. All
+    // entries are in block 0, so take_while produces nothing and last_block_num.saturating_sub(1) =
+    // -1.
     let result = queries::select_account_storage_map_values_paged(
         &mut conn,
         account_id,
@@ -1456,8 +1456,8 @@ fn select_storage_map_sync_values_all_entries_in_genesis_block() {
         1,
     );
 
-    // Should not error - should return a valid page (possibly with empty values
-    // indicating no progress, which the caller interprets as limit_exceeded)
+    // Should not error - should return a valid page (possibly with empty values indicating no
+    // progress, which the caller interprets as limit_exceeded)
     let page = result.expect("should not return an internal error for genesis block entries");
     // The page should indicate no progress was made (stuck at genesis)
     assert!(
@@ -1466,9 +1466,9 @@ fn select_storage_map_sync_values_all_entries_in_genesis_block() {
     );
 }
 
-/// Tests that single-block overflow works for non-genesis blocks too.
-/// All entries are in block 5 and exceed the limit. The function should
-/// signal no progress rather than returning incorrect data.
+/// Tests that single-block overflow works for non-genesis blocks too. All entries are in block 5
+/// and exceed the limit. The function should signal no progress rather than returning incorrect
+/// data.
 #[test]
 fn select_storage_map_sync_values_all_entries_in_single_non_genesis_block() {
     let mut conn = create_db();
@@ -1502,8 +1502,8 @@ fn select_storage_map_sync_values_all_entries_in_single_non_genesis_block() {
     assert_eq!(page.last_block_included, block5, "should signal no progress at block 5");
 }
 
-/// Tests that normal multi-block pagination still works correctly:
-/// entries in blocks 1, 2, 3 with limit causing block 3 to be dropped.
+/// Tests that normal multi-block pagination still works correctly: entries in blocks 1, 2, 3 with
+/// limit causing block 3 to be dropped.
 #[test]
 fn select_storage_map_sync_values_multi_block_pagination() {
     let mut conn = create_db();
@@ -1633,10 +1633,10 @@ async fn reconstruct_storage_map_from_db_pages_until_latest() {
     });
 }
 
-/// Tests that `reconstruct_storage_map_from_db` returns `LimitExceeded` when the first
-/// block in the range has more entries than the limit allows. Previously this returned
-/// `AllEntries([])` because the pagination loop exited immediately (`last_block_included` ==
-/// `block_num`) without checking that no values were actually returned.
+/// Tests that `reconstruct_storage_map_from_db` returns `LimitExceeded` when the first block in the
+/// range has more entries than the limit allows. Previously this returned `AllEntries([])` because
+/// the pagination loop exited immediately (`last_block_included` == `block_num`) without checking
+/// that no values were actually returned.
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn reconstruct_storage_map_from_db_returns_limit_exceeded_for_single_block_overflow() {
@@ -1674,8 +1674,8 @@ async fn reconstruct_storage_map_from_db_returns_limit_exceeded_for_single_block
     .await
     .unwrap();
 
-    // Use limit=1 so that 3 entries in a single block exceed the limit.
-    // block_range_start is block5 (the first block with data), and the target is also block5.
+    // Use limit=1 so that 3 entries in a single block exceed the limit. block_range_start is block5
+    // (the first block with data), and the target is also block5.
     let details = db
         .reconstruct_storage_map_from_db(account_id, slot_name.clone(), block5, Some(1))
         .await
@@ -2123,8 +2123,8 @@ async fn genesis_with_account_assets_and_storage() {
     crate::db::Db::bootstrap(":memory:".into(), genesis_block).unwrap();
 }
 
-/// Verifies genesis block with multiple accounts of different types.
-/// Tests realistic genesis scenario with basic accounts, assets, and storage.
+/// Verifies genesis block with multiple accounts of different types. Tests realistic genesis
+/// scenario with basic accounts, assets, and storage.
 #[tokio::test]
 #[miden_node_test_macro::enable_logging]
 async fn genesis_with_multiple_accounts() {
@@ -3027,8 +3027,8 @@ fn test_prune_history() {
         "block_tip storage map value should be retained"
     );
 
-    // Test that is_latest=true entries are never deleted, even if old
-    // Insert an old entry marked as latest
+    // Test that is_latest=true entries are never deleted, even if old Insert an old entry marked as
+    // latest
     let faucet_4 = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_3).unwrap();
     let asset_old = Asset::Fungible(FungibleAsset::new(faucet_4, 9999).unwrap());
     let vault_key_old_latest = asset_old.vault_key();
@@ -3041,8 +3041,8 @@ fn test_prune_history() {
     )
     .unwrap();
 
-    // This entry at block 0 is marked as is_latest=true by insert_account_vault_asset
-    // Run cleanup again
+    // This entry at block 0 is marked as is_latest=true by insert_account_vault_asset Run cleanup
+    // again
     let (vault_deleted_2, ..) = queries::prune_history(conn, block_tip).unwrap();
 
     // The old latest entry should not be deleted (vault_deleted_2 should be 0)
@@ -3455,8 +3455,8 @@ fn account_state_forest_retains_latest_after_100_blocks_and_pruning() {
     let initial_storage_map_root =
         forest.get_storage_map_root(account_id, &slot_map, block_1).unwrap();
 
-    // Blocks 2-100: Do nothing (no updates to this account)
-    // Simulate other activity by just advancing to block 100
+    // Blocks 2-100: Do nothing (no updates to this account) Simulate other activity by just
+    // advancing to block 100
 
     let block_100 = BlockNumber::from(100);
 
@@ -3481,8 +3481,8 @@ fn account_state_forest_retains_latest_after_100_blocks_and_pruning() {
     let witness = forest.get_storage_map_witness(account_id, &slot_map, block_100, key1);
     assert!(witness.is_ok());
 
-    // Now add an update at block 51 (within retention window) to test that old entries
-    // get pruned when newer entries exist
+    // Now add an update at block 51 (within retention window) to test that old entries get pruned
+    // when newer entries exist
     let block_51 = BlockNumber::from(51);
 
     // Update with new values
@@ -3800,12 +3800,12 @@ fn account_state_forest_preserves_most_recent_storage_value_slot() {
 
     forest.update_account(block_1, &delta_1).unwrap();
 
-    // Note: Value slots don't have roots in AccountStateForest - they're just part of the
-    // account storage header. The AccountStateForest only tracks map slots.
-    // So there's nothing to verify for value slots in the forest.
+    // Note: Value slots don't have roots in AccountStateForest - they're just part of the account
+    // storage header. The AccountStateForest only tracks map slots. So there's nothing to verify
+    // for value slots in the forest.
 
-    // This test documents that value slots are NOT tracked in AccountStateForest
-    // (they don't need to be, since their digest is 1:1 with the value)
+    // This test documents that value slots are NOT tracked in AccountStateForest (they don't need
+    // to be, since their digest is 1:1 with the value)
 
     // Advance 100 blocks without any updates
     let block_100 = BlockNumber::from(100);
@@ -3900,9 +3900,8 @@ fn account_state_forest_preserves_mixed_slots_independently() {
     // Prune at block 100
     let total_roots_removed = forest.prune(block_100);
 
-    // Vault: block 1 is most recent, should NOT be pruned
-    // Map A: block 1 is old (block 51 is newer), SHOULD be pruned
-    // Map B: block 1 is most recent, should NOT be pruned
+    // Vault: block 1 is most recent, should NOT be pruned Map A: block 1 is old (block 51 is
+    // newer), SHOULD be pruned Map B: block 1 is most recent, should NOT be pruned
     assert_eq!(
         total_roots_removed, 0,
         "Vault root from block 1 should NOT be pruned (most recent)"

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -595,8 +595,8 @@ mod compile_tests {
         StateInitializationError,
     };
 
-    /// Ensure all enum variants remain compat with the desired
-    /// trait bounds. Otherwise one gets very unwieldy errors.
+    /// Ensure all enum variants remain compat with the desired trait bounds. Otherwise one gets
+    /// very unwieldy errors.
     #[expect(dead_code)]
     fn assumed_trait_bounds_upheld() {
         fn ensure_is_error<E>(_phony: PhantomData<E>)

--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -207,8 +207,8 @@ impl GenesisConfig {
                 faucet_account.id(),
                 secret_key,
             ));
-            // Do _not_ collect the account, only after we know all wallet assets
-            // we know the remaining supply in the faucets.
+            // Do _not_ collect the account, only after we know all wallet assets we know the
+            // remaining supply in the faucets.
         }
 
         let fee_parameters =
@@ -280,8 +280,8 @@ impl GenesisConfig {
         // Apply all fungible faucet adjustments to the respective faucet
         for (symbol, mut faucet_account) in faucet_accounts {
             let faucet_id = faucet_account.id();
-            // If there is no account using the asset, we use an empty delta to set the
-            // nonce to `ONE`.
+            // If there is no account using the asset, we use an empty delta to set the nonce to
+            // `ONE`.
             let total_issuance = faucet_issuance.get(&faucet_id).copied().unwrap_or_default();
 
             let mut storage_delta = AccountStorageDelta::default();
@@ -577,8 +577,8 @@ impl AccountSecrets {
 // HELPERS
 // ================================================================================================
 
-/// Process wallet assets and return them as a fungible asset delta.
-/// Track the negative adjustments for the respective faucets.
+/// Process wallet assets and return them as a fungible asset delta. Track the negative adjustments
+/// for the respective faucets.
 fn prepare_fungible_asset_update(
     assets: impl IntoIterator<Item = AssetEntry>,
     faucets: &IndexMap<TokenSymbolStr, Account>,

--- a/crates/store/src/genesis/mod.rs
+++ b/crates/store/src/genesis/mod.rs
@@ -33,8 +33,8 @@ pub struct GenesisState {
     pub validator_key: PublicKey,
 }
 
-/// A type-safety wrapper ensuring that genesis block data can only be created from
-/// [`GenesisState`] or validated from a [`SignedBlock`] via [`GenesisBlock::try_from`].
+/// A type-safety wrapper ensuring that genesis block data can only be created from [`GenesisState`]
+/// or validated from a [`SignedBlock`] via [`GenesisBlock::try_from`].
 pub struct GenesisBlock(SignedBlock);
 
 /// A genesis block with all data except the validator signature.

--- a/crates/store/src/server/block_producer.rs
+++ b/crates/store/src/server/block_producer.rs
@@ -30,8 +30,8 @@ use crate::state::Finality;
 // BLOCK PRODUCER API
 // ================================================================================================
 
-/// Extends [`StoreApi`] with the proof-scheduler notification channel, which is only required
-/// by the `BlockProducer` gRPC service. Not used in replica mode.
+/// Extends [`StoreApi`] with the proof-scheduler notification channel, which is only required by
+/// the `BlockProducer` gRPC service. Not used in replica mode.
 #[derive(Clone)]
 pub(super) struct BlockProducerApi {
     pub(super) inner: StoreApi,
@@ -119,8 +119,7 @@ impl block_producer_server::BlockProducer for BlockProducerApi {
             async move {
                 let signed_block = SignedBlock::new(header, body, signature)
                     .map_err(|err| Status::new(tonic::Code::Internal, err.as_report()))?;
-                // Note: This is an internal endpoint, so its safe to expose the full error
-                // report.
+                // Note: This is an internal endpoint, so its safe to expose the full error report.
                 this.inner
                     .state
                     .apply_block(signed_block)

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -398,8 +398,8 @@ impl Store {
 
         Ok(join_set)
     }
-    /// Spawns a background task that periodically records the on-disk size of every store data
-    /// path as `OTel` span attributes.
+    /// Spawns a background task that periodically records the on-disk size of every store data path
+    /// as `OTel` span attributes.
     fn spawn_disk_monitor(data_directory: PathBuf) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_mins(5));

--- a/crates/store/src/server/proof_scheduler.rs
+++ b/crates/store/src/server/proof_scheduler.rs
@@ -165,8 +165,8 @@ async fn run(
                 let (block_num, proof_bytes) = proving_result?;
                 pending.insert(block_num, proof_bytes);
 
-                // Drain completed proofs in ascending order so the proven tip advances
-                // without gaps.
+                // Drain completed proofs in ascending order so the proven tip advances without
+                // gaps.
                 let mut next = proven_tip.read().child();
                 while let Some(proof_bytes) = pending.remove(&next) {
                     block_store.commit_proof(next, &proof_bytes).await?;

--- a/crates/store/src/server/replica_sync.rs
+++ b/crates/store/src/server/replica_sync.rs
@@ -38,8 +38,8 @@ pub(crate) trait ReplicaSync: Sized + Send + Sync + 'static {
     /// Returns the upstream store URL to connect to.
     fn upstream_url(&self) -> &Url;
 
-    /// Subscribes to the upstream stream via `client` and processes events until the stream ends
-    /// or an error occurs.
+    /// Subscribes to the upstream stream via `client` and processes events until the stream ends or
+    /// an error occurs.
     async fn subscribe(&self, client: StoreReplicaClient) -> anyhow::Result<()>;
 
     /// Opens a connection to [`upstream_url`](Self::upstream_url) and calls

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -400,8 +400,8 @@ impl rpc_server::Rpc for StoreApi {
             .await
             .map_err(SyncTransactionsError::from)?;
 
-        // Convert database TransactionRecords directly to proto TransactionRecords.
-        // All data needed for the proto TransactionHeader is stored in the transactions table.
+        // Convert database TransactionRecords directly to proto TransactionRecords. All data needed
+        // for the proto TransactionHeader is stored in the transactions table.
         let transactions: Vec<_> = transaction_records_db
             .into_iter()
             .map(crate::db::TransactionRecord::into_proto)

--- a/crates/store/src/state/apply_block.rs
+++ b/crates/store/src/state/apply_block.rs
@@ -80,8 +80,8 @@ impl State {
         // Signals the write lock has been acquired, and the transaction can be committed.
         let (inform_acquire_done, acquire_done) = oneshot::channel::<()>();
 
-        // Extract public account updates with deltas before block is moved into async task.
-        // Private accounts are filtered out since they don't expose their state changes.
+        // Extract public account updates with deltas before block is moved into async task. Private
+        // accounts are filtered out since they don't expose their state changes.
         let account_deltas =
             Vec::from_iter(body.updated_accounts().iter().filter_map(
                 |update| match update.details() {
@@ -90,18 +90,16 @@ impl State {
                 },
             ));
 
-        // The DB and in-memory state updates need to be synchronized and are partially
-        // overlapping. Namely, the DB transaction only proceeds after this task acquires the
-        // in-memory write lock. This requires the DB update to run concurrently, so a new task is
-        // spawned.
+        // The DB and in-memory state updates need to be synchronized and are partially overlapping.
+        // Namely, the DB transaction only proceeds after this task acquires the in-memory write
+        // lock. This requires the DB update to run concurrently, so a new task is spawned.
         let db = Arc::clone(&self.db);
         let db_update_task = tokio::spawn(
             async move { db.apply_block(allow_acquire, acquire_done, signed_block, notes).await }
                 .in_current_span(),
         );
 
-        // Wait for the message from the DB update task, that we ready to commit the DB
-        // transaction.
+        // Wait for the message from the DB update task, that we ready to commit the DB transaction.
         acquired_allowed
             .instrument(info_span!(target: COMPONENT, "await_db_readiness"))
             .await
@@ -112,25 +110,24 @@ impl State {
 
         self.with_inner_write_blocking(|inner| {
             // We need to check that neither the nullifier tree nor the account tree have changed
-            // while we were waiting for the DB preparation task to complete. If either of them
-            // did change, we do not proceed with in-memory and database updates, since it may
-            // lead to an inconsistent state.
+            // while we were waiting for the DB preparation task to complete. If either of them did
+            // change, we do not proceed with in-memory and database updates, since it may lead to
+            // an inconsistent state.
             if inner.nullifier_tree.root() != nullifier_tree_old_root
                 || inner.account_tree.root_latest() != account_tree_old_root
             {
                 return Err(ApplyBlockError::ConcurrentWrite);
             }
 
-            // Notify the DB update task that the write lock has been acquired, so it can commit
-            // the DB transaction.
+            // Notify the DB update task that the write lock has been acquired, so it can commit the
+            // DB transaction.
             inform_acquire_done
                 .send(())
                 .map_err(|_| ApplyBlockError::DbUpdateTaskFailed("Receiver was dropped".into()))?;
 
-            // TODO: shutdown #91
-            // Await for successful commit of the DB transaction. If the commit fails, we mustn't
-            // change in-memory state, so we return a block applying error and don't proceed with
-            // in-memory updates.
+            // TODO: shutdown #91 Await for successful commit of the DB transaction. If the commit
+            // fails, we mustn't change in-memory state, so we return a block applying error and
+            // don't proceed with in-memory updates.
             tokio::runtime::Handle::current()
                 .block_on(db_update_task)?
                 .map_err(|err| ApplyBlockError::DbUpdateTaskFailed(err.as_report()))?;

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -50,16 +50,16 @@ pub const NULLIFIER_TREE_STORAGE_DIR: &str = "nullifiertree";
 /// Directory name for the account state forest storage within the data directory.
 pub const ACCOUNT_STATE_FOREST_STORAGE_DIR: &str = "accountstateforest";
 
-/// Page size for loading account commitments from the database during tree rebuilding.
-/// This limits memory usage when rebuilding trees with millions of accounts.
+/// Page size for loading account commitments from the database during tree rebuilding. This limits
+/// memory usage when rebuilding trees with millions of accounts.
 const ACCOUNT_COMMITMENTS_PAGE_SIZE: NonZeroUsize = NonZeroUsize::new(10_000).unwrap();
 
-/// Page size for loading nullifiers from the database during tree rebuilding.
-/// This limits memory usage when rebuilding trees with millions of nullifiers.
+/// Page size for loading nullifiers from the database during tree rebuilding. This limits memory
+/// usage when rebuilding trees with millions of nullifiers.
 const NULLIFIERS_PAGE_SIZE: NonZeroUsize = NonZeroUsize::new(10_000).unwrap();
 
-/// Page size for loading public account IDs from the database during forest rebuilding.
-/// This limits memory usage when rebuilding with millions of public accounts.
+/// Page size for loading public account IDs from the database during forest rebuilding. This limits
+/// memory usage when rebuilding with millions of public accounts.
 const PUBLIC_ACCOUNT_IDS_PAGE_SIZE: NonZeroUsize = NonZeroUsize::new(1_000).unwrap();
 
 // STORAGE TYPE ALIAS
@@ -212,9 +212,9 @@ impl TreeStorageLoader for MemoryStorage {
         AccountTree::new(smt).map_err(StateInitializationError::FailedToCreateAccountsTree)
     }
 
-    // TODO: Make the loading methodology for account and nullifier trees consistent.
-    // Currently we use `NullifierTree::new_unchecked()` for nullifiers but `AccountTree::new()`
-    // for accounts. Consider using `NullifierTree::with_storage_from_entries()` for consistency.
+    // TODO: Make the loading methodology for account and nullifier trees consistent. Currently we
+    // use `NullifierTree::new_unchecked()` for nullifiers but `AccountTree::new()` for accounts.
+    // Consider using `NullifierTree::with_storage_from_entries()` for consistency.
     #[instrument(target = COMPONENT, skip_all)]
     async fn load_nullifier_tree(
         self,
@@ -464,8 +464,7 @@ pub fn load_smt<S: SmtStorage>(storage: S) -> Result<LargeSmt<S>, StateInitializ
 pub async fn load_mmr(db: &mut Db) -> Result<Blockchain, StateInitializationError> {
     let block_commitments = db.select_all_block_header_commitments().await?;
 
-    // SAFETY: We assume the loaded MMR is valid and does not have more than u32::MAX
-    // entries.
+    // SAFETY: We assume the loaded MMR is valid and does not have more than u32::MAX entries.
     let chain_mmr = Blockchain::from_mmr_unchecked(Mmr::from(
         block_commitments.iter().copied().map(BlockHeaderCommitment::word),
     ));
@@ -493,8 +492,8 @@ pub async fn rebuild_account_state_forest(
 
         // Process each account in this page
         for account_id in page.account_ids {
-            // TODO: Loading the full account from the database is inefficient and will need to
-            // go away. <https://github.com/0xMiden/node/issues/1556>
+            // TODO: Loading the full account from the database is inefficient and will need to go
+            // away. <https://github.com/0xMiden/node/issues/1556>
             let account_info = db.select_account(account_id).await?;
             let account = account_info
                 .details

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -163,8 +163,7 @@ pub struct State {
     /// Request termination of the process due to a fatal internal state error.
     termination_ask: tokio::sync::mpsc::Sender<ApplyBlockError>,
 
-    /// The latest proven-in-sequence block number, updated by the proof scheduler or
-    /// `apply_proof`.
+    /// The latest proven-in-sequence block number, updated by the proof scheduler or `apply_proof`.
     proven_tip: ProvenTipWriter,
 
     /// Watch sender fired after each block is committed. Replicas subscribe via
@@ -175,8 +174,8 @@ pub struct State {
     /// block that has been evicted, it falls back to loading from the block store.
     pub(crate) block_cache: BlockCache,
 
-    /// FIFO cache of recent block proofs for replica subscriptions. When a subscriber needs a
-    /// proof that has been evicted, it falls back to loading from the block store.
+    /// FIFO cache of recent block proofs for replica subscriptions. When a subscriber needs a proof
+    /// that has been evicted, it falls back to loading from the block store.
     pub(crate) proof_cache: ProofCache,
 }
 
@@ -254,9 +253,9 @@ impl State {
             TreeStorage::create(data_path, &nullifier_storage_config, NULLIFIER_TREE_STORAGE_DIR)?;
         let nullifier_tree = nullifier_storage.load_nullifier_tree(&mut db).await?;
 
-        // Verify that tree roots match the expected roots from the database.
-        // This catches any divergence between persistent storage and the database caused by
-        // corruption or incomplete shutdown.
+        // Verify that tree roots match the expected roots from the database. This catches any
+        // divergence between persistent storage and the database caused by corruption or incomplete
+        // shutdown.
         verify_tree_consistency(account_tree.root(), nullifier_tree.root(), &mut db).await?;
 
         let account_tree = AccountTreeWithHistory::new(account_tree, latest_block_num);
@@ -420,8 +419,8 @@ impl State {
         self.db.select_notes_by_id(note_ids).await
     }
 
-    /// If the input block number is the current chain tip, `None` is returned.
-    /// Otherwise, gets the current chain tip's block header with its corresponding MMR peaks.
+    /// If the input block number is the current chain tip, `None` is returned. Otherwise, gets the
+    /// current chain tip's block header with its corresponding MMR peaks.
     pub async fn get_current_blockchain_data(
         &self,
         block_num: Option<BlockNumber>,
@@ -476,9 +475,9 @@ impl State {
             return Err(GetBatchInputsError::TransactionBlockReferencesEmpty);
         }
 
-        // First we grab note inclusion proofs for the known notes. These proofs only
-        // prove that the note was included in a given block. We then also need to prove that
-        // each of those blocks is included in the chain.
+        // First we grab note inclusion proofs for the known notes. These proofs only prove that the
+        // note was included in a given block. We then also need to prove that each of those blocks
+        // is included in the chain.
         let note_proofs = self
             .db
             .select_note_inclusion_proofs(unauthenticated_note_commitments)
@@ -494,8 +493,8 @@ impl State {
         let mut blocks: BTreeSet<BlockNumber> = tx_reference_blocks;
         blocks.extend(note_blocks);
 
-        // Scoped block to automatically drop the read lock guard as soon as we're done.
-        // We also avoid accessing the db in the block as this would delay dropping the guard.
+        // Scoped block to automatically drop the read lock guard as soon as we're done. We also
+        // avoid accessing the db in the block as this would delay dropping the guard.
         let (batch_reference_block, partial_mmr) = {
             let inner_state = self.inner.read().await;
 
@@ -576,9 +575,9 @@ impl State {
         unauthenticated_note_commitments: BTreeSet<Word>,
         reference_blocks: BTreeSet<BlockNumber>,
     ) -> Result<BlockInputs, GetBlockInputsError> {
-        // Get the note inclusion proofs from the DB.
-        // We do this first so we have to acquire the lock to the state just once. There we need the
-        // reference blocks of the note proofs to get their authentication paths in the chain MMR.
+        // Get the note inclusion proofs from the DB. We do this first so we have to acquire the
+        // lock to the state just once. There we need the reference blocks of the note proofs to get
+        // their authentication paths in the chain MMR.
         let unauthenticated_note_proofs = self
             .db
             .select_note_inclusion_proofs(unauthenticated_note_commitments)
@@ -604,8 +603,8 @@ impl State {
             .await
             .map_err(GetBlockInputsError::SelectBlockHeaderError)?;
 
-        // Find and remove the latest block as we must not add it to the chain MMR, since it is
-        // not yet in the chain.
+        // Find and remove the latest block as we must not add it to the chain MMR, since it is not
+        // yet in the chain.
         let latest_block_header_index = headers
             .iter()
             .enumerate()

--- a/crates/store/src/state/sync_state.rs
+++ b/crates/store/src/state/sync_state.rs
@@ -93,10 +93,9 @@ impl State {
         block_range: RangeInclusive<BlockNumber>,
     ) -> Result<(Vec<(NoteSyncUpdate, MmrProof)>, BlockNumber), NoteSyncError> {
         let block_end = *block_range.end();
-        // The MMR at forest N contains proofs for blocks 0..N-1, so we use block_end + 1 to
-        // include the proof for block_end.
-        // SAFETY: it is ensured that block_end <= chain_tip, and the blockchain MMR always has
-        // at least chain_tip + 1 leaves.
+        // The MMR at forest N contains proofs for blocks 0..N-1, so we use block_end + 1 to include
+        // the proof for block_end. SAFETY: it is ensured that block_end <= chain_tip, and the
+        // blockchain MMR always has at least chain_tip + 1 leaves.
         let mmr_checkpoint = block_end + 1;
 
         let note_syncs = self.db.get_note_sync_multi(block_range, note_tags.into()).await?;

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -15,8 +15,8 @@ const DEFAULT_REPLENISH_N_PER_SECOND_PER_IP: NonZeroU64 = NonZeroU64::new(16).un
 const DEFAULT_BURST_SIZE: NonZeroU32 = NonZeroU32::new(128).unwrap();
 const DEFAULT_MAX_CONCURRENT_CONNECTIONS: u64 = 1_000;
 
-// Formats a Duration into a human-readable string for display in clap help text
-// and yields a &'static str by _leaking_ the string deliberately.
+// Formats a Duration into a human-readable string for display in clap help text and yields a
+// &'static str by _leaking_ the string deliberately.
 pub fn duration_to_human_readable_string(duration: Duration) -> &'static str {
     Box::new(humantime::format_duration(duration).to_string()).leak()
 }
@@ -80,8 +80,8 @@ pub struct GrpcOptionsExternal {
     )]
     pub max_connection_age: Duration,
 
-    /// Number of connections to be served before the "API tokens" need to be replenished
-    /// per IP address.
+    /// Number of connections to be served before the "API tokens" need to be replenished per IP
+    /// address.
     #[arg(
         long = "grpc.burst_size",
         default_value_t = DEFAULT_BURST_SIZE,

--- a/crates/utils/src/fifo_cache.rs
+++ b/crates/utils/src/fifo_cache.rs
@@ -87,10 +87,10 @@ mod tests {
 
     #[test]
     fn overwrite_key_evicts_on_next_push() {
-        // Pushing the same key twice leaves a ghost entry in the eviction queue.
-        // The ghost is a no-op when it surfaces as the oldest entry: the key is
-        // already absent from the map so map.remove() does nothing. The important
-        // invariant is that no *other* key is spuriously evicted.
+        // Pushing the same key twice leaves a ghost entry in the eviction queue. The ghost is a
+        // no-op when it surfaces as the oldest entry: the key is already absent from the map so
+        // map.remove() does nothing. The important invariant is that no *other* key is spuriously
+        // evicted.
         let c = cache(2);
         c.push(1, "a");
         c.push(1, "b"); // eviction queue: [1, 1], map: {1: "b"}

--- a/crates/utils/src/limiter.rs
+++ b/crates/utils/src/limiter.rs
@@ -22,8 +22,8 @@ pub struct QueryLimitError {
     limit: usize,
 }
 
-/// Checks limits against the desired query parameters, per query parameter and
-/// bails if they exceed a defined value.
+/// Checks limits against the desired query parameters, per query parameter and bails if they exceed
+/// a defined value.
 pub trait QueryParamLimiter {
     /// Name of the parameter to mention in the error.
     const PARAM_NAME: &'static str;
@@ -42,8 +42,7 @@ pub trait QueryParamLimiter {
     }
 }
 
-/// Maximum payload size (in bytes) for paginated responses returned by the
-/// store.
+/// Maximum payload size (in bytes) for paginated responses returned by the store.
 pub const MAX_RESPONSE_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
 
 /// Used for the following RPC endpoints:

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -67,8 +67,8 @@ pub fn setup_tracing(otel: OpenTelemetry) -> anyhow::Result<Option<OtelGuard>> {
     let tracer_provider = if otel.is_enabled() {
         let provider = init_tracer_provider()?;
 
-        // Store the provider globally so the panic hook can flush it.
-        // SdkTracerProvider is internally reference-counted, so cloning is cheap.
+        // Store the provider globally so the panic hook can flush it. SdkTracerProvider is
+        // internally reference-counted, so cloning is cheap.
         TRACER_PROVIDER
             .set(provider.clone())
             .expect("setup_tracing should only be called once");
@@ -86,8 +86,8 @@ pub fn setup_tracing(otel: OpenTelemetry) -> anyhow::Result<Option<OtelGuard>> {
         .with(otel_layer.with_filter(env_or_default_filter()));
     tracing::subscriber::set_global_default(subscriber).map_err(Into::<anyhow::Error>::into)?;
 
-    // Register panic hook now that tracing is initialized.
-    // This chains with the default panic hook to preserve backtrace printing.
+    // Register panic hook now that tracing is initialized. This chains with the default panic hook
+    // to preserve backtrace printing.
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         tracing::error!(panic = true, info = %info, "panic");
@@ -97,8 +97,8 @@ pub fn setup_tracing(otel: OpenTelemetry) -> anyhow::Result<Option<OtelGuard>> {
         let wrapped = anyhow::Error::msg(info_str);
         tracing::Span::current().set_error(wrapped.as_ref());
 
-        // Flush traces before the program terminates.
-        // This ensures the panic trace is exported even though the OtelGuard won't be dropped.
+        // Flush traces before the program terminates. This ensures the panic trace is exported even
+        // though the OtelGuard won't be dropped.
         if let Some(provider) = TRACER_PROVIDER.get() {
             if let Err(err) = provider.force_flush() {
                 eprintln!("Failed to flush traces on panic: {err:?}");

--- a/crates/utils/src/lru_cache.rs
+++ b/crates/utils/src/lru_cache.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use lru::LruCache as InnerCache;
 use tracing::instrument;
 
-/// A newtype wrapper around an LRU cache. Ensures that the cache lock is not held across
-/// await points.
+/// A newtype wrapper around an LRU cache. Ensures that the cache lock is not held across await
+/// points.
 #[derive(Clone)]
 pub struct LruCache<K, V>(Arc<Mutex<InnerCache<K, V>>>);
 
@@ -54,9 +54,9 @@ where
 
     #[instrument(name = "lru.lock", skip_all)]
     fn lock(&self) -> MutexGuard<'_, InnerCache<K, V>> {
-        // SAFETY: The mutex is only held for the duration of the get/put operation
-        // where panics are possible only if we're running out of memory, in which
-        // case the entire process is likely to be unstable anyway.
+        // SAFETY: The mutex is only held for the duration of the get/put operation where panics are
+        // possible only if we're running out of memory, in which case the entire process is likely
+        // to be unstable anyway.
         self.0.lock().expect("LRU cache mutex poisoned")
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,16 @@
+# We have a custom `cargo xtask fmt-comments` which performs the comment formatting.
+#
+# The custom xtask also supports reflowing short comment lines, unlike rustftm which
+# only supports truncation.
+#
+# The custom xtask reads `comment_width` from here for consistency and we explicitly
+# disable rustfmt's comment wrapping to give the xtask control.
+comment_width = 100
+wrap_comments = false
+
 array_width                    = 80
 attr_fn_like_width             = 80
 chain_width                    = 80
-comment_width                  = 100
 condense_wildcard_suffixes     = true
 edition                        = "2024"
 fn_call_width                  = 80
@@ -16,4 +25,3 @@ struct_lit_width               = 40
 struct_variant_width           = 40
 use_field_init_shorthand       = true
 use_try_shorthand              = true
-wrap_comments                  = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+edition.workspace      = true
+license.workspace      = true
+name                   = "xtask"
+publish                = false
+rust-version.workspace = true
+version.workspace      = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow           = { workspace = true }
+clap             = { features = ["derive"], workspace = true }
+fs-err           = { workspace = true }
+toml             = { workspace = true }
+tree-sitter      = "0.26"
+tree-sitter-rust = "0.24"

--- a/xtask/src/comment_reflow.rs
+++ b/xtask/src/comment_reflow.rs
@@ -312,6 +312,10 @@ fn safe_comment_text(content: &str) -> Option<&str> {
         return None;
     }
 
+    if is_repeated_separator(trimmed) {
+        return None;
+    }
+
     Some(trimmed)
 }
 
@@ -330,6 +334,16 @@ fn is_markdown_sensitive(trimmed: &str) -> bool {
         || is_table_row(trimmed)
         || is_url_only(trimmed)
         || is_link_reference(trimmed)
+}
+
+fn is_repeated_separator(trimmed: &str) -> bool {
+    let mut chars = trimmed.chars();
+    let Some(separator) = chars.next() else {
+        return false;
+    };
+
+    // Section dividers like `// =====` and `// -----` are intentional layout, not prose.
+    trimmed.len() >= 3 && separator.is_ascii_punctuation() && chars.all(|char| char == separator)
 }
 
 fn is_list_item(trimmed: &str) -> bool {
@@ -469,5 +483,19 @@ fn main() {}
 fn main() {}
 "
         );
+    }
+
+    #[test]
+    fn skips_repeated_separator_comments() {
+        let source = r"// ================================================================================================
+// SECTION HEADER
+// ================================================================================================
+fn main() {}
+";
+
+        let reflowed =
+            reflow_source(source, Config { width: 60, include_normal_comments: true }).unwrap();
+
+        assert_eq!(reflowed, source);
     }
 }

--- a/xtask/src/comment_reflow.rs
+++ b/xtask/src/comment_reflow.rs
@@ -1,0 +1,473 @@
+//! Conservative Rust line-comment reflow support for the repository formatter.
+//!
+//! The formatter is intentionally narrower than rustfmt's comment handling. It only rewrites
+//! contiguous full-line comment blocks that look like plain prose, and it skips comments whose
+//! layout may carry meaning in Markdown, code examples, or hand-aligned text.
+//!
+//! The CLI includes regular `//` comments by default. Callers can still use [`Config`] to restrict
+//! reflowing to rustdoc comments (`///` and `//!`) when they need a narrower pass.
+
+use std::ffi::OsStr;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tree_sitter::{Node, Parser};
+
+/// Comment reflow settings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Config {
+    /// Target total line width, including indentation and comment marker.
+    pub width: usize,
+
+    /// Whether regular `//` comments should be reflowed in addition to rustdoc comments.
+    pub include_normal_comments: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Prefix {
+    InnerDoc,
+    OuterDoc,
+    Normal,
+}
+
+impl Prefix {
+    fn parse(comment: &str, include_normal_comments: bool) -> Option<(Self, &str)> {
+        if let Some(rest) = comment.strip_prefix("//!") {
+            return Some((Self::InnerDoc, rest));
+        }
+
+        // Four-slash comments are usually deliberate non-rustdoc comments and should not be
+        // normalized into `///`-style prose.
+        if comment.starts_with("////") {
+            return None;
+        }
+
+        if let Some(rest) = comment.strip_prefix("///") {
+            return Some((Self::OuterDoc, rest));
+        }
+
+        if include_normal_comments {
+            return comment.strip_prefix("//").map(|rest| (Self::Normal, rest));
+        }
+
+        None
+    }
+
+    const fn marker(self) -> &'static str {
+        match self {
+            Self::InnerDoc => "//!",
+            Self::OuterDoc => "///",
+            Self::Normal => "//",
+        }
+    }
+}
+
+/// A full-line comment with enough source position data to replace its original line.
+#[derive(Debug, Eq, PartialEq)]
+struct CommentLine {
+    line_idx: usize,
+    line_start: usize,
+    line_end: usize,
+    indent: String,
+    prefix: Prefix,
+    content: String,
+}
+
+/// A byte-range rewrite to be applied to the original source.
+#[derive(Debug, Eq, PartialEq)]
+struct Replacement {
+    range: Range<usize>,
+    text: String,
+}
+
+/// Reflow all safe comment blocks in a Rust source string.
+///
+/// The source is parsed with tree-sitter so that only syntactic line comments are considered. This
+/// avoids touching comment-looking text inside strings, macros, or other token contexts where regex
+/// matching would be unsafe.
+pub fn reflow_source(source: &str, config: Config) -> Result<String> {
+    let mut parser = Parser::new();
+    let language = tree_sitter::Language::from(tree_sitter_rust::LANGUAGE);
+    parser.set_language(&language).context("loading tree-sitter Rust grammar")?;
+
+    let tree = parser.parse(source, None).context("tree-sitter returned no parse tree")?;
+    let line_starts = line_starts(source);
+    let comment_lines =
+        comment_lines(source, tree.root_node(), &line_starts, config.include_normal_comments);
+    let replacements = replacements(&comment_lines, config.width);
+
+    Ok(apply_replacements(source, &replacements))
+}
+
+/// Collect Rust source files from explicit files, directories, or the repository root.
+///
+/// Directory traversal skips common generated or dependency directories so the default repository
+/// run stays scoped to checked-in source.
+pub fn rust_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+
+    if paths.is_empty() {
+        collect_rust_files(Path::new("."), &mut files)?;
+    } else {
+        for path in paths {
+            collect_rust_files(path, &mut files)
+                .with_context(|| format!("walking {}", path.display()))?;
+        }
+    }
+
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn collect_rust_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    let metadata =
+        fs_err::symlink_metadata(path).with_context(|| format!("reading {}", path.display()))?;
+
+    if metadata.is_file() {
+        if path.extension() == Some(OsStr::new("rs")) {
+            files.push(path.to_path_buf());
+        }
+        return Ok(());
+    }
+
+    if !metadata.is_dir() || should_skip_dir(path) {
+        return Ok(());
+    }
+
+    for entry in fs_err::read_dir(path)? {
+        collect_rust_files(&entry?.path(), files)?;
+    }
+
+    Ok(())
+}
+
+fn should_skip_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| matches!(name, ".git" | "target" | "node_modules"))
+}
+
+fn line_starts(source: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+
+    for (idx, byte) in source.bytes().enumerate() {
+        if byte == b'\n' {
+            starts.push(idx + 1);
+        }
+    }
+
+    starts
+}
+
+fn comment_lines(
+    source: &str,
+    root: Node<'_>,
+    line_starts: &[usize],
+    include_normal_comments: bool,
+) -> Vec<CommentLine> {
+    let mut ranges = Vec::new();
+    collect_line_comment_ranges(root, &mut ranges);
+    ranges.sort_by_key(|range| range.start);
+
+    ranges
+        .into_iter()
+        .filter_map(|range| comment_line(source, range, line_starts, include_normal_comments))
+        .collect()
+}
+
+fn collect_line_comment_ranges(node: Node<'_>, ranges: &mut Vec<Range<usize>>) {
+    if node.kind() == "line_comment" {
+        ranges.push(node.byte_range());
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_line_comment_ranges(child, ranges);
+    }
+}
+
+fn comment_line(
+    source: &str,
+    range: Range<usize>,
+    line_starts: &[usize],
+    include_normal_comments: bool,
+) -> Option<CommentLine> {
+    let line_idx = line_starts.partition_point(|start| *start <= range.start) - 1;
+    let line_start = *line_starts.get(line_idx)?;
+    let line_end = line_end(source, line_idx, line_starts);
+
+    // Reflow only full-line comments. Trailing comments are often attached to nearby code and can
+    // be semantically or stylistically different from prose blocks.
+    if !source[line_start..range.start].chars().all(char::is_whitespace) {
+        return None;
+    }
+
+    let comment = &source[range.start..range.end.min(line_end)];
+    let (prefix, content) = Prefix::parse(comment, include_normal_comments)?;
+
+    Some(CommentLine {
+        line_idx,
+        line_start,
+        line_end,
+        indent: source[line_start..range.start].to_owned(),
+        prefix,
+        content: content.to_owned(),
+    })
+}
+
+fn line_end(source: &str, line_idx: usize, line_starts: &[usize]) -> usize {
+    let line_start = line_starts[line_idx];
+    let next_line_start = line_starts.get(line_idx + 1).copied().unwrap_or(source.len());
+    let mut end = next_line_start;
+
+    if end > line_start && source.as_bytes()[end - 1] == b'\n' {
+        end -= 1;
+    }
+
+    if end > line_start && source.as_bytes()[end - 1] == b'\r' {
+        end -= 1;
+    }
+
+    end
+}
+
+fn replacements(comment_lines: &[CommentLine], width: usize) -> Vec<Replacement> {
+    let mut replacements = Vec::new();
+    let mut block_start = 0;
+
+    while block_start < comment_lines.len() {
+        let mut block_end = block_start + 1;
+
+        // Only adjacent lines with the same indentation and marker are joined into one paragraph.
+        // Blank lines, indentation changes, and prefix changes are treated as paragraph boundaries.
+        while block_end < comment_lines.len()
+            && same_block(&comment_lines[block_end - 1], &comment_lines[block_end])
+        {
+            block_end += 1;
+        }
+
+        if let Some(replacement) = reflow_block(&comment_lines[block_start..block_end], width) {
+            replacements.push(replacement);
+        }
+
+        block_start = block_end;
+    }
+
+    replacements
+}
+
+fn same_block(previous: &CommentLine, current: &CommentLine) -> bool {
+    previous.line_idx + 1 == current.line_idx
+        && previous.indent == current.indent
+        && previous.prefix == current.prefix
+}
+
+fn reflow_block(block: &[CommentLine], width: usize) -> Option<Replacement> {
+    let first = block.first()?;
+    let last = block.last()?;
+    let line_prefix = format!("{}{}", first.indent, first.prefix.marker());
+    let text_width = width.checked_sub(line_prefix.chars().count() + 1)?;
+
+    if text_width == 0 {
+        return None;
+    }
+
+    let mut words = Vec::new();
+    for line in block {
+        let text = safe_comment_text(&line.content)?;
+        for word in text.split_whitespace() {
+            // Do not split long words or URLs. If one word cannot fit, leave the block untouched.
+            if word.chars().count() > text_width {
+                return None;
+            }
+            words.push(word);
+        }
+    }
+
+    if words.is_empty() {
+        return None;
+    }
+
+    let text = wrap_words(&line_prefix, &words, text_width);
+    let range = first.line_start..last.line_end;
+
+    Some(Replacement { range, text })
+}
+
+fn safe_comment_text(content: &str) -> Option<&str> {
+    let text = content.strip_prefix(' ').unwrap_or(content).trim_end();
+
+    if text.starts_with(char::is_whitespace) || has_intentional_spacing(text) {
+        return None;
+    }
+
+    let trimmed = text.trim();
+    if trimmed.is_empty() || trimmed.len() != text.len() {
+        return None;
+    }
+
+    if is_markdown_sensitive(trimmed) {
+        return None;
+    }
+
+    Some(trimmed)
+}
+
+fn has_intentional_spacing(text: &str) -> bool {
+    // Multiple spaces and tabs often mean alignment, ASCII diagrams, or manually spaced examples.
+    text.contains('\t') || text.as_bytes().windows(2).any(|window| window == b"  ")
+}
+
+fn is_markdown_sensitive(trimmed: &str) -> bool {
+    // Markdown structures can change meaning when lines are merged or rewrapped.
+    trimmed.starts_with("```")
+        || trimmed.starts_with("~~~")
+        || trimmed.starts_with('#')
+        || trimmed.starts_with('>')
+        || is_list_item(trimmed)
+        || is_table_row(trimmed)
+        || is_url_only(trimmed)
+        || is_link_reference(trimmed)
+}
+
+fn is_list_item(trimmed: &str) -> bool {
+    if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("+ ") {
+        return true;
+    }
+
+    let marker_len = trimmed.bytes().take_while(u8::is_ascii_digit).count();
+    marker_len > 0
+        && trimmed[marker_len..]
+            .strip_prefix(['.', ')'])
+            .is_some_and(|rest| rest.starts_with(char::is_whitespace))
+}
+
+fn is_table_row(trimmed: &str) -> bool {
+    trimmed.starts_with('|') || trimmed.ends_with('|') || trimmed.contains(" | ")
+}
+
+fn is_url_only(trimmed: &str) -> bool {
+    let without_brackets = trimmed
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        .unwrap_or(trimmed);
+
+    (without_brackets.starts_with("http://") || without_brackets.starts_with("https://"))
+        && !without_brackets.chars().any(char::is_whitespace)
+}
+
+fn is_link_reference(trimmed: &str) -> bool {
+    trimmed.starts_with('[') && trimmed.contains("]:")
+}
+
+fn wrap_words(line_prefix: &str, words: &[&str], text_width: usize) -> String {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in words {
+        let word_len = word.chars().count();
+        let current_len = current.chars().count();
+
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current_len + 1 + word_len <= text_width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(format!("{line_prefix} {current}"));
+            current.clear();
+            current.push_str(word);
+        }
+    }
+
+    if !current.is_empty() {
+        lines.push(format!("{line_prefix} {current}"));
+    }
+
+    lines.join("\n")
+}
+
+fn apply_replacements(source: &str, replacements: &[Replacement]) -> String {
+    if replacements.is_empty() {
+        return source.to_owned();
+    }
+
+    let mut output = String::with_capacity(source.len());
+    let mut cursor = 0;
+
+    for replacement in replacements {
+        output.push_str(&source[cursor..replacement.range.start]);
+        output.push_str(&replacement.text);
+        cursor = replacement.range.end;
+    }
+
+    output.push_str(&source[cursor..]);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, reflow_source};
+
+    fn reflow(source: &str, width: usize) -> String {
+        reflow_source(source, Config { width, include_normal_comments: false }).unwrap()
+    }
+
+    #[test]
+    fn reflows_outer_doc_comment_blocks() {
+        let source = r"/// This is a doc comment that should be wrapped into a few short lines by
+/// the formatter.
+fn main() {}
+";
+
+        let expected = r"/// This is a doc comment that
+/// should be wrapped into a
+/// few short lines by the
+/// formatter.
+fn main() {}
+";
+
+        assert_eq!(reflow(source, 30), expected);
+    }
+
+    #[test]
+    fn does_not_reflow_trailing_comments() {
+        let source = r"fn main() {
+    let _value = 1; /// this trailing doc comment is ignored by design
+}
+";
+
+        assert_eq!(reflow(source, 40), source);
+    }
+
+    #[test]
+    fn skips_markdown_lists() {
+        let source = r"/// - first item that should stay exactly where it is
+/// - second item that should stay exactly where it is
+fn main() {}
+";
+
+        assert_eq!(reflow(source, 30), source);
+    }
+
+    #[test]
+    fn can_reflow_regular_comments_when_enabled() {
+        let source = r"// A normal comment can also be wrapped when the caller explicitly asks for all comments.
+fn main() {}
+";
+
+        let reflowed =
+            reflow_source(source, Config { width: 45, include_normal_comments: true }).unwrap();
+
+        assert_eq!(
+            reflowed,
+            r"// A normal comment can also be wrapped when
+// the caller explicitly asks for all
+// comments.
+fn main() {}
+"
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,122 @@
+mod comment_reflow;
+
+use std::io::ErrorKind;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail, ensure};
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(about = "Repository maintenance tasks", name = "xtask")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Reflow safe Rust line-comment blocks.
+    FmtComments(FmtCommentsArgs),
+}
+
+#[derive(Debug, Args)]
+struct FmtCommentsArgs {
+    /// Rewrite files in place.
+    #[arg(long, conflicts_with = "check")]
+    write: bool,
+
+    /// Check whether files are already reflowed.
+    #[arg(long)]
+    check: bool,
+
+    /// Reflow only `///` and `//!` rustdoc comments.
+    #[arg(long)]
+    doc_comments_only: bool,
+
+    /// Target total line width. Defaults to rustfmt.toml's `comment_width`, or 100.
+    #[arg(long)]
+    width: Option<usize>,
+
+    /// Files or directories to process. Defaults to the repository tree.
+    paths: Vec<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::FmtComments(args) => run_fmt_comments(&args),
+    }
+}
+
+fn run_fmt_comments(args: &FmtCommentsArgs) -> Result<()> {
+    let width = comment_width(args.width)?;
+    let paths = comment_reflow::rust_files(&args.paths).context("collecting Rust files")?;
+    let config = comment_reflow::Config {
+        width,
+        include_normal_comments: !args.doc_comments_only,
+    };
+
+    let mut changed = Vec::new();
+
+    for path in paths {
+        let source =
+            fs_err::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+        let reflowed = comment_reflow::reflow_source(&source, config)
+            .with_context(|| format!("reflowing {}", path.display()))?;
+
+        if reflowed != source {
+            if args.write {
+                fs_err::write(&path, reflowed)
+                    .with_context(|| format!("writing {}", path.display()))?;
+            }
+            changed.push(path);
+        }
+    }
+
+    if changed.is_empty() {
+        return Ok(());
+    }
+
+    if args.write {
+        eprintln!("reflowed comments in {} file(s)", changed.len());
+        return Ok(());
+    }
+
+    for path in &changed {
+        eprintln!("comments need reflow: {}", path.display());
+    }
+
+    let mode = if args.check { "--check" } else { "default check" };
+    bail!(
+        "{} file(s) need comment reflow ({mode}); run `cargo xtask fmt-comments --write`",
+        changed.len()
+    );
+}
+
+fn comment_width(explicit: Option<usize>) -> Result<usize> {
+    if let Some(width) = explicit {
+        return validate_width(width);
+    }
+
+    let source = match fs_err::read_to_string("rustfmt.toml") {
+        Ok(source) => source,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(100),
+        Err(err) => return Err(err).context("reading rustfmt.toml"),
+    };
+
+    let config =
+        toml::from_str::<toml::Value>(&source).context("parsing rustfmt.toml for comment_width")?;
+    let width = config
+        .get("comment_width")
+        .and_then(toml::Value::as_integer)
+        .and_then(|width| usize::try_from(width).ok())
+        .unwrap_or(100);
+
+    validate_width(width)
+}
+
+fn validate_width(width: usize) -> Result<usize> {
+    ensure!(width >= 20, "comment width must be at least 20 columns");
+    Ok(width)
+}


### PR DESCRIPTION
This PR adds `cargo xtask comment-reflow` command which lengthens short comment lines by reflowing them to the comment width if they fit.

This was AI driven but I think at a glance it makes sense..

This PR hands over control of comment length to this tool; it explicitly disables `rustfmt`'s wrapping of comments.

The bulk of the files can of course be ignored since they're the comment wrappings. Well maybe do look through them for suspicious things?

This will conflict with everything so if the approach is okay I'd love to get this in sooner rather than later..

Supersedes #1413.