### PR TITLE
chore: use local data for ntx builder datastore impl

### DIFF
--- a/bin/ntx-builder/src/actor/execute.rs
+++ b/bin/ntx-builder/src/actor/execute.rs
@@ -15,6 +15,7 @@ use miden_protocol::account::{
     PartialAccount,
     StorageMapKey,
     StorageMapWitness,
+    StorageSlotContent,
     StorageSlotName,
     StorageSlotType,
 };
@@ -627,26 +628,14 @@ impl DataStore for NtxDataStore {
         vault_keys: BTreeSet<AssetVaultKey>,
     ) -> impl FutureMaybeSend<Result<Vec<AssetWitness>, DataStoreError>> {
         async move {
-            let ref_block = self.reference_block.block_num();
+            if account_id != self.account.id() {
+                return Err(DataStoreError::other(format!(
+                    "vault asset witnesses requested for non-native account {account_id}"
+                )));
+            }
 
-            // Get vault asset witnesses from RPC, retrying on transient gRPC failures.
-            let witnesses = (|| {
-                let vault_keys = vault_keys.clone();
-                async move {
-                    self.rpc
-                        .get_vault_asset_witnesses(account_id, vault_keys, Some(ref_block))
-                        .await
-                }
-            })
-            .retry(self.rpc_backoff())
-            .when(is_transient_rpc_error)
-            .notify(|err, dur| {
-                log_transient_retry("rpc.get_vault_asset_witnesses", err, dur);
-            })
-            .await
-            .map_err(|err| {
-                DataStoreError::other_with_source("failed to get vault asset witnesses", err)
-            })?;
+            let vault = self.account.vault();
+            let witnesses = vault_keys.into_iter().map(|key| vault.open(key)).collect();
 
             Ok(witnesses)
         }
@@ -671,28 +660,24 @@ impl DataStore for NtxDataStore {
                 slot_name.clone()
             };
 
-            let ref_block = self.reference_block.block_num();
+            // As with vault witnesses, the storage map witness is generated locally by opening the
+            // account's storage-map SMT; the full account state is held in the local DB.
+            if account_id != self.account.id() {
+                return Err(DataStoreError::other(format!(
+                    "storage map witness requested for non-native account {account_id}"
+                )));
+            }
 
-            // Get storage map witness from RPC, retrying on transient gRPC failures.
-            let witness = (|| {
-                let slot_name = slot_name.clone();
-                async move {
-                    self.rpc
-                        .get_storage_map_witness(account_id, slot_name, map_key, Some(ref_block))
-                        .await
-                }
-            })
-            .retry(self.rpc_backoff())
-            .when(is_transient_rpc_error)
-            .notify(|err, dur| {
-                log_transient_retry("rpc.get_storage_map_witness", err, dur);
-            })
-            .await
-            .map_err(|err| {
-                DataStoreError::other_with_source("failed to get storage map witness", err)
+            let slot = self.account.storage().get(&slot_name).ok_or_else(|| {
+                DataStoreError::other(format!("storage slot {slot_name} not found in account"))
             })?;
+            let StorageSlotContent::Map(map) = slot.content() else {
+                return Err(DataStoreError::other(format!(
+                    "storage slot {slot_name} is not a map"
+                )));
+            };
 
-            Ok(witness)
+            Ok(map.open(&map_key))
         }
     }
 

--- a/bin/ntx-builder/src/actor/execute.rs
+++ b/bin/ntx-builder/src/actor/execute.rs
@@ -15,7 +15,6 @@ use miden_protocol::account::{
     PartialAccount,
     StorageMapKey,
     StorageMapWitness,
-    StorageSlotContent,
     StorageSlotName,
     StorageSlotType,
 };
@@ -624,25 +623,30 @@ impl DataStore for NtxDataStore {
     fn get_vault_asset_witnesses(
         &self,
         account_id: AccountId,
-        vault_root: Word,
+        _vault_root: Word,
         vault_keys: BTreeSet<AssetVaultKey>,
     ) -> impl FutureMaybeSend<Result<Vec<AssetWitness>, DataStoreError>> {
         async move {
-            if account_id != self.account.id() {
-                return Err(DataStoreError::other(format!(
-                    "vault asset witnesses requested for non-native account {account_id}"
-                )));
-            }
+            let ref_block = self.reference_block.block_num();
 
-            let vault = self.account.vault();
-            if vault.root() != vault_root {
-                return Err(DataStoreError::other(format!(
-                    "local vault root {} does not match requested root {vault_root}",
-                    vault.root()
-                )));
-            }
-
-            let witnesses = vault_keys.into_iter().map(|key| vault.open(key)).collect();
+            // Get vault asset witnesses from RPC, retrying on transient gRPC failures.
+            let witnesses = (|| {
+                let vault_keys = vault_keys.clone();
+                async move {
+                    self.rpc
+                        .get_vault_asset_witnesses(account_id, vault_keys, Some(ref_block))
+                        .await
+                }
+            })
+            .retry(self.rpc_backoff())
+            .when(is_transient_rpc_error)
+            .notify(|err, dur| {
+                log_transient_retry("rpc.get_vault_asset_witnesses", err, dur);
+            })
+            .await
+            .map_err(|err| {
+                DataStoreError::other_with_source("failed to get vault asset witnesses", err)
+            })?;
 
             Ok(witnesses)
         }
@@ -667,24 +671,28 @@ impl DataStore for NtxDataStore {
                 slot_name.clone()
             };
 
-            // As with vault witnesses, the storage map witness is generated locally by opening the
-            // account's storage-map SMT; the full account state is held in the local DB.
-            if account_id != self.account.id() {
-                return Err(DataStoreError::other(format!(
-                    "storage map witness requested for non-native account {account_id}"
-                )));
-            }
+            let ref_block = self.reference_block.block_num();
 
-            let slot = self.account.storage().get(&slot_name).ok_or_else(|| {
-                DataStoreError::other(format!("storage slot {slot_name} not found in account"))
+            // Get storage map witness from RPC, retrying on transient gRPC failures.
+            let witness = (|| {
+                let slot_name = slot_name.clone();
+                async move {
+                    self.rpc
+                        .get_storage_map_witness(account_id, slot_name, map_key, Some(ref_block))
+                        .await
+                }
+            })
+            .retry(self.rpc_backoff())
+            .when(is_transient_rpc_error)
+            .notify(|err, dur| {
+                log_transient_retry("rpc.get_storage_map_witness", err, dur);
+            })
+            .await
+            .map_err(|err| {
+                DataStoreError::other_with_source("failed to get storage map witness", err)
             })?;
-            let StorageSlotContent::Map(map) = slot.content() else {
-                return Err(DataStoreError::other(format!(
-                    "storage slot {slot_name} is not a map"
-                )));
-            };
 
-            Ok(map.open(&map_key))
+            Ok(witness)
         }
     }
 

--- a/bin/ntx-builder/src/actor/execute.rs
+++ b/bin/ntx-builder/src/actor/execute.rs
@@ -624,7 +624,7 @@ impl DataStore for NtxDataStore {
     fn get_vault_asset_witnesses(
         &self,
         account_id: AccountId,
-        _vault_root: Word,
+        vault_root: Word,
         vault_keys: BTreeSet<AssetVaultKey>,
     ) -> impl FutureMaybeSend<Result<Vec<AssetWitness>, DataStoreError>> {
         async move {
@@ -635,6 +635,13 @@ impl DataStore for NtxDataStore {
             }
 
             let vault = self.account.vault();
+            if vault.root() != vault_root {
+                return Err(DataStoreError::other(format!(
+                    "local vault root {} does not match requested root {vault_root}",
+                    vault.root()
+                )));
+            }
+
             let witnesses = vault_keys.into_iter().map(|key| vault.open(key)).collect();
 
             Ok(witnesses)

--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use backon::{ExponentialBuilder, Retryable};
@@ -10,8 +11,16 @@ use miden_node_proto::generated::rpc::{BlockSubscriptionRequest, BlockSubscripti
 use miden_node_proto::generated::{self as proto};
 use miden_node_utils::ErrorReport;
 use miden_protocol::Word;
-use miden_protocol::account::{AccountCode, AccountId, PartialAccount, PartialStorage};
-use miden_protocol::asset::PartialVault;
+use miden_protocol::account::{
+    AccountCode,
+    AccountId,
+    PartialAccount,
+    PartialStorage,
+    StorageMapKey,
+    StorageMapWitness,
+    StorageSlotName,
+};
+use miden_protocol::asset::{AssetVaultKey, AssetWitness, PartialVault};
 use miden_protocol::block::{BlockNumber, SignedBlock};
 use miden_protocol::note::NoteScript;
 use miden_protocol::transaction::{AccountInputs, ProvenTransaction, TransactionInputs};
@@ -232,6 +241,36 @@ fn build_minimal_foreign_account(
         None,
     )?;
     Ok(partial_account)
+}
+
+// ACTOR-PATH WITNESS METHODS
+// ================================================================================================
+//
+// These witness lookups are account-agnostic: the executor invokes them for the native account as
+// well as for foreign accounts pulled in via FPI. They are served over RPC rather than from local
+// state because foreign accounts are not tracked locally. The real RPC implementation lands with
+// the ntx-builder RPC client (#2162); until then they remain stubs.
+
+#[expect(clippy::unused_async)]
+impl RpcClient {
+    pub async fn get_vault_asset_witnesses(
+        &self,
+        _account_id: AccountId,
+        _vault_keys: BTreeSet<AssetVaultKey>,
+        _block_num: Option<BlockNumber>,
+    ) -> Result<Vec<AssetWitness>, RpcError> {
+        unimplemented!("get_vault_asset_witnesses is rewired in PR 2 of the ntx-builder refactor")
+    }
+
+    pub async fn get_storage_map_witness(
+        &self,
+        _account_id: AccountId,
+        _slot_name: StorageSlotName,
+        _map_key: StorageMapKey,
+        _block_num: Option<BlockNumber>,
+    ) -> Result<StorageMapWitness, RpcError> {
+        unimplemented!("get_storage_map_witness is rewired in PR 2 of the ntx-builder refactor")
+    }
 }
 
 // NOTE SCRIPT LOOKUP

--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -1,16 +1,17 @@
-use std::collections::BTreeSet;
 use std::time::Duration;
 
 use backon::{ExponentialBuilder, Retryable};
 use futures::Stream;
 use futures::stream::TryStreamExt;
 use miden_node_proto::clients::{Builder, RpcClient as InnerRpcClient};
+use miden_node_proto::domain::account::{AccountDetails, AccountResponse};
+use miden_node_proto::errors::ConversionError;
 use miden_node_proto::generated::rpc::{BlockSubscriptionRequest, BlockSubscriptionResponse};
 use miden_node_proto::generated::{self as proto};
 use miden_node_utils::ErrorReport;
 use miden_protocol::Word;
-use miden_protocol::account::{AccountId, StorageMapKey, StorageMapWitness, StorageSlotName};
-use miden_protocol::asset::{AssetVaultKey, AssetWitness};
+use miden_protocol::account::{AccountCode, AccountId, PartialAccount, PartialStorage};
+use miden_protocol::asset::PartialVault;
 use miden_protocol::block::{BlockNumber, SignedBlock};
 use miden_protocol::note::NoteScript;
 use miden_protocol::transaction::{AccountInputs, ProvenTransaction, TransactionInputs};
@@ -148,47 +149,118 @@ fn decode_block_subscription_response(
     Ok((block, committed_tip))
 }
 
-// ACTOR-PATH METHODS
+// FOREIGN ACCOUNT INPUTS
 // ================================================================================================
-//
-// The actor module still references these methods. PR 1 keeps the actor code in tree as dead
-// code (it is not spawned), so the methods exist as stubs to preserve compilation. PR 2 wires
-// them through the appropriate RPC gRPC service.
 
-#[expect(clippy::unused_async)]
 impl RpcClient {
+    /// Fetches the inputs of a foreign account referenced during transaction execution.
+    #[instrument(
+        target = COMPONENT,
+        name = "ntx.rpc.client.get_account_inputs",
+        skip_all,
+        err,
+    )]
     pub async fn get_account_inputs(
         &self,
-        _account_id: AccountId,
-        _block_num: BlockNumber,
+        account_id: AccountId,
+        block_num: BlockNumber,
     ) -> Result<AccountInputs, RpcError> {
-        unimplemented!("get_account_inputs is rewired in PR 2 of the ntx-builder refactor")
-    }
+        // Request account code, account header, and storage header in order to build a minimal
+        // partial account.
+        let proto_request = proto::rpc::AccountRequest {
+            account_id: Some(proto::account::AccountId { id: account_id.to_bytes() }),
+            block_num: Some(block_num.into()),
+            details: Some(proto::rpc::account_request::AccountDetailRequest {
+                code_commitment: Some(Word::default().into()),
+                asset_vault_commitment: None,
+                // No storage maps are requested for a minimal foreign account.
+                storage_request: None,
+            }),
+        };
 
-    pub async fn get_vault_asset_witnesses(
-        &self,
-        _account_id: AccountId,
-        _vault_keys: BTreeSet<AssetVaultKey>,
-        _block_num: Option<BlockNumber>,
-    ) -> Result<Vec<AssetWitness>, RpcError> {
-        unimplemented!("get_vault_asset_witnesses is rewired in PR 2 of the ntx-builder refactor")
-    }
+        let proto_response = self
+            .inner
+            .clone()
+            .get_account(proto_request)
+            .await
+            .map_err(RpcError::GrpcClientError)?
+            .into_inner();
 
-    pub async fn get_storage_map_witness(
-        &self,
-        _account_id: AccountId,
-        _slot_name: StorageSlotName,
-        _map_key: StorageMapKey,
-        _block_num: Option<BlockNumber>,
-    ) -> Result<StorageMapWitness, RpcError> {
-        unimplemented!("get_storage_map_witness is rewired in PR 2 of the ntx-builder refactor")
-    }
+        let account_response =
+            AccountResponse::try_from(proto_response).map_err(RpcError::Conversion)?;
 
+        let account_details = account_response.details.ok_or_else(|| {
+            RpcError::Conversion(ConversionError::missing_field::<proto::rpc::AccountResponse>(
+                "details",
+            ))
+        })?;
+        let partial_account =
+            build_minimal_foreign_account(&account_details).map_err(RpcError::Conversion)?;
+
+        Ok(AccountInputs::new(partial_account, account_response.witness))
+    }
+}
+
+/// Builds a minimal partial account from the provided account details.
+///
+/// The partial account is built without storage maps or an asset vault. This is intended to be used
+/// to retrieve foreign account data during transaction execution.
+fn build_minimal_foreign_account(
+    account_details: &AccountDetails,
+) -> Result<PartialAccount, ConversionError> {
+    // Derive account code.
+    let account_code_bytes = account_details.account_code.as_ref().ok_or_else(|| {
+        ConversionError::missing_field::<proto::rpc::account_response::AccountDetails>(
+            "account_code",
+        )
+    })?;
+    let account_code = AccountCode::read_from_bytes(account_code_bytes)?;
+
+    // Derive partial storage. Storage maps are not required for foreign accounts.
+    let partial_storage = PartialStorage::new(account_details.storage_details.header.clone(), [])?;
+
+    // Derive partial vault from vault root only.
+    let partial_vault = PartialVault::new(account_details.account_header.vault_root());
+
+    // Construct partial account.
+    let partial_account = PartialAccount::new(
+        account_details.account_header.id(),
+        account_details.account_header.nonce(),
+        account_code,
+        partial_storage,
+        partial_vault,
+        None,
+    )?;
+    Ok(partial_account)
+}
+
+// NOTE SCRIPT LOOKUP
+// ================================================================================================
+
+impl RpcClient {
+    /// Fetches a note script by its root from the RPC service.
+    #[instrument(
+        target = COMPONENT,
+        name = "ntx.rpc.client.get_note_script_by_root",
+        skip_all,
+        err,
+    )]
     pub async fn get_note_script_by_root(
         &self,
-        _script_root: Word,
+        root: Word,
     ) -> Result<Option<NoteScript>, RpcError> {
-        unimplemented!("get_note_script_by_root is rewired in PR 2 of the ntx-builder refactor")
+        let request = proto::note::NoteScriptRoot { root: Some(root.into()) };
+
+        let script = self
+            .inner
+            .clone()
+            .get_note_script_by_root(request)
+            .await
+            .map_err(RpcError::GrpcClientError)?
+            .into_inner()
+            .script;
+
+        script.map(NoteScript::try_from).transpose().map_err(RpcError::Conversion)
     }
 }
 
@@ -201,4 +273,6 @@ pub enum RpcError {
     GrpcClientError(#[source] tonic::Status),
     #[error("failed to deserialize RPC payload")]
     Deserialize(#[source] miden_protocol::utils::serde::DeserializationError),
+    #[error("failed to convert RPC payload")]
+    Conversion(#[source] ConversionError),
 }


### PR DESCRIPTION
Will delete the RPC part after https://github.com/0xMiden/node/pull/2162 gets merged.

This moves the DataStore implementation for the ntx builder to be local-first