### PR TITLE
fix: store private notes attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Added `--tx-expiration-delta` (env `MIDEN_NODE_NTX_BUILDER_TX_EXPIRATION_DELTA`, default `30`) to the network transaction builder: submitted network transactions now expire on-chain after this many blocks, and the builder reuses the same delta as the local window before resubmitting a transaction that has not landed ([#2148](https://github.com/0xMiden/node/pull/2148)).
 - Added a `miden-ntx-builder bootstrap` command that initializes the ntx-builder database from a trusted genesis block file. The `start` command now requires a bootstrapped database instead of fetching the genesis block from the committed-block subscription on first run ([#2149](https://github.com/0xMiden/node/pull/2149)).
 - Persisted the genesis commitment in the ntx-builder at bootstrap and sent it in the RPC `Accept` header so the node accepts its write transactions, and added RPC client implementations ([#2162](https://github.com/0xMiden/node/pull/2162)).
+- Persisted attachments of private output notes when applying a block, so they are now returned by `GetNotesById` ([#2172](https://github.com/0xMiden/node/pull/2172)).
 
 ## v0.14.11 (TBD)
 

--- a/crates/store/src/state/apply_block.rs
+++ b/crates/store/src/state/apply_block.rs
@@ -8,7 +8,7 @@ use miden_protocol::batch::OrderedBatches;
 use miden_protocol::block::account_tree::AccountMutationSet;
 use miden_protocol::block::nullifier_tree::NullifierMutationSet;
 use miden_protocol::block::{BlockBody, BlockHeader, BlockInputs, BlockNumber, SignedBlock};
-use miden_protocol::note::{NoteAttachments, NoteDetails, Nullifier};
+use miden_protocol::note::{NoteDetails, Nullifier};
 use miden_protocol::transaction::OutputNote;
 use miden_protocol::utils::serde::Serializable;
 use tokio::sync::oneshot;
@@ -331,7 +331,7 @@ impl State {
                         public.as_note().attachments().clone(),
                         Some(public.as_note().nullifier()),
                     ),
-                    OutputNote::Private(_) => (None, NoteAttachments::empty(), None),
+                    OutputNote::Private(private) => (None, private.attachments().clone(), None),
                 };
 
                 let inclusion_path = note_tree.open(note_index);


### PR DESCRIPTION
Fixes the `apply_block` to store the attachments for private notes, so they are included in the `GetNotesById` response.

Tested this on client integration test: https://github.com/0xMiden/miden-client/pull/2214.
