### PR TITLE
fix(rpc): move submit proof checks off async runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Removed `CheckNullifiers` endpoint ([#2049](https://github.com/0xMiden/node/pull/2049)).
 - Replaced blocking-in-async operations in the validator, remote prover, and ntx-builder with `spawn_blocking` to avoid starving the Tokio runtime ([#2041](https://github.com/0xMiden/node/pull/2041)).
 - Replaced local store block proving with `spawn_blocking` to avoid starving the Tokio runtime ([#1976](https://github.com/0xMiden/node/issues/1976)).
+- Replaced blocking proof verification in RPC transaction submission endpoints with `spawn_blocking` to avoid starving the Tokio runtime ([#1976](https://github.com/0xMiden/node/issues/1976)).
 - Implemented persistent RocksDB backend for `AccountStateForest`, improving startup time ([#2020](https://github.com/0xMiden/node/pull/2020)).
 - [BREAKING] Replaced binding URL env vars and CLI flags with listen socket addresses ([#2054](https://github.com/0xMiden/node/pull/2054)).
 - [BREAKING] `BlockRange.block_to` is now required for all RPC endpoints ([#2056](https://github.com/0xMiden/node/pull/2056)).

--- a/bin/ntx-builder/src/lib.rs
+++ b/bin/ntx-builder/src/lib.rs
@@ -385,7 +385,7 @@ impl NtxBuilderConfig {
             self.sqlite_connection_pool_size,
         )
         .await?;
-      
+
         // Get the genesis commitment to send in the accept header
         let genesis_commitment = db.get_genesis_commitment().await.context(
             "failed to read genesis commitment; \

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -40,6 +40,7 @@ use miden_node_utils::limiter::{
 };
 use miden_node_utils::lru_cache::LruCache;
 use miden_node_utils::retry::{self, Retryable};
+use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::account::AccountId;
 use miden_protocol::asset::Asset;
@@ -777,14 +778,20 @@ impl api_server::Api for RpcService {
             self.reject_if_any_network_accounts(candidate_id).await?;
         }
 
-        let tx_verifier = TransactionVerifier::new(MIN_PROOF_SECURITY_LEVEL);
-        tx_verifier.verify(&tx).map_err(|err| {
-            Status::invalid_argument(format!(
-                "Invalid proof for transaction {}: {}",
-                tx.id(),
-                err.as_report()
-            ))
-        })?;
+        let tx_id = tx.id();
+        spawn_blocking_in_current_span(move || {
+            TransactionVerifier::new(MIN_PROOF_SECURITY_LEVEL).verify(&tx).map_err(|err| {
+                Status::invalid_argument(format!(
+                    "Invalid proof for transaction {}: {}",
+                    tx_id,
+                    err.as_report()
+                ))
+            })
+        })
+        .await
+        .map_err(|err| {
+            Status::internal(format!("transaction proof verification task failed: {err}"))
+        })??;
 
         // In full node mode we forward the request to the source.
         let (block_producer, validator) = match &self.mode {
@@ -882,11 +889,22 @@ impl api_server::Api for RpcService {
         //
         // Need to do this because ProvenBatch has no real kernel yet, so we can only
         // really check that the calculated proof matches the one given in the request.
-        let expected_proof = LocalBatchProver::new(MIN_PROOF_SECURITY_LEVEL)
-            .prove(proposed_batch.clone())
-            .map_err(|err| {
-                Status::invalid_argument(err.as_report_context("proposed block proof failed"))
-            })?;
+        let expected_proof = spawn_blocking_in_current_span({
+            let proposed_batch = proposed_batch.clone();
+            move || {
+                LocalBatchProver::new(MIN_PROOF_SECURITY_LEVEL).prove(proposed_batch).map_err(
+                    |err| {
+                        Status::invalid_argument(
+                            err.as_report_context("proposed block proof failed"),
+                        )
+                    },
+                )
+            }
+        })
+        .await
+        .map_err(|err| {
+            Status::internal(format!("batch proof verification task failed: {err}"))
+        })??;
 
         if expected_proof != proven_batch {
             return Err(Status::invalid_argument("batch proof did not match proposed batch"));


### PR DESCRIPTION
Partially addresses #1976.

## Problem

The RPC transaction submission endpoints perform CPU-heavy proof work directly inside async request handlers:

- `SubmitProvenTx` verifies the submitted transaction proof with `TransactionVerifier::verify`.
- `SubmitProvenTxBatch` locally re-proves the proposed batch to compare it with the submitted batch proof.

Both operations can block Tokio worker threads while the RPC service is handling requests.

## Changes

- Move `SubmitProvenTx` transaction proof verification into `spawn_blocking_in_current_span`.
- Move `SubmitProvenTxBatch` local batch proof comparison into `spawn_blocking_in_current_span`.
- Preserve the existing invalid-argument errors for proof failures.
- Return internal errors only if the blocking task itself fails to join.
- Add a changelog entry for the follow-up #1976 fix.

## Testing

- `cargo +nightly fmt --check --all`
- `git diff --check`

I also tried `cargo check -p miden-node-rpc` and `cargo check --manifest-path crates/rpc/Cargo.toml`, but both stop during dependency checkout on Windows because the current protocol dependency pulls an AggLayer submodule file with `:` in the filename:

`tools/addRollupType/addRollupMainnet10/add_rollup_type_10_output-2025-03-11T15:54:21.263Z.json`