### PR TITLE
feat: yank replica service and move methods to RPC service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Refactored the remote prover gRPC API implementation to use the new per-method trait implementations ([#1975](https://github.com/0xMiden/node/issues/1975)).
 - Aligned `SyncNullifiers` list-limit validation in RPC and store with `nullifier_prefix` parameter semantics, extended `GetLimits` test coverage, and documented query parameter limits ([#1986](https://github.com/0xMiden/node/pull/1986)).
 - Added a `replica` mode to the store, which streams blocks from an upstream master store ([#1987](https://github.com/0xMiden/node/pull/1987)).
-- Added `StoreReplica` gRPC service with endpoints for streaming blocks and proofs ([#1987](https://github.com/0xMiden/node/pull/1987)).
+- Added public and store `Rpc` streaming endpoints for replica block/proof synchronization ([#1987](https://github.com/0xMiden/node/pull/1987)).
 - Replaced the network monitor's JavaScript dashboard with a server-rendered Maud + HTMX frontend ([#2024](https://github.com/0xMiden/node/pull/2024)).
 - [BREAKING] Removed `CheckNullifiers` endpoint ([#2049](https://github.com/0xMiden/node/pull/2049)).
 - Replaced blocking-in-async operations in the validator, remote prover, and ntx-builder with `spawn_blocking` to avoid starving the Tokio runtime ([#2041](https://github.com/0xMiden/node/pull/2041)).

--- a/bin/node/src/commands/store.rs
+++ b/bin/node/src/commands/store.rs
@@ -99,15 +99,15 @@ pub enum StoreCommand {
 
     /// Starts the store in replica mode.
     ///
-    /// In this mode the store syncs blocks from an upstream store's `StoreReplica` gRPC service.
-    /// Only the `Rpc` and `StoreReplica` gRPC services are exposed — the `BlockProducer` and
-    /// `NtxBuilder` services are not started and no proof scheduler runs.
+    /// In this mode the store syncs blocks from an upstream store's `Rpc` gRPC service.
+    /// Only the `Rpc` gRPC service is exposed — the `BlockProducer` and `NtxBuilder` services are
+    /// not started and no proof scheduler runs.
     StartReplica {
         /// Socket address at which to serve the store's RPC API.
         #[arg(long = "rpc.listen", env = ENV_RPC_LISTEN, value_name = "LISTEN")]
         rpc_listen: SocketAddr,
 
-        /// gRPC URL of the upstream store's `StoreReplica` endpoint to sync blocks from.
+        /// gRPC URL of the upstream store's `Rpc` endpoint to sync blocks from.
         #[arg(long = "upstream-store.url", env = ENV_UPSTREAM_URL, value_name = "URL")]
         upstream_store_url: Url,
 

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -244,6 +244,9 @@ impl RpcService {
 
 #[tonic::async_trait]
 impl api_server::Api for RpcService {
+    type BlockSubscriptionStream = tonic::codec::Streaming<proto::rpc::BlockSubscriptionResponse>;
+    type ProofSubscriptionStream = tonic::codec::Streaming<proto::rpc::ProofSubscriptionResponse>;
+
     // -- Nullifier endpoints -----------------------------------------------------------------
 
     async fn sync_nullifiers(
@@ -303,6 +306,30 @@ impl api_server::Api for RpcService {
         debug!(target: COMPONENT, request = ?request_ref);
 
         self.store.clone().sync_chain_mmr(request).await
+    }
+
+    async fn block_subscription(
+        &self,
+        request: Request<proto::rpc::BlockSubscriptionRequest>,
+    ) -> Result<Response<Self::BlockSubscriptionStream>, Status> {
+        let request_ref = request.get_ref();
+        Span::current().set_attribute("block.from", request_ref.block_from);
+
+        debug!(target: COMPONENT, request = ?request_ref);
+
+        self.store.clone().block_subscription(request).await
+    }
+
+    async fn proof_subscription(
+        &self,
+        request: Request<proto::rpc::ProofSubscriptionRequest>,
+    ) -> Result<Response<Self::ProofSubscriptionStream>, Status> {
+        let request_ref = request.get_ref();
+        Span::current().set_attribute("block.from", request_ref.block_from);
+
+        debug!(target: COMPONENT, request = ?request_ref);
+
+        self.store.clone().proof_subscription(request).await
     }
 
     // -- Note endpoints ----------------------------------------------------------------------

--- a/crates/store/src/server/mod.rs
+++ b/crates/store/src/server/mod.rs
@@ -61,10 +61,10 @@ pub enum StoreMode {
         max_concurrent_proofs: NonZeroUsize,
     },
 
-    /// Receives blocks from an upstream store's `StoreReplica` gRPC service.
+    /// Receives blocks from an upstream store's `Rpc` gRPC service.
     ///
-    /// Only the `Rpc` and `StoreReplica` gRPC services are exposed. The `BlockProducer` and
-    /// `NtxBuilder` services are not started and no proof scheduler runs.
+    /// Only the `Rpc` gRPC service is exposed. The `BlockProducer` and `NtxBuilder` services are
+    /// not started and no proof scheduler runs.
     Replica { upstream_url: Url },
 }
 
@@ -310,7 +310,7 @@ impl Store {
 
     /// Spawns the gRPC servers for block-producer mode.
     ///
-    /// Starts three listeners: Rpc+StoreReplica (shared), `NtxBuilder`, and `BlockProducer`.
+    /// Starts three listeners: `Rpc`, `NtxBuilder`, and `BlockProducer`.
     fn spawn_block_producer_grpc_servers(
         store_api: api::StoreApi,
         block_producer_api: block_producer::BlockProducerApi,
@@ -322,8 +322,6 @@ impl Store {
         let mut join_set = JoinSet::new();
 
         let rpc_service = store::rpc_server::RpcServer::new(store_api.clone());
-        let replica_service =
-            store::store_replica_server::StoreReplicaServer::new(store_api.clone());
         let ntx_builder_service = store::ntx_builder_server::NtxBuilderServer::new(store_api);
         let block_producer_service =
             store::block_producer_server::BlockProducerServer::new(block_producer_api);
@@ -343,7 +341,6 @@ impl Store {
         join_set.spawn(
             make_server()
                 .add_service(rpc_service)
-                .add_service(replica_service)
                 .add_service(reflection_service.clone())
                 .serve_with_incoming(TcpListenerStream::new(rpc_listener)),
         );
@@ -368,8 +365,7 @@ impl Store {
 
     /// Spawns the gRPC servers for replica mode.
     ///
-    /// Only the Rpc and `StoreReplica` services are exposed — no `BlockProducer`, `NtxBuilder`, or
-    /// proof scheduler.
+    /// Only the `Rpc` service is exposed — no `BlockProducer`, `NtxBuilder`, or proof scheduler.
     fn spawn_replica_grpc_servers(
         store_api: api::StoreApi,
         grpc_options: GrpcOptionsInternal,
@@ -377,8 +373,7 @@ impl Store {
     ) -> anyhow::Result<JoinSet<Result<(), tonic::transport::Error>>> {
         let mut join_set = JoinSet::new();
 
-        let rpc_service = store::rpc_server::RpcServer::new(store_api.clone());
-        let replica_service = store::store_replica_server::StoreReplicaServer::new(store_api);
+        let rpc_service = store::rpc_server::RpcServer::new(store_api);
 
         let reflection_service = tonic_reflection::server::Builder::configure()
             .register_file_descriptor_set(store_api_descriptor())
@@ -391,7 +386,6 @@ impl Store {
                 .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
                 .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
                 .add_service(rpc_service)
-                .add_service(replica_service)
                 .add_service(reflection_service)
                 .serve_with_incoming(TcpListenerStream::new(rpc_listener)),
         );

--- a/crates/store/src/server/replica.rs
+++ b/crates/store/src/server/replica.rs
@@ -2,12 +2,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use miden_node_proto::generated::store::{
-    BlockProof,
+use miden_node_proto::generated::rpc::{
     BlockSubscriptionRequest,
+    BlockSubscriptionResponse,
     ProofSubscriptionRequest,
-    SignedBlock,
-    store_replica_server,
+    ProofSubscriptionResponse,
 };
 use miden_node_utils::ErrorReport;
 use miden_protocol::block::BlockNumber;
@@ -39,37 +38,36 @@ impl<S: Stream> Stream for GuardedStream<S> {
     }
 }
 
-// STORE REPLICA API
+// RPC SUBSCRIPTION API
 // ================================================================================================
 
-#[tonic::async_trait]
-impl store_replica_server::StoreReplica for StoreApi {
-    type BlockSubscriptionStream = Pin<
-        Box<
-            dyn tonic::codegen::tokio_stream::Stream<Item = Result<SignedBlock, Status>>
-                + Send
-                + 'static,
-        >,
-    >;
+pub(super) type BlockSubscriptionStream = Pin<
+    Box<
+        dyn tonic::codegen::tokio_stream::Stream<Item = Result<BlockSubscriptionResponse, Status>>
+            + Send
+            + 'static,
+    >,
+>;
 
-    type ProofSubscriptionStream = Pin<
-        Box<
-            dyn tonic::codegen::tokio_stream::Stream<Item = Result<BlockProof, Status>>
-                + Send
-                + 'static,
-        >,
-    >;
+pub(super) type ProofSubscriptionStream = Pin<
+    Box<
+        dyn tonic::codegen::tokio_stream::Stream<Item = Result<ProofSubscriptionResponse, Status>>
+            + Send
+            + 'static,
+    >,
+>;
 
+impl StoreApi {
     /// Streams committed blocks to a replica starting from `from_block_number`.
     ///
     /// Subscribes to the committed-tip watch channel and maintains a sequential counter. On each
     /// tip advance it emits all blocks from the current position up to the new tip, falling back to
     /// the block store for any entry not in the in-memory cache. The stream closes only when the
     /// client disconnects or the server shuts down.
-    async fn block_subscription(
+    pub(super) async fn block_subscription_inner(
         &self,
         request: Request<BlockSubscriptionRequest>,
-    ) -> Result<Response<Self::BlockSubscriptionStream>, Status> {
+    ) -> Result<Response<BlockSubscriptionStream>, Status> {
         let permit = Arc::clone(&self.block_subscription_semaphore)
             .try_acquire_owned()
             .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
@@ -82,18 +80,20 @@ impl store_replica_server::StoreReplica for StoreApi {
             self.committed_tip_rx.clone(),
             Arc::clone(&self.state),
         );
-        Ok(Response::new(Box::pin(GuardedStream { inner: stream, _permit: permit })))
+        let stream: BlockSubscriptionStream =
+            Box::pin(GuardedStream { inner: stream, _permit: permit });
+        Ok(Response::new(stream))
     }
 
     /// Streams block proofs to a replica starting from `from_block_number`.
     ///
-    /// Uses the same watch-channel approach as [`Self::block_subscription`]: waits for the
+    /// Uses the same watch-channel approach as [`Self::block_subscription_inner`]: waits for the
     /// proven-in-sequence tip to advance, then emits all proofs from the current position up to
     /// the new tip, falling back to the block store for cache misses.
-    async fn proof_subscription(
+    pub(super) async fn proof_subscription_inner(
         &self,
         request: Request<ProofSubscriptionRequest>,
-    ) -> Result<Response<Self::ProofSubscriptionStream>, Status> {
+    ) -> Result<Response<ProofSubscriptionStream>, Status> {
         let permit = Arc::clone(&self.proof_subscription_semaphore)
             .try_acquire_owned()
             .map_err(|_| Status::resource_exhausted("maximum proof subscriptions reached"))?;
@@ -106,7 +106,9 @@ impl store_replica_server::StoreReplica for StoreApi {
             self.proven_tip_rx.clone(),
             Arc::clone(&self.state),
         );
-        Ok(Response::new(Box::pin(GuardedStream { inner: stream, _permit: permit })))
+        let stream: ProofSubscriptionStream =
+            Box::pin(GuardedStream { inner: stream, _permit: permit });
+        Ok(Response::new(stream))
     }
 }
 
@@ -119,7 +121,7 @@ fn build_block_stream(
     cache: BlockCache,
     tip_rx: watch::Receiver<BlockNumber>,
     state: Arc<State>,
-) -> impl Stream<Item = Result<SignedBlock, Status>> + Send + 'static {
+) -> impl Stream<Item = Result<BlockSubscriptionResponse, Status>> + Send + 'static {
     let (tx, rx) = mpsc::channel(32);
     tokio::spawn(async move {
         if let Err(status) = run_block_stream(from, cache, tip_rx, state, &tx).await {
@@ -136,7 +138,7 @@ fn build_proof_stream(
     cache: ProofCache,
     tip_rx: watch::Receiver<BlockNumber>,
     state: Arc<State>,
-) -> impl Stream<Item = Result<BlockProof, Status>> + Send + 'static {
+) -> impl Stream<Item = Result<ProofSubscriptionResponse, Status>> + Send + 'static {
     let (tx, rx) = mpsc::channel(32);
     tokio::spawn(async move {
         if let Err(status) = run_proof_stream(from, cache, tip_rx, state, &tx).await {
@@ -159,7 +161,7 @@ async fn run_block_stream(
     cache: BlockCache,
     mut tip_rx: watch::Receiver<BlockNumber>,
     state: Arc<State>,
-    tx: &mpsc::Sender<Result<SignedBlock, Status>>,
+    tx: &mpsc::Sender<Result<BlockSubscriptionResponse, Status>>,
 ) -> Result<(), Status> {
     let mut next = from;
     loop {
@@ -167,7 +169,14 @@ async fn run_block_stream(
         let tip = *tip_rx.borrow_and_update();
         while next <= tip {
             let bytes = fetch_block(next, &cache, &state).await?;
-            if tx.send(Ok(SignedBlock { block: bytes })).await.is_err() {
+            if tx
+                .send(Ok(BlockSubscriptionResponse {
+                    block: bytes,
+                    committed_chain_tip: tip.as_u32(),
+                }))
+                .await
+                .is_err()
+            {
                 // Client disconnected.
                 return Ok(());
             }
@@ -190,7 +199,7 @@ async fn run_proof_stream(
     cache: ProofCache,
     mut tip_rx: watch::Receiver<BlockNumber>,
     state: Arc<State>,
-    tx: &mpsc::Sender<Result<BlockProof, Status>>,
+    tx: &mpsc::Sender<Result<ProofSubscriptionResponse, Status>>,
 ) -> Result<(), Status> {
     let mut next = from;
     loop {
@@ -198,7 +207,15 @@ async fn run_proof_stream(
         let tip = *tip_rx.borrow_and_update();
         while next <= tip {
             let proof = fetch_proof(next, &cache, &state).await?;
-            if tx.send(Ok(BlockProof { block_num: next.as_u32(), proof })).await.is_err() {
+            if tx
+                .send(Ok(ProofSubscriptionResponse {
+                    block_num: next.as_u32(),
+                    proof,
+                    proven_chain_tip: tip.as_u32(),
+                }))
+                .await
+                .is_err()
+            {
                 // Client disconnected.
                 return Ok(());
             }

--- a/crates/store/src/server/replica.rs
+++ b/crates/store/src/server/replica.rs
@@ -2,21 +2,15 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use miden_node_proto::generated::rpc::{
-    BlockSubscriptionRequest,
-    BlockSubscriptionResponse,
-    ProofSubscriptionRequest,
-    ProofSubscriptionResponse,
-};
+use miden_node_proto::generated::rpc::{BlockSubscriptionResponse, ProofSubscriptionResponse};
 use miden_node_utils::ErrorReport;
 use miden_protocol::block::BlockNumber;
 use pin_project::pin_project;
 use tokio::sync::{OwnedSemaphorePermit, mpsc, watch};
 use tokio_stream::Stream;
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::{Request, Response, Status};
+use tonic::Status;
 
-use crate::server::api::StoreApi;
 use crate::state::{BlockCache, ProofCache, State};
 
 // GUARDED STREAM
@@ -24,10 +18,16 @@ use crate::state::{BlockCache, ProofCache, State};
 
 /// Wraps a stream and holds a semaphore permit for its lifetime, releasing it on drop.
 #[pin_project]
-struct GuardedStream<S: Stream> {
+pub(super) struct GuardedStream<S: Stream> {
     #[pin]
     inner: S,
     _permit: OwnedSemaphorePermit,
+}
+
+impl<S: Stream> GuardedStream<S> {
+    pub(super) fn new(inner: S, permit: OwnedSemaphorePermit) -> Self {
+        Self { inner, _permit: permit }
+    }
 }
 
 impl<S: Stream> Stream for GuardedStream<S> {
@@ -57,66 +57,11 @@ pub(super) type ProofSubscriptionStream = Pin<
     >,
 >;
 
-impl StoreApi {
-    /// Streams committed blocks to a replica starting from `from_block_number`.
-    ///
-    /// Subscribes to the committed-tip watch channel and maintains a sequential counter. On each
-    /// tip advance it emits all blocks from the current position up to the new tip, falling back to
-    /// the block store for any entry not in the in-memory cache. The stream closes only when the
-    /// client disconnects or the server shuts down.
-    pub(super) async fn block_subscription_inner(
-        &self,
-        request: Request<BlockSubscriptionRequest>,
-    ) -> Result<Response<BlockSubscriptionStream>, Status> {
-        let permit = Arc::clone(&self.block_subscription_semaphore)
-            .try_acquire_owned()
-            .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
-
-        let from = BlockNumber::from(request.into_inner().block_from);
-
-        let stream = build_block_stream(
-            from,
-            self.block_cache.clone(),
-            self.committed_tip_rx.clone(),
-            Arc::clone(&self.state),
-        );
-        let stream: BlockSubscriptionStream =
-            Box::pin(GuardedStream { inner: stream, _permit: permit });
-        Ok(Response::new(stream))
-    }
-
-    /// Streams block proofs to a replica starting from `from_block_number`.
-    ///
-    /// Uses the same watch-channel approach as [`Self::block_subscription_inner`]: waits for the
-    /// proven-in-sequence tip to advance, then emits all proofs from the current position up to
-    /// the new tip, falling back to the block store for cache misses.
-    pub(super) async fn proof_subscription_inner(
-        &self,
-        request: Request<ProofSubscriptionRequest>,
-    ) -> Result<Response<ProofSubscriptionStream>, Status> {
-        let permit = Arc::clone(&self.proof_subscription_semaphore)
-            .try_acquire_owned()
-            .map_err(|_| Status::resource_exhausted("maximum proof subscriptions reached"))?;
-
-        let from = BlockNumber::from(request.into_inner().block_from);
-
-        let stream = build_proof_stream(
-            from,
-            self.proof_cache.clone(),
-            self.proven_tip_rx.clone(),
-            Arc::clone(&self.state),
-        );
-        let stream: ProofSubscriptionStream =
-            Box::pin(GuardedStream { inner: stream, _permit: permit });
-        Ok(Response::new(stream))
-    }
-}
-
 // STREAM BUILDERS
 // ================================================================================================
 
 /// Spawns the block-stream task and returns its output as a [`ReceiverStream`].
-fn build_block_stream(
+pub(super) fn build_block_stream(
     from: BlockNumber,
     cache: BlockCache,
     tip_rx: watch::Receiver<BlockNumber>,
@@ -133,7 +78,7 @@ fn build_block_stream(
 }
 
 /// Spawns the proof-stream task and returns its output as a [`ReceiverStream`].
-fn build_proof_stream(
+pub(super) fn build_proof_stream(
     from: BlockNumber,
     cache: ProofCache,
     tip_rx: watch::Receiver<BlockNumber>,

--- a/crates/store/src/server/replica.rs
+++ b/crates/store/src/server/replica.rs
@@ -165,10 +165,10 @@ async fn run_block_stream(
 ) -> Result<(), Status> {
     let mut next = from;
     loop {
-        // Read tip.
-        let tip = *tip_rx.borrow_and_update();
+        let mut tip = *tip_rx.borrow_and_update();
         while next <= tip {
             let bytes = fetch_block(next, &cache, &state).await?;
+            tip = *tip_rx.borrow_and_update();
             if tx
                 .send(Ok(BlockSubscriptionResponse {
                     block: bytes,
@@ -203,10 +203,10 @@ async fn run_proof_stream(
 ) -> Result<(), Status> {
     let mut next = from;
     loop {
-        // Read tip.
-        let tip = *tip_rx.borrow_and_update();
+        let mut tip = *tip_rx.borrow_and_update();
         while next <= tip {
             let proof = fetch_proof(next, &cache, &state).await?;
+            tip = *tip_rx.borrow_and_update();
             if tx
                 .send(Ok(ProofSubscriptionResponse {
                     block_num: next.as_u32(),

--- a/crates/store/src/server/replica_sync.rs
+++ b/crates/store/src/server/replica_sync.rs
@@ -4,11 +4,8 @@ use std::time::Duration;
 use anyhow::Context;
 use async_trait::async_trait;
 use miden_crypto::utils::Deserializable;
-use miden_node_proto::generated::store::{
-    BlockSubscriptionRequest,
-    ProofSubscriptionRequest,
-    store_replica_client,
-};
+use miden_node_proto::generated::rpc::{BlockSubscriptionRequest, ProofSubscriptionRequest};
+use miden_node_proto::generated::store::rpc_client;
 use miden_protocol::block::{BlockNumber, SignedBlock};
 use tokio_stream::StreamExt;
 use tracing::{info, warn};
@@ -18,7 +15,7 @@ use crate::state::{Finality, State};
 
 pub(crate) const RECONNECT_DELAY: Duration = Duration::from_secs(5);
 
-type StoreReplicaClient = store_replica_client::StoreReplicaClient<tonic::transport::Channel>;
+type StoreRpcClient = rpc_client::RpcClient<tonic::transport::Channel>;
 
 // REPLICA SYNC
 // ================================================================================================
@@ -40,7 +37,7 @@ pub(crate) trait ReplicaSync: Sized + Send + Sync + 'static {
 
     /// Subscribes to the upstream stream via `client` and processes events until the stream ends or
     /// an error occurs.
-    async fn subscribe(&self, client: StoreReplicaClient) -> anyhow::Result<()>;
+    async fn subscribe(&self, client: StoreRpcClient) -> anyhow::Result<()>;
 
     /// Opens a connection to [`upstream_url`](Self::upstream_url) and calls
     /// [`subscribe`](Self::subscribe) with the resulting client.
@@ -48,7 +45,7 @@ pub(crate) trait ReplicaSync: Sized + Send + Sync + 'static {
         let channel = tonic::transport::Channel::from_shared(self.upstream_url().to_string())?
             .connect()
             .await?;
-        self.subscribe(StoreReplicaClient::new(channel)).await
+        self.subscribe(StoreRpcClient::new(channel)).await
     }
 
     /// Runs [`sync`](Self::sync) in an infinite loop, sleeping [`RECONNECT_DELAY`] on failure.
@@ -98,7 +95,7 @@ impl ReplicaSync for BlockReplicaSync {
         &self.upstream_url
     }
 
-    async fn subscribe(&self, mut client: StoreReplicaClient) -> anyhow::Result<()> {
+    async fn subscribe(&self, mut client: StoreRpcClient) -> anyhow::Result<()> {
         let block_from = self.state.chain_tip(Finality::Committed).await.child().as_u32();
         info!(block_from, upstream_url = %self.upstream_url, "Connecting to upstream store for blocks");
 
@@ -141,7 +138,7 @@ impl ReplicaSync for ProofReplicaSync {
         &self.upstream_url
     }
 
-    async fn subscribe(&self, mut client: StoreReplicaClient) -> anyhow::Result<()> {
+    async fn subscribe(&self, mut client: StoreRpcClient) -> anyhow::Result<()> {
         let block_from = self.state.chain_tip(Finality::Proven).await.as_u32().saturating_add(1);
         info!(block_from, upstream_url = %self.upstream_url, "Connecting to upstream store for proofs");
 

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use miden_node_proto::decode::{
     convert_digests_to_words,
     read_account_id,
@@ -35,7 +37,13 @@ use crate::errors::{
     SyncTransactionsError,
 };
 use crate::server::api::{StoreApi, internal_error};
-use crate::server::replica::{BlockSubscriptionStream, ProofSubscriptionStream};
+use crate::server::replica::{
+    BlockSubscriptionStream,
+    GuardedStream,
+    ProofSubscriptionStream,
+    build_block_stream,
+    build_proof_stream,
+};
 use crate::state::Finality;
 
 // CLIENT ENDPOINTS
@@ -50,14 +58,40 @@ impl rpc_server::Rpc for StoreApi {
         &self,
         request: Request<proto::rpc::BlockSubscriptionRequest>,
     ) -> Result<Response<Self::BlockSubscriptionStream>, Status> {
-        self.block_subscription_inner(request).await
+        let permit = Arc::clone(&self.block_subscription_semaphore)
+            .try_acquire_owned()
+            .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
+
+        let from = BlockNumber::from(request.into_inner().block_from);
+
+        let stream = build_block_stream(
+            from,
+            self.block_cache.clone(),
+            self.committed_tip_rx.clone(),
+            Arc::clone(&self.state),
+        );
+        let stream: Self::BlockSubscriptionStream = Box::pin(GuardedStream::new(stream, permit));
+        Ok(Response::new(stream))
     }
 
     async fn proof_subscription(
         &self,
         request: Request<proto::rpc::ProofSubscriptionRequest>,
     ) -> Result<Response<Self::ProofSubscriptionStream>, Status> {
-        self.proof_subscription_inner(request).await
+        let permit = Arc::clone(&self.proof_subscription_semaphore)
+            .try_acquire_owned()
+            .map_err(|_| Status::resource_exhausted("maximum proof subscriptions reached"))?;
+
+        let from = BlockNumber::from(request.into_inner().block_from);
+
+        let stream = build_proof_stream(
+            from,
+            self.proof_cache.clone(),
+            self.proven_tip_rx.clone(),
+            Arc::clone(&self.state),
+        );
+        let stream: Self::ProofSubscriptionStream = Box::pin(GuardedStream::new(stream, permit));
+        Ok(Response::new(stream))
     }
 
     /// Returns block header for the specified block number.

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -35,6 +35,7 @@ use crate::errors::{
     SyncTransactionsError,
 };
 use crate::server::api::{StoreApi, internal_error};
+use crate::server::replica::{BlockSubscriptionStream, ProofSubscriptionStream};
 use crate::state::Finality;
 
 // CLIENT ENDPOINTS
@@ -42,6 +43,23 @@ use crate::state::Finality;
 
 #[tonic::async_trait]
 impl rpc_server::Rpc for StoreApi {
+    type BlockSubscriptionStream = BlockSubscriptionStream;
+    type ProofSubscriptionStream = ProofSubscriptionStream;
+
+    async fn block_subscription(
+        &self,
+        request: Request<proto::rpc::BlockSubscriptionRequest>,
+    ) -> Result<Response<Self::BlockSubscriptionStream>, Status> {
+        self.block_subscription_inner(request).await
+    }
+
+    async fn proof_subscription(
+        &self,
+        request: Request<proto::rpc::ProofSubscriptionRequest>,
+    ) -> Result<Response<Self::ProofSubscriptionStream>, Status> {
+        self.proof_subscription_inner(request).await
+    }
+
     /// Returns block header for the specified block number.
     ///
     /// If the block number is not provided, block header for the latest block is returned.

--- a/docs/external/src/rpc.md
+++ b/docs/external/src/rpc.md
@@ -18,6 +18,8 @@ The gRPC service definition can be found in the Miden node's `proto` [directory]
 - [GetNetworkNoteStatus](#getnetworknotestatus)
 - [GetNotesById](#getnotesbyid)
 - [GetNoteScriptByRoot](#getnotescriptbyroot)
+- [BlockSubscription](#blocksubscription)
+- [ProofSubscription](#proofsubscription)
 - [Status](#status)
 - [SubmitProvenTx](#submitproventx)
 - [SyncAccountStorageMaps](#syncaccountstoragemaps)
@@ -125,6 +127,20 @@ If the note is not found in the network transaction builder's database, the endp
 ### GetNoteScriptByRoot
 
 Request the script for a note by its root.
+
+### BlockSubscription
+
+Streams committed blocks starting from `block_from` inclusive.
+
+Each stream item contains the serialized signed block and the committed chain tip observed when
+the item was emitted.
+
+### ProofSubscription
+
+Streams block proofs starting from `block_from` inclusive.
+
+Each stream item contains the block number, serialized block proof, and the proven chain tip
+observed when the item was emitted.
 
 ### Status
 

--- a/proto/proto/internal/store.proto
+++ b/proto/proto/internal/store.proto
@@ -55,6 +55,19 @@ service Rpc {
 
     // Returns transactions records for specific accounts within a block range.
     rpc SyncTransactions(rpc.SyncTransactionsRequest) returns (rpc.SyncTransactionsResponse) {}
+
+    // Streams committed blocks starting from the given block number (inclusive).
+    //
+    // Replays historical blocks first, then streams live blocks as they are committed.
+    // On lag (replica falls too far behind), the stream is closed with a DATA_LOSS error and
+    // the client should reconnect from its local tip.
+    rpc BlockSubscription(rpc.BlockSubscriptionRequest) returns (stream rpc.BlockSubscriptionResponse) {}
+
+    // Streams block proofs starting from the given block number (inclusive).
+    //
+    // Replays existing proofs first, then streams new proofs as they are generated.
+    // On lag, the stream is closed with a DATA_LOSS error.
+    rpc ProofSubscription(rpc.ProofSubscriptionRequest) returns (stream rpc.ProofSubscriptionResponse) {}
 }
 
 // BLOCK PRODUCER STORE API
@@ -221,65 +234,6 @@ message TransactionInputs {
 
     // Whether the account ID prefix is unique. Only relevant for account creation requests.
     optional bool new_account_id_prefix_is_unique = 5; // TODO: Replace this with an error. When a general error message exists.
-}
-
-// STORE REPLICA API
-// ================================================================================================
-
-// Store API for replica synchronization.
-//
-// Any store instance exposes this service so that replicas can subscribe to a continuous stream
-// of committed blocks and block proofs. Replicas connect, specify their current local tip (or 0
-// for genesis), receive historical blocks first (catch-up), and then receive live blocks as they
-// are committed.
-service StoreReplica {
-    // Streams committed blocks starting from the given block number (inclusive).
-    //
-    // Replays historical blocks first, then streams live blocks as they are committed.
-    // On lag (replica falls too far behind), the stream is closed with a DATA_LOSS error and
-    // the client should reconnect from its local tip.
-    rpc BlockSubscription(BlockSubscriptionRequest) returns (stream SignedBlock) {}
-
-    // Streams block proofs starting from the given block number (inclusive).
-    //
-    // Replays existing proofs first, then streams new proofs as they are generated.
-    // On lag, the stream is closed with a DATA_LOSS error.
-    rpc ProofSubscription(ProofSubscriptionRequest) returns (stream BlockProof) {}
-}
-
-// BLOCK SUBSCRIPTION
-// ================================================================================================
-
-// Request to subscribe to the committed block stream.
-message BlockSubscriptionRequest {
-    // The block number to start streaming from (inclusive).
-    fixed32 block_from = 1;
-}
-
-// A committed block streamed to a replica.
-message SignedBlock {
-    // The block encoded using [miden_serde_utils::Serializable] implementation for
-    // [miden_protocol::block::SignedBlock].
-    bytes block = 1;
-}
-
-// PROOF SUBSCRIPTION
-// ================================================================================================
-
-// Request to subscribe to the block proof stream.
-message ProofSubscriptionRequest {
-    // The block number to start streaming from (inclusive).
-    fixed32 block_from = 1;
-}
-
-// A block proof streamed to a replica.
-message BlockProof {
-    // The block number this proof corresponds to.
-    fixed32 block_num = 1;
-
-    // The block proof encoded using [miden_serde_utils::Serializable] implementation for
-    // [miden_protocol::block::BlockProof].
-    bytes proof = 2;
 }
 
 // NTX BUILDER STORE API

--- a/proto/proto/rpc.proto
+++ b/proto/proto/rpc.proto
@@ -84,6 +84,19 @@ service Api {
     // Returns MMR delta needed to synchronize the chain MMR within the requested block range.
     rpc SyncChainMmr(SyncChainMmrRequest) returns (SyncChainMmrResponse) {}
 
+    // Streams committed blocks starting from the given block number (inclusive).
+    //
+    // Replays historical blocks first, then streams live blocks as they are committed.
+    // On lag (replica falls too far behind), the stream is closed with a DATA_LOSS error and
+    // the client should reconnect from its local tip.
+    rpc BlockSubscription(BlockSubscriptionRequest) returns (stream BlockSubscriptionResponse) {}
+
+    // Streams block proofs starting from the given block number (inclusive).
+    //
+    // Replays existing proofs first, then streams new proofs as they are generated.
+    // On lag, the stream is closed with a DATA_LOSS error.
+    rpc ProofSubscription(ProofSubscriptionRequest) returns (stream ProofSubscriptionResponse) {}
+
     // NOTE DEBUGGING ENDPOINTS
     // --------------------------------------------------------------------------------------------
 
@@ -95,6 +108,47 @@ service Api {
     //
     // Returns `NOT_FOUND` if the note ID is not tracked by the network transaction builder.
     rpc GetNetworkNoteStatus(note.NoteId) returns (GetNetworkNoteStatusResponse) {}
+}
+
+// BLOCK SUBSCRIPTION
+// ================================================================================================
+
+// Request to subscribe to the committed block stream.
+message BlockSubscriptionRequest {
+    // The block number to start streaming from (inclusive).
+    fixed32 block_from = 1;
+}
+
+// A committed block streamed to a replica.
+message BlockSubscriptionResponse {
+    // The block encoded using [miden_serde_utils::Serializable] implementation for
+    // [miden_protocol::block::SignedBlock].
+    bytes block = 1;
+
+    // The committed chain tip when this item was emitted.
+    fixed32 committed_chain_tip = 2;
+}
+
+// PROOF SUBSCRIPTION
+// ================================================================================================
+
+// Request to subscribe to the block proof stream.
+message ProofSubscriptionRequest {
+    // The block number to start streaming from (inclusive).
+    fixed32 block_from = 1;
+}
+
+// A block proof streamed to a replica.
+message ProofSubscriptionResponse {
+    // The block number this proof corresponds to.
+    fixed32 block_num = 1;
+
+    // The block proof encoded using [miden_serde_utils::Serializable] implementation for
+    // [miden_protocol::block::BlockProof].
+    bytes proof = 2;
+
+    // The proven chain tip when this item was emitted.
+    fixed32 proven_chain_tip = 3;
 }
 
 // RPC STATUS


### PR DESCRIPTION
This PR moves the block and proof subscription streams from a dedicated gRPC service on the store, to the public RPC service and the store's RPC service.

The public RPC service simply proxies to the store.

In addition I've added the current committed/proven tip to the stream items so that the caller knows how in-sync they currently are. @SantiagoPittella this should help with the ntx sync.

@sergerad this will conflict with your on-going work in #2102 but should maybe simplify your protobuf concerns?

Closes #2112