### PR TITLE
fix(tests): don't clean up RocksDB directory before store shutdown

### DIFF
--- a/crates/block-producer/src/server/tests.rs
+++ b/crates/block-producer/src/server/tests.rs
@@ -5,7 +5,6 @@ use miden_node_proto::generated::block_producer::api_client as block_producer_cl
 use miden_node_store::{DEFAULT_MAX_CONCURRENT_PROOFS, GenesisState, Store, StoreMode};
 use miden_node_utils::clap::{GrpcOptionsInternal, StorageOptions};
 use miden_node_utils::fee::test_fee_params;
-use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_protocol::testing::random_secret_key::random_secret_key;
 use miden_validator::{Validator, ValidatorSigner};
 use tokio::net::TcpListener;
@@ -15,6 +14,26 @@ use tonic::transport::{Channel, Endpoint};
 use url::Url;
 
 use crate::{BlockProducer, DEFAULT_MAX_BATCHES_PER_BLOCK, DEFAULT_MAX_TXS_PER_BATCH};
+
+/// A wrapper around the store runtime and data directory.
+///
+/// Guarantees that the store runtime is shut down _before_ the data directory is dropped and thus removed.
+struct TestStore {
+    runtime: Option<runtime::Runtime>,
+    _data_directory: tempfile::TempDir,
+}
+
+impl Drop for TestStore {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            std::thread::spawn(move || {
+                runtime.shutdown_timeout(Duration::from_millis(500));
+            })
+            .join()
+            .expect("store runtime shutdown thread should complete");
+        }
+    }
+}
 
 /// Tests that the block producer starts up correctly even when the store is not initially
 /// available. The block producer should retry with exponential backoff until the store becomes
@@ -94,8 +113,7 @@ async fn block_producer_startup_is_robust_to_network_failures() {
     );
 
     // start the store
-    let data_directory = tempfile::tempdir().expect("tempdir should be created");
-    let store_runtime = start_store(store_addr, data_directory.path()).await;
+    let _store = start_store(store_addr).await;
 
     // wait for the block producer's exponential backoff to connect to the store use a retry loop
     // since CI environments may be slower
@@ -122,25 +140,20 @@ async fn block_producer_startup_is_robust_to_network_failures() {
     // verify the response contains expected data
     let status = response.unwrap().into_inner();
     assert_eq!(status.status, "connected");
-
-    // Shutdown the store before data_directory is dropped to allow the database to flush properly
-    shutdown_store(store_runtime).await;
 }
 
 /// Starts the store with a fresh genesis state and returns the runtime handle.
-async fn start_store(
-    store_addr: std::net::SocketAddr,
-    data_directory: &std::path::Path,
-) -> runtime::Runtime {
+async fn start_store(store_addr: std::net::SocketAddr) -> TestStore {
+    let data_directory = tempfile::tempdir().expect("tempdir should be created");
     let signer = random_secret_key();
     let genesis_state = GenesisState::new(vec![], test_fee_params(), 1, 1, signer.public_key());
     let genesis_block = genesis_state
         .clone()
         .into_block(&signer)
         .expect("genesis block should be created");
-    Store::bootstrap(genesis_block, data_directory).expect("store should bootstrap");
+    Store::bootstrap(genesis_block, data_directory.path()).expect("store should bootstrap");
 
-    let dir = data_directory.to_path_buf();
+    let dir = data_directory.path().to_path_buf();
     let rpc_listener =
         TcpListener::bind("127.0.0.1:0").await.expect("store should bind the RPC port");
     let ntx_builder_listener = TcpListener::bind("127.0.0.1:0")
@@ -171,17 +184,10 @@ async fn start_store(
         .await
         .expect("store should start serving");
     });
-    store_runtime
-}
-
-/// Shuts down the store runtime properly to allow the database to flush before the temp directory
-/// is deleted.
-async fn shutdown_store(store_runtime: runtime::Runtime) {
-    spawn_blocking_in_current_span(move || {
-        store_runtime.shutdown_timeout(Duration::from_millis(500));
-    })
-    .await
-    .expect("shutdown should complete");
+    TestStore {
+        runtime: Some(store_runtime),
+        _data_directory: data_directory,
+    }
 }
 
 /// Sends a status request to the block producer to verify connectivity.

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -45,6 +45,125 @@ use url::Url;
 
 use crate::Rpc;
 
+/// A wrapper around the store runtime and data directory.
+///
+/// Guarantees that the store runtime is shut down _before_ the data directory is dropped and thus removed.
+struct TestStore {
+    runtime: Option<Runtime>,
+    data_directory: Option<TempDir>,
+    genesis_commitment: Word,
+    store_addr: SocketAddr,
+}
+
+impl TestStore {
+    fn genesis_commitment(&self) -> Word {
+        self.genesis_commitment
+    }
+
+    fn store_addr(&self) -> SocketAddr {
+        self.store_addr
+    }
+
+    async fn shutdown(mut self) -> TempDir {
+        if let Some(runtime) = self.runtime.take() {
+            shutdown_store_runtime(runtime).await;
+        }
+        self.data_directory.take().expect("data_directory should be set")
+    }
+
+    async fn start(store_listener: TcpListener) -> Self {
+        let data_directory = tempfile::tempdir().expect("tempdir should be created");
+        let genesis_commitment = Self::bootstrap(data_directory.path());
+        Self::start_without_bootstrap(data_directory, genesis_commitment, store_listener).await
+    }
+
+    fn bootstrap(path: &std::path::Path) -> Word {
+        let config = GenesisConfig::default();
+        let signer = SecretKey::new();
+        let (genesis_state, _) = config.into_state(signer.public_key()).unwrap();
+        let genesis_block = genesis_state
+            .clone()
+            .into_block(&signer)
+            .expect("genesis block should be created");
+        let genesis_commitment = genesis_block.inner().header().commitment();
+
+        Store::bootstrap(genesis_block, path).expect("store should bootstrap");
+
+        genesis_commitment
+    }
+
+    async fn start_without_bootstrap(
+        data_directory: TempDir,
+        genesis_commitment: Word,
+        store_listener: TcpListener,
+    ) -> Self {
+        let dir = data_directory.path().to_path_buf();
+        let store_addr =
+            store_listener.local_addr().expect("store listener should get a local address");
+        let rpc_listener = store_listener;
+        let ntx_builder_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind store ntx-builder gRPC endpoint");
+        let block_producer_listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("store should bind a port");
+
+        // In order to later kill the store, we need to spawn a new runtime and run the store on it.
+        // That allows us to kill all the tasks spawned by the store when we kill the runtime.
+        let store_runtime =
+            runtime::Builder::new_multi_thread().enable_time().enable_io().build().unwrap();
+        store_runtime.spawn(async move {
+            Store {
+                rpc_listener,
+                mode: StoreMode::BlockProducer {
+                    block_producer_listener,
+                    ntx_builder_listener,
+                    block_prover_url: None,
+                    max_concurrent_proofs: DEFAULT_MAX_CONCURRENT_PROOFS,
+                },
+                data_directory: dir,
+                database_options: miden_node_store::DatabaseOptions::default(),
+                grpc_options: GrpcOptionsInternal::test(),
+                storage_options: StorageOptions::default(),
+            }
+            .serve()
+            .await
+            .expect("store should start serving");
+        });
+
+        Self {
+            runtime: Some(store_runtime),
+            data_directory: Some(data_directory),
+            genesis_commitment,
+            store_addr,
+        }
+    }
+}
+
+impl Drop for TestStore {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            shutdown_store_runtime_blocking(runtime);
+        }
+    }
+}
+
+/// Shuts down the store runtime properly to allow `RocksDB` to flush before the temp directory is
+/// deleted.
+async fn shutdown_store_runtime(store_runtime: Runtime) {
+    spawn_blocking_in_current_span(move || shutdown_store_runtime_blocking(store_runtime))
+        .await
+        .expect("shutdown should complete");
+}
+
+fn shutdown_store_runtime_blocking(store_runtime: Runtime) {
+    std::thread::spawn(move || {
+        store_runtime.shutdown_timeout(Duration::from_secs(3));
+        std::thread::sleep(Duration::from_millis(200));
+    })
+    .join()
+    .expect("store runtime shutdown thread should complete");
+}
+
 /// Byte offset of the account delta commitment in serialized `ProvenTransaction`. Layout:
 /// `AccountId` (15) + `initial_commitment` (32) + `final_commitment` (32) = 79
 const DELTA_COMMITMENT_BYTE_OFFSET: usize = 15 + 32 + 32;
@@ -107,7 +226,7 @@ fn build_test_proven_tx(
 async fn rpc_server_accepts_requests_without_accept_header() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
+    let _store = TestStore::start(store_listener).await;
 
     // Override the client so that the ACCEPT header is not set.
     let mut rpc_client = {
@@ -125,9 +244,6 @@ async fn rpc_server_accepts_requests_without_accept_header() {
 
     // Assert that the server did not reject our request.
     assert!(response.is_ok());
-
-    // Shutdown to avoid runtime drop error.
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
@@ -138,7 +254,7 @@ async fn rpc_rate_limits_per_ip() {
         ..GrpcOptionsExternal::test()
     };
     let (_, rpc_addr, store_listener) = start_rpc_with_options(grpc_options).await;
-    let (store_runtime, data_directory, _genesis, _store_addr) = start_store(store_listener).await;
+    let _store = TestStore::start(store_listener).await;
 
     let url = rpc_addr.to_string();
     let url = Url::parse(format!("http://{}", &url).as_str()).unwrap();
@@ -159,25 +275,19 @@ async fn rpc_rate_limits_per_ip() {
         last_error.is_some_and(|code| code == tonic::Code::ResourceExhausted),
         "expected rate limit error but got: {last_error:?}"
     );
-
-    shutdown_store(store_runtime).await;
-    drop(data_directory);
 }
 
 #[tokio::test]
 async fn rpc_server_accepts_requests_with_accept_header() {
     // Start the RPC.
     let (mut rpc_client, _, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
+    let _store = TestStore::start(store_listener).await;
 
     // Send any request to the RPC.
     let response = send_request(&mut rpc_client).await;
 
     // Assert the server does not reject our request on the basis of missing accept header.
     assert!(response.is_ok());
-
-    // Shutdown to avoid runtime drop error.
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
@@ -185,8 +295,7 @@ async fn rpc_server_rejects_requests_with_accept_header_invalid_version() {
     for version in ["1.9.0", "0.8.1", "0.8.0", "0.999.0", "99.0.0"] {
         // Start the RPC.
         let (_, rpc_addr, store_listener) = start_rpc().await;
-        let (store_runtime, _data_directory, _genesis, _store_addr) =
-            start_store(store_listener).await;
+        let _store = TestStore::start(store_listener).await;
 
         // Recreate the RPC client with an invalid version.
         let url = rpc_addr.to_string();
@@ -209,9 +318,6 @@ async fn rpc_server_rejects_requests_with_accept_header_invalid_version() {
         assert!(response.is_err());
         assert_eq!(response.as_ref().err().unwrap().code(), tonic::Code::InvalidArgument);
         assert!(response.as_ref().err().unwrap().message().contains("server does not support"),);
-
-        // Shutdown to avoid runtime drop error.
-        shutdown_store(store_runtime).await;
     }
 }
 
@@ -228,31 +334,33 @@ async fn rpc_startup_is_robust_to_network_failures() {
     assert!(response.is_err());
 
     // Start the store.
-    let (store_runtime, data_directory, _genesis, store_addr) = start_store(store_listener).await;
+    let store = TestStore::start(store_listener).await;
 
     // Test: send request against RPC api and should succeed
     let response = send_request_until_success(&mut rpc_client).await;
     assert!(response.unwrap().into_inner().block_header.is_some());
 
     // Test: shutdown the store and should fail
-    shutdown_store(store_runtime).await;
+    let store_addr = store.store_addr();
+    let genesis_commitment = store.genesis_commitment();
+    let data_directory = store.shutdown().await;
     let response = send_request(&mut rpc_client).await;
     assert!(response.is_err());
 
     // Test: restart the store and request should succeed
-    let store_runtime = restart_store(store_addr, data_directory.path()).await;
+    let store_listener = TcpListener::bind(store_addr).await.expect("Failed to bind store");
+    let _store =
+        TestStore::start_without_bootstrap(data_directory, genesis_commitment, store_listener)
+            .await;
     let response = send_request_until_success(&mut rpc_client).await;
     assert_eq!(response.unwrap().into_inner().block_header.unwrap().block_num, 0);
-
-    // Shutdown the store before data_directory is dropped to allow RocksDB to flush properly
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
 async fn rpc_server_has_web_support() {
     // Start server
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
+    let _store = TestStore::start(store_listener).await;
 
     // Send a status request
     let client = reqwest::Client::new();
@@ -288,14 +396,14 @@ async fn rpc_server_has_web_support() {
     assert!(headers.get("access-control-allow-credentials").is_some());
     assert!(headers.get("access-control-expose-headers").is_some());
     assert!(headers.get("vary").is_some());
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
 async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, genesis, _store_addr) = start_store(store_listener).await;
+    let store = TestStore::start(store_listener).await;
+    let genesis = store.genesis_commitment();
 
     // Wait for the store to be ready before sending requests.
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -340,16 +448,14 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
         err.contains("failed to validate account delta in transaction account update"),
         "expected error message to contain delta commitment error but got: {err}"
     );
-
-    // Shutdown to avoid runtime drop error.
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
 async fn rpc_server_rejects_proven_transactions_with_invalid_reference_block() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, genesis, _store_addr) = start_store(store_listener).await;
+    let store = TestStore::start(store_listener).await;
+    let genesis = store.genesis_commitment();
 
     // Wait for the store to be ready before sending requests.
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -385,16 +491,14 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_reference_block() {
         err.contains("does not match the chain's commitment of"),
         "expected error message to contain reference block error but got: {err}"
     );
-
-    // Shutdown to avoid runtime drop error.
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
 async fn rpc_server_rejects_tx_submissions_without_genesis() {
     // Start the RPC.
     let (_, rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, genesis, _store_addr) = start_store(store_listener).await;
+    let store = TestStore::start(store_listener).await;
+    let genesis = store.genesis_commitment();
 
     // Override the client so that the ACCEPT header is not set.
     let mut rpc_client =
@@ -427,9 +531,6 @@ async fn rpc_server_rejects_tx_submissions_without_genesis() {
         ),
         "expected error message to reference incompatible content media types but got: {err:?}"
     );
-
-    // Shutdown to avoid runtime drop error.
-    shutdown_store(store_runtime).await;
 }
 
 /// Sends an arbitrary / irrelevant request to the RPC.
@@ -522,100 +623,11 @@ async fn start_rpc_with_options(
     (rpc_client, rpc_addr, store_listener)
 }
 
-async fn start_store(store_listener: TcpListener) -> (Runtime, TempDir, Word, SocketAddr) {
-    // Start the store.
-    let data_directory = tempfile::tempdir().expect("tempdir should be created");
-
-    let config = GenesisConfig::default();
-    let signer = SecretKey::new();
-    let (genesis_state, _) = config.into_state(signer.public_key()).unwrap();
-    let genesis_block = genesis_state
-        .clone()
-        .into_block(&signer)
-        .expect("genesis block should be created");
-    let genesis_commitment = genesis_block.inner().header().commitment();
-    Store::bootstrap(genesis_block, data_directory.path()).expect("store should bootstrap");
-    let dir = data_directory.path().to_path_buf();
-    let store_addr =
-        store_listener.local_addr().expect("store listener should get a local address");
-    let rpc_listener = store_listener;
-    let ntx_builder_listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("Failed to bind store ntx-builder gRPC endpoint");
-    let block_producer_listener =
-        TcpListener::bind("127.0.0.1:0").await.expect("store should bind a port");
-    // In order to later kill the store, we need to spawn a new runtime and run the store on it.
-    // That allows us to kill all the tasks spawned by the store when we kill the runtime.
-    let store_runtime =
-        runtime::Builder::new_multi_thread().enable_time().enable_io().build().unwrap();
-    store_runtime.spawn(async move {
-        Store {
-            rpc_listener,
-            mode: StoreMode::BlockProducer {
-                block_producer_listener,
-                ntx_builder_listener,
-                block_prover_url: None,
-                max_concurrent_proofs: DEFAULT_MAX_CONCURRENT_PROOFS,
-            },
-            data_directory: dir,
-            database_options: miden_node_store::DatabaseOptions::default(),
-            grpc_options: GrpcOptionsInternal::test(),
-            storage_options: StorageOptions::default(),
-        }
-        .serve()
-        .await
-        .expect("store should start serving");
-    });
-    (store_runtime, data_directory, genesis_commitment, store_addr)
-}
-
-/// Shuts down the store runtime properly to allow `RocksDB` to flush before the temp directory is
-/// deleted.
-async fn shutdown_store(store_runtime: Runtime) {
-    spawn_blocking_in_current_span(move || store_runtime.shutdown_timeout(Duration::from_secs(3)))
-        .await
-        .expect("shutdown should complete");
-    // Give RocksDB time to release its lock file after the runtime shutdown
-    tokio::time::sleep(Duration::from_millis(200)).await;
-}
-
-/// Restarts a store using an existing data directory. Returns the runtime handle for shutdown.
-async fn restart_store(store_addr: SocketAddr, data_directory: &std::path::Path) -> Runtime {
-    let rpc_listener = TcpListener::bind(store_addr).await.expect("Failed to bind store");
-    let ntx_builder_listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("Failed to bind store ntx-builder gRPC endpoint");
-    let block_producer_listener =
-        TcpListener::bind("127.0.0.1:0").await.expect("store should bind a port");
-    let dir = data_directory.to_path_buf();
-    let store_runtime =
-        runtime::Builder::new_multi_thread().enable_time().enable_io().build().unwrap();
-    store_runtime.spawn(async move {
-        Store {
-            rpc_listener,
-            mode: StoreMode::BlockProducer {
-                block_producer_listener,
-                ntx_builder_listener,
-                block_prover_url: None,
-                max_concurrent_proofs: DEFAULT_MAX_CONCURRENT_PROOFS,
-            },
-            data_directory: dir,
-            database_options: miden_node_store::DatabaseOptions::default(),
-            grpc_options: GrpcOptionsInternal::test(),
-            storage_options: StorageOptions::default(),
-        }
-        .serve()
-        .await
-        .expect("store should start serving");
-    });
-    store_runtime
-}
-
 #[tokio::test]
 async fn get_limits_endpoint() {
     // Start the RPC and store
     let (mut rpc_client, _rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
+    let _store = TestStore::start(store_listener).await;
 
     // Call the get_limits endpoint
     let response = rpc_client.get_limits(()).await.expect("get_limits should succeed");
@@ -675,15 +687,12 @@ async fn get_limits_endpoint() {
         QueryParamNoteIdLimit::PARAM_NAME,
         QueryParamNoteIdLimit::LIMIT
     );
-
-    // Shutdown to avoid runtime drop error.
-    shutdown_store(store_runtime).await;
 }
 
 #[tokio::test]
 async fn sync_chain_mmr_returns_delta() {
     let (mut rpc_client, _rpc_addr, store_listener) = start_rpc().await;
-    let (store_runtime, _data_directory, _genesis, _store_addr) = start_store(store_listener).await;
+    let _store = TestStore::start(store_listener).await;
 
     let request = proto::rpc::SyncChainMmrRequest {
         current_client_block_height: 0,
@@ -695,8 +704,6 @@ async fn sync_chain_mmr_returns_delta() {
     let mmr_delta = response.mmr_delta.expect("mmr_delta should exist");
     assert_eq!(mmr_delta.forest, 0);
     assert!(mmr_delta.data.is_empty());
-
-    shutdown_store(store_runtime).await;
 }
 
 #[test]


### PR DESCRIPTION
Due to missing store shutdown on panic test failures could cause the temporary directory to be cleaned up while the store was still running.

This would then cause a panic when the LargeSmt RocksDB storage backend was being dropped because we're doing an explicit flush there.

This change fixes this by introducing a `TestStore` wrapper around the store and the temporary directory that makes sure that the store runtime is stopped before deleting the temporary directory.