### PR TITLE
fix(store): reject future sync block ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [BREAKING] Renamed `SubmitProvenBatch` RPC endpoint to `SubmitProvenTxBatch` ([#2094](https://github.com/0xMiden/node/pull/2094)).
 - Fixed block producer mempool panic when selecting transactions that depend on notes created by pruned committed transactions ([#2097](https://github.com/0xMiden/node/pull/2097)).
 - Implemented filtering based on the network account note script root allowlist in ntx-builder ([#2042](https://github.com/0xMiden/node/issues/2042)).
+- Validated sync endpoint block ranges against the committed chain tip before querying state ([#1866](https://github.com/0xMiden/node/issues/1866)).
 
 - [BREAKING] Renamed `ExplorerStatusDetails` fields in the network monitor's `/status` payload from `number_of_*` to `total_*` (`total_transactions`, `total_nullifiers`, `total_notes`, `total_account_updates`). The values now represent network-wide cumulative totals from the explorer's `overviewStats` query instead of last-block counts.
 - [BREAKING] Removed `--wallet-filepath` / `--counter-filepath` flags and the `MIDEN_MONITOR_WALLET_FILEPATH` / `MIDEN_MONITOR_COUNTER_FILEPATH` env vars from the network monitor. The monitor now keeps wallet and counter accounts fully in memory and regenerates them on every startup; the dashboard's counter value resets to zero on restart.

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -359,6 +359,11 @@ pub enum SyncNullifiersError {
     DatabaseError(#[from] DatabaseError),
     #[error("invalid block range")]
     InvalidBlockRange(#[from] InvalidBlockRange),
+    #[error("block_to ({block_to}) is greater than chain tip ({chain_tip})")]
+    FutureBlock {
+        chain_tip: BlockNumber,
+        block_to: BlockNumber,
+    },
     #[error("unsupported prefix length: {0} (only 16-bit prefixes are supported)")]
     InvalidPrefixLength(u32),
     #[error("malformed nullifier prefix")]
@@ -375,6 +380,11 @@ pub enum SyncAccountVaultError {
     DatabaseError(#[from] DatabaseError),
     #[error("invalid block range")]
     InvalidBlockRange(#[from] InvalidBlockRange),
+    #[error("block_to ({block_to}) is greater than chain tip ({chain_tip})")]
+    FutureBlock {
+        chain_tip: BlockNumber,
+        block_to: BlockNumber,
+    },
     #[error("malformed account ID")]
     DeserializationFailed(#[from] ConversionError),
     #[error("account {0} is not public")]
@@ -391,6 +401,11 @@ pub enum SyncAccountStorageMapsError {
     DatabaseError(#[from] DatabaseError),
     #[error("invalid block range")]
     InvalidBlockRange(#[from] InvalidBlockRange),
+    #[error("block_to ({block_to}) is greater than chain tip ({chain_tip})")]
+    FutureBlock {
+        chain_tip: BlockNumber,
+        block_to: BlockNumber,
+    },
     #[error("malformed account ID")]
     DeserializationFailed(#[from] ConversionError),
     #[error("account {0} not found")]
@@ -485,6 +500,11 @@ pub enum SyncTransactionsError {
     DatabaseError(#[from] DatabaseError),
     #[error("invalid block range")]
     InvalidBlockRange(#[from] InvalidBlockRange),
+    #[error("block_to ({block_to}) is greater than chain tip ({chain_tip})")]
+    FutureBlock {
+        chain_tip: BlockNumber,
+        block_to: BlockNumber,
+    },
     #[error("malformed account ID")]
     DeserializationFailed(#[from] ConversionError),
     #[error("account {0} not found")]

--- a/crates/store/src/server/rpc_api.rs
+++ b/crates/store/src/server/rpc_api.rs
@@ -124,6 +124,11 @@ impl rpc_server::Rpc for StoreApi {
             read_block_range::<SyncNullifiersError>(request.block_range, "SyncNullifiersRequest")?
                 .into_inclusive_range::<SyncNullifiersError>()?;
 
+        let chain_tip = self.state.chain_tip(Finality::Committed).await;
+        if *block_range.end() > chain_tip {
+            Err(SyncNullifiersError::FutureBlock { chain_tip, block_to: *block_range.end() })?;
+        }
+
         let (nullifiers, block_num) = self
             .state
             .sync_nullifiers(request.prefix_len, request.nullifiers, block_range)
@@ -137,8 +142,6 @@ impl rpc_server::Rpc for StoreApi {
                 block_num: nullifier_info.block_num.as_u32(),
             })
             .collect();
-
-        let chain_tip = self.state.chain_tip(Finality::Committed).await;
 
         Ok(Response::new(proto::rpc::SyncNullifiersResponse {
             pagination_info: Some(proto::rpc::PaginationInfo {
@@ -314,6 +317,11 @@ impl rpc_server::Rpc for StoreApi {
         )?
         .into_inclusive_range::<SyncAccountVaultError>()?;
 
+        let chain_tip = self.state.chain_tip(Finality::Committed).await;
+        if *block_range.end() > chain_tip {
+            Err(SyncAccountVaultError::FutureBlock { chain_tip, block_to: *block_range.end() })?;
+        }
+
         let (last_included_block, updates) = self
             .state
             .sync_account_vault(account_id, block_range)
@@ -331,8 +339,6 @@ impl rpc_server::Rpc for StoreApi {
                 }
             })
             .collect();
-
-        let chain_tip = self.state.chain_tip(Finality::Committed).await;
 
         Ok(Response::new(proto::rpc::SyncAccountVaultResponse {
             pagination_info: Some(proto::rpc::PaginationInfo {
@@ -367,6 +373,14 @@ impl rpc_server::Rpc for StoreApi {
         )?
         .into_inclusive_range::<SyncAccountStorageMapsError>()?;
 
+        let chain_tip = self.state.chain_tip(Finality::Committed).await;
+        if *block_range.end() > chain_tip {
+            Err(SyncAccountStorageMapsError::FutureBlock {
+                chain_tip,
+                block_to: *block_range.end(),
+            })?;
+        }
+
         let storage_maps_page = self
             .state
             .sync_account_storage_maps(account_id, block_range)
@@ -383,8 +397,6 @@ impl rpc_server::Rpc for StoreApi {
                 block_num: map_value.block_num.as_u32(),
             })
             .collect();
-
-        let chain_tip = self.state.chain_tip(Finality::Committed).await;
 
         Ok(Response::new(proto::rpc::SyncAccountStorageMapsResponse {
             pagination_info: Some(proto::rpc::PaginationInfo {
@@ -440,6 +452,11 @@ impl rpc_server::Rpc for StoreApi {
         )?
         .into_inclusive_range::<SyncTransactionsError>()?;
 
+        let chain_tip = self.state.chain_tip(Finality::Committed).await;
+        if *block_range.end() > chain_tip {
+            Err(SyncTransactionsError::FutureBlock { chain_tip, block_to: *block_range.end() })?;
+        }
+
         let account_ids: Vec<AccountId> =
             read_account_ids::<SyncTransactionsError, _>(request.account_ids)?;
 
@@ -458,8 +475,6 @@ impl rpc_server::Rpc for StoreApi {
             .into_iter()
             .map(crate::db::TransactionRecord::into_proto)
             .collect();
-
-        let chain_tip = self.state.chain_tip(Finality::Committed).await;
 
         Ok(Response::new(proto::rpc::SyncTransactionsResponse {
             pagination_info: Some(proto::rpc::PaginationInfo {


### PR DESCRIPTION
## Summary

- Rejects sync requests whose `block_to` is greater than the current chain tip.
- Adds explicit `FutureBlock` errors for nullifiers, account vault, storage maps, and transactions sync paths.
- Aligns these endpoints with existing `sync_notes` chain-tip validation.

Closes #1866

## Testing

- `cargo check -p miden-node-store --all-targets` could not complete locally on Windows because the `miden-agglayer` dependency checkout fails on an invalid `:` path in a submodule file.