### PR TITLE
fix(store/schema): remove redundant indexes

### DIFF
--- a/bin/ntx-builder/src/db/migrations.rs
+++ b/bin/ntx-builder/src/db/migrations.rs
@@ -25,7 +25,7 @@ mod tests {
     use std::process::Command;
 
     use anyhow::{Context, Result, ensure};
-    use miden_node_db::migration::SchemaHash;
+    use miden_node_db::migration::{SchemaHash, SchemaHashes};
 
     use super::*;
 
@@ -37,7 +37,7 @@ mod tests {
     fn migration_schema_hashes_are_stable() -> Result<()> {
         let migrator = migrator()?;
 
-        assert_eq!(migrator.schema_hashes(), &EXPECTED_SCHEMA_HASHES);
+        assert_eq!(migrator.schema_hashes(), SchemaHashes(&EXPECTED_SCHEMA_HASHES));
         Ok(())
     }
 

--- a/bin/validator/src/db/migrations.rs
+++ b/bin/validator/src/db/migrations.rs
@@ -25,7 +25,7 @@ mod tests {
     use std::process::Command;
 
     use anyhow::{Context, Result, ensure};
-    use miden_node_db::migration::SchemaHash;
+    use miden_node_db::migration::{SchemaHash, SchemaHashes};
 
     use super::*;
 
@@ -37,7 +37,7 @@ mod tests {
     fn migration_schema_hashes_are_stable() -> Result<()> {
         let migrator = migrator()?;
 
-        assert_eq!(migrator.schema_hashes(), &EXPECTED_SCHEMA_HASHES);
+        assert_eq!(migrator.schema_hashes(), SchemaHashes(&EXPECTED_SCHEMA_HASHES));
         Ok(())
     }
 

--- a/crates/db/src/migration/builder.rs
+++ b/crates/db/src/migration/builder.rs
@@ -110,6 +110,7 @@ mod tests {
     use rusqlite::{Connection, Transaction};
 
     use super::super::{Migrator, SchemaHash};
+    use crate::migration::SchemaHashes;
 
     fn add_item_height(tx: &Transaction<'_>) -> Result<()> {
         tx.execute_batch("ALTER TABLE items ADD COLUMN height INTEGER;")?;
@@ -152,7 +153,7 @@ mod tests {
             .push_code("add item height", add_item_height)?
             .build()?;
 
-        assert_eq!(migrator.schema_hashes(), &[retired_hash, sql_hash, final_hash]);
+        assert_eq!(migrator.schema_hashes(), SchemaHashes(&[retired_hash, sql_hash, final_hash]));
         Ok(())
     }
 }

--- a/crates/db/src/migration/migrator.rs
+++ b/crates/db/src/migration/migrator.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail, ensure};
 use rusqlite::Connection;
 
 use super::entry::{Migration, MigrationEntry, SqlMigration, apply_migration_and_verify_schema};
-use super::{MigratorBuilder, SchemaHash, schema};
+use super::{MigratorBuilder, SchemaHash, SchemaHashes, schema};
 
 /// Applies versioned database migrations.
 ///
@@ -111,8 +111,8 @@ impl Migrator {
     ///
     /// Callers can use these hashes in tests when retiring active migrations into SQL: the
     /// replacement SQL should produce the same hash at the same migration index.
-    pub fn schema_hashes(&self) -> &[SchemaHash] {
-        &self.expected_schema_hashes
+    pub fn schema_hashes(&self) -> SchemaHashes<'_> {
+        SchemaHashes(&self.expected_schema_hashes)
     }
 
     /// Applies missing migrations to the database at `database_filepath`.

--- a/crates/db/src/migration/mod.rs
+++ b/crates/db/src/migration/mod.rs
@@ -25,4 +25,4 @@ mod schema;
 pub use builder::MigratorBuilder;
 pub use entry::CodeMigrationFn;
 pub use migrator::Migrator;
-pub use schema::SchemaHash;
+pub use schema::{SchemaHash, SchemaHashes};

--- a/crates/db/src/migration/schema.rs
+++ b/crates/db/src/migration/schema.rs
@@ -100,6 +100,34 @@ impl fmt::Display for SchemaHash {
     }
 }
 
+#[derive(PartialEq)]
+pub struct SchemaHashes<'a>(pub &'a [SchemaHash]);
+
+impl fmt::Display for SchemaHashes<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for hash in self.0 {
+            writeln!(f, "{hash}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for SchemaHashes<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl SchemaHashes<'_> {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 fn normalize_sql(sql: &str) -> String {
     sql.trim_end()
         .trim_end_matches(';')

--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -45,19 +45,22 @@ mod tests {
     use std::process::Command;
 
     use anyhow::{Context, Result, ensure};
-    use miden_node_db::migration::SchemaHash;
+    use miden_node_db::migration::{SchemaHash, SchemaHashes};
 
     use super::*;
 
     const EXPECTED_SCHEMA_HASHES: [SchemaHash; 1] = [SchemaHash::from_hex(
-        "b3bdd2e530fbb66c9146cda9f3bf79df49c6a6bf99f7432aae0a8927a15406ac",
+        "57ede2ef6984e3450838db516058517badc630567f09bb0f522b9ddedb76f7e8",
     )];
 
     #[test]
     fn migration_schema_hashes_are_stable() -> Result<()> {
         let migrator = migrator()?;
 
-        assert_eq!(migrator.schema_hashes(), &EXPECTED_SCHEMA_HASHES);
+        pretty_assertions::assert_eq!(
+            migrator.schema_hashes(),
+            SchemaHashes(&EXPECTED_SCHEMA_HASHES)
+        );
         Ok(())
     }
 

--- a/crates/store/src/db/migrations/001_initial.sql
+++ b/crates/store/src/db/migrations/001_initial.sql
@@ -37,7 +37,6 @@ CREATE TABLE accounts (
 ) WITHOUT ROWID;
 
 CREATE INDEX idx_accounts_network_type ON accounts(network_account_type) WHERE network_account_type = 1;
-CREATE INDEX idx_accounts_id_block ON accounts(account_id, block_num DESC);
 CREATE INDEX idx_accounts_latest ON accounts(account_id, is_latest) WHERE is_latest = 1;
 CREATE INDEX idx_accounts_created_at_block ON accounts(created_at_block);
 -- Index for joining with block_headers
@@ -85,8 +84,6 @@ CREATE INDEX idx_notes_sender ON notes(sender, committed_at);
 CREATE INDEX idx_notes_tag ON notes(tag, committed_at);
 CREATE INDEX idx_notes_nullifier ON notes(nullifier);
 CREATE INDEX idx_notes_target_account ON notes(target_account_id, committed_at) WHERE target_account_id IS NOT NULL;
--- Index for joining with block_headers on committed_at
-CREATE INDEX idx_notes_committed_at ON notes(committed_at);
 -- Index for joining with note_scripts
 CREATE INDEX idx_notes_script_root ON notes(script_root) WHERE script_root IS NOT NULL;
 -- Index for joining with block_headers on consumed_at
@@ -111,8 +108,6 @@ CREATE TABLE account_storage_map_values (
     FOREIGN KEY (account_id, block_num) REFERENCES accounts(account_id, block_num) ON DELETE CASCADE
 ) WITHOUT ROWID;
 
--- Index for joining with accounts table on compound key
-CREATE INDEX idx_account_storage_account_block ON account_storage_map_values(account_id, block_num);
 -- Index for querying latest values
 CREATE INDEX idx_account_storage_latest ON account_storage_map_values(account_id, is_latest) WHERE is_latest = 1;
 
@@ -127,8 +122,6 @@ CREATE TABLE account_vault_assets (
     FOREIGN KEY (account_id, block_num) REFERENCES accounts(account_id, block_num) ON DELETE CASCADE
 ) WITHOUT ROWID;
 
--- Index for joining with accounts table on compound key
-CREATE INDEX idx_vault_assets_account_block ON account_vault_assets(account_id, block_num);
 -- Index for querying latest assets
 CREATE INDEX idx_vault_assets_latest ON account_vault_assets(account_id, is_latest) WHERE is_latest = 1;
 
@@ -160,8 +153,6 @@ CREATE TABLE transactions (
     PRIMARY KEY (transaction_id)
 ) WITHOUT ROWID;
 
--- Index for joining with accounts (note: account may not exist in accounts table)
-CREATE INDEX idx_transactions_account_id ON transactions(account_id);
 -- Index for joining with block_headers
 CREATE INDEX idx_transactions_block_num ON transactions(block_num);
 -- Composite index to speed up select_transactions_records.


### PR DESCRIPTION
In SQLite, a composite index only supports queries that filter on a leftmost prefix of the indexed columns.
This also means that an index on `(a, b, c)` makes a separate index on `(a)` redundant for equality/range lookup starts.

The following indexes seem to be redundant in our store SQLite schema:

- `idx_accounts_id_block` on `(account_id, block_num DESC)` is covered by `accounts` primary key `(account_id, block_num)`.
- `idx_notes_committed_at` on `(committed_at)` is covered by `notes` primary key `(committed_at, batch_index, note_index)`.
- `idx_account_storage_account_block` on `(account_id, block_num)` is covered by `account_storage_map_values` primary key `(account_id, block_num, slot_name, key)`.
- `idx_vault_assets_account_block` on `(account_id, block_num)` is covered by `account_vault_assets` primary key `(account_id, block_num, vault_key)`.
- `idx_transactions_account_id` on `(account_id)` is covered by `idx_transactions_account_block_txid` on `(account_id, block_num, transaction_id)`.