### PR TITLE
chore: fix test macro publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ miden-node-proto                = { path = "crates/proto", version = "0.15.0-rc.
 miden-node-proto-build          = { path = "proto", version = "0.15.0-rc.0" }
 miden-node-rpc                  = { path = "crates/rpc", version = "0.15.0-rc.0" }
 miden-node-store                = { path = "crates/store", version = "0.15.0-rc.0" }
-miden-node-test-macro           = { path = "crates/test-macro", version = "0.1" }
+miden-node-test-macro           = { path = "crates/test-macro" }
 miden-node-utils                = { path = "crates/utils", version = "0.15.0-rc.0" }
 miden-remote-prover-client      = { path = "crates/remote-prover-client", version = "0.15.0-rc.0" }
 # Temporary workaround until <https://github.com/rust-rocksdb/rust-rocksdb/pull/1029>


### PR DESCRIPTION
I accidentally assigned the test macro crate a version in the last release attempt. This caused publishing to fail.

This fixes that, and then I'll re-release.