### PR TITLE
docs: clarify validator bootstrap path arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [BREAKING] Renamed `SubmitProvenBatch` RPC endpoint to `SubmitProvenTxBatch` ([#2094](https://github.com/0xMiden/node/pull/2094)).
 - Fixed block producer mempool panic when selecting transactions that depend on notes created by pruned committed transactions ([#2097](https://github.com/0xMiden/node/pull/2097)).
 - Implemented filtering based on the network account note script root allowlist in ntx-builder ([#2042](https://github.com/0xMiden/node/issues/2042)).
+- Clarified validator bootstrap CLI help text for input files and output directories ([#1807](https://github.com/0xMiden/node/issues/1807)).
 
 - [BREAKING] Renamed `ExplorerStatusDetails` fields in the network monitor's `/status` payload from `number_of_*` to `total_*` (`total_transactions`, `total_nullifiers`, `total_notes`, `total_account_updates`). The values now represent network-wide cumulative totals from the explorer's `overviewStats` query instead of last-block counts.
 - [BREAKING] Removed `--wallet-filepath` / `--counter-filepath` flags and the `MIDEN_MONITOR_WALLET_FILEPATH` / `MIDEN_MONITOR_COUNTER_FILEPATH` env vars from the network monitor. The monitor now keeps wallet and counter accounts fully in memory and regenerates them on every startup; the dashboard's counter value resets to zero on restart.

--- a/bin/validator/src/commands/mod.rs
+++ b/bin/validator/src/commands/mod.rs
@@ -34,15 +34,18 @@ pub enum ValidatorCommand {
     /// and writes the signed block and account secret files to disk. Also initializes the
     /// validator's database with the genesis block as the chain tip.
     Bootstrap {
-        /// Directory in which to write the genesis block file.
-        #[arg(long, value_name = "DIR")]
+        /// Output directory for the generated genesis block file.
+        #[arg(long, value_name = "OUTPUT_DIR")]
         genesis_block_directory: PathBuf,
-        /// Directory to write the account secret files (.mac) to.
-        #[arg(long, value_name = "DIR")]
+
+        /// Output directory for the generated account secret files (.mac).
+        #[arg(long, value_name = "OUTPUT_DIR")]
         accounts_directory: PathBuf,
-        /// Directory in which to store the validator's database.
-        #[arg(long, env = ENV_DATA_DIRECTORY, value_name = "DIR")]
+
+        /// Output directory for the validator database created during bootstrap.
+        #[arg(long, env = ENV_DATA_DIRECTORY, value_name = "OUTPUT_DIR")]
         data_directory: PathBuf,
+
         /// Maximum number of SQLite connections in the validator database connection pool.
         #[arg(
             long = "sqlite.connection_pool_size",
@@ -51,9 +54,11 @@ pub enum ValidatorCommand {
             value_name = "NUM"
         )]
         sqlite_connection_pool_size: NonZeroUsize,
-        /// Use the given configuration file to construct the genesis state from.
-        #[arg(long, env = ENV_GENESIS_CONFIG_FILE, value_name = "GENESIS_CONFIG")]
+
+        /// Input configuration file used to construct the genesis state.
+        #[arg(long, env = ENV_GENESIS_CONFIG_FILE, value_name = "INPUT_FILE")]
         genesis_config_file: Option<PathBuf>,
+
         /// Configuration for the Validator key used to sign the genesis block.
         #[command(flatten)]
         validator_key: ValidatorKey,


### PR DESCRIPTION
## Summary

- Clarifies validator bootstrap input/output path argument help text.
- Updates value names so generated CLI help distinguishes source files from generated outputs.
- Adds changelog entry for #1807.

Closes #1807

## Testing

- `cargo check -p miden-validator --all-targets` could not run locally on Windows because the `miden-agglayer` dependency checkout fails on an invalid `:` path in a submodule file.