### PR TITLE
ci: fix docker build context

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,9 +33,15 @@ jobs:
             port: 3000
     name: Build ${{ matrix.component }}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
       - name: Build
         uses: WarpBuilds/build-push-action@8c1f3b8bd22c68607865d99ff650d37a564229a5 # v6.0.7
         with:
+          context: .
           push: false
           file: ./Dockerfile
           platforms: linux/amd64


### PR DESCRIPTION
Was missing the repo checkout step.

However, warp docker action does state that without the `context: .` it checks out the repo at the relevant ref, so its possible this is just the same behavior.

We are seeing weird stuff in our CI with docker caching and builds failing on merge to next; this potentially fixes it.