### PR TITLE
chore: v0.15.0-rc.3 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.15.0-rc.2 (2026-06-05)
 
-- Actually upgrade the `p3-goldilocks` transient dependency to `0.5.3` ([#]()).
+- Actually upgrade the `p3-goldilocks` transient dependency to `0.5.3` ([#2213](https://github.com/0xMiden/node/pull/2213)).
 
 ## v0.15.0-rc.2 (2026-06-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## v0.15.0-rc.2 (2026-06-05)
 
+- Actually upgrade the `p3-goldilocks` transient dependency to `0.5.3` ([#]()).
+
+## v0.15.0-rc.2 (2026-06-05)
+
 - Added `arm64/linux` support to Docker images ([#2209](https://github.com/0xMiden/node/pull/2209)).
 - Force upgrade `p3-goldilocks` to `> 0.5.2` to include a bugfix causing signature verification to fail [#2211](https://github.com/0xMiden/node/pull/2211)).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "miden-genesis"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3433,11 +3433,11 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "clap",
  "fs-err",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "backon",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "backon",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7550,7 +7550,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,9 +4295,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+checksum = "8972ccd1d5dc90e46cdb1f2ab4ee2bae49b3917e5e98aa533f0c2b779c010445"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -4309,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+checksum = "17771aca44632f9cc11f2718d7ea7ec06794946c4190ef3a985bfc893f14c18a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4324,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+checksum = "6f3eb24d0591fd4d282d89cbe4e4efba5571c699375006f80b2cbf53ce83461c"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -4340,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+checksum = "5751c6591a0d2397d726620c2c29a7436ec6c5e19d2ed74ca5d078d4fbb18eb5"
 dependencies = [
  "num-bigint",
  "p3-challenger",
@@ -4371,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+checksum = "ea9c94c0714944e7b8a9a62e6340b1e3e1d3f8ecfd3e35c08798360200e73eff"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4386,18 +4386,18 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+checksum = "eebc233a34b1ab0273f35b4052fa2eeb3114b22ba4575bd7da00716e878ffb77"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+checksum = "6b5441fa8116246ec9e6c835f15273cb27777ca572960ec87476b67fef13e01e"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -4408,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "p3-monty-31"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+checksum = "8724f330ea6d19dd4f2436aa0f88b5fcbf88f0f55ca7fccd3fea8b736dbcddad"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -4432,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+checksum = "04e2a562fea210baae390a32f9ecf0dd8724ae3f4352d1c8e413077b6f00a162"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -4443,9 +4443,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+checksum = "06394851c161d17e4aa4ad2aad5557d32f14cadd1dc838f965d8e1821a63b8c5"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4456,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+checksum = "9ac1a276d421f8ef3361bb7d8c39a02c93c6b3f10eeaa559cc4c50222f9a5b82"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -4468,9 +4468,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+checksum = "d08a58162a4c264269ef454f0b28dcda89939490eecacb2b2cf5b00f719b80f6"
 dependencies = [
  "rayon",
  "serde",
@@ -4824,7 +4824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4845,7 +4845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ url                = { features = ["serde"], version = "2.5" }
 [workspace.metadata.cargo-shear]
 # libsqlite3-sys is kept to control the bundled SQLite linkage.
 # tonic-prost is used by generated gRPC code rather than handwritten Rust.
-ignored = ["libsqlite3-sys",  "tonic-prost"]
+ignored = ["libsqlite3-sys", "tonic-prost"]
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.93"
-version      = "0.15.0-rc.2"
+version      = "0.15.0-rc.3"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]
@@ -44,20 +44,20 @@ debug = true
 
 [workspace.dependencies]
 # Workspace crates.
-miden-large-smt-backend-rocksdb = { path = "crates/large-smt-backend-rocksdb", version = "0.15.0-rc.2" }
-miden-node-block-producer       = { path = "crates/block-producer", version = "0.15.0-rc.2" }
-miden-node-db                   = { path = "crates/db", version = "0.15.0-rc.2" }
-miden-node-grpc-error-macro     = { path = "crates/grpc-error-macro", version = "0.15.0-rc.2" }
-miden-node-proto                = { path = "crates/proto", version = "0.15.0-rc.2" }
-miden-node-proto-build          = { path = "proto", version = "0.15.0-rc.2" }
-miden-node-rpc                  = { path = "crates/rpc", version = "0.15.0-rc.2" }
-miden-node-store                = { path = "crates/store", version = "0.15.0-rc.2" }
+miden-large-smt-backend-rocksdb = { path = "crates/large-smt-backend-rocksdb", version = "0.15.0-rc.3" }
+miden-node-block-producer       = { path = "crates/block-producer", version = "0.15.0-rc.3" }
+miden-node-db                   = { path = "crates/db", version = "0.15.0-rc.3" }
+miden-node-grpc-error-macro     = { path = "crates/grpc-error-macro", version = "0.15.0-rc.3" }
+miden-node-proto                = { path = "crates/proto", version = "0.15.0-rc.3" }
+miden-node-proto-build          = { path = "proto", version = "0.15.0-rc.3" }
+miden-node-rpc                  = { path = "crates/rpc", version = "0.15.0-rc.3" }
+miden-node-store                = { path = "crates/store", version = "0.15.0-rc.3" }
 miden-node-test-macro           = { path = "crates/test-macro" }
-miden-node-utils                = { path = "crates/utils", version = "0.15.0-rc.2" }
-miden-remote-prover-client      = { path = "crates/remote-prover-client", version = "0.15.0-rc.2" }
+miden-node-utils                = { path = "crates/utils", version = "0.15.0-rc.3" }
+miden-remote-prover-client      = { path = "crates/remote-prover-client", version = "0.15.0-rc.3" }
 # Temporary workaround until <https://github.com/rust-rocksdb/rust-rocksdb/pull/1029>
 # is part of `rocksdb-rust` release
-miden-node-rocksdb-cxx-linkage-fix = { path = "crates/rocksdb-cxx-linkage-fix", version = "0.15.0-rc.2" }
+miden-node-rocksdb-cxx-linkage-fix = { path = "crates/rocksdb-cxx-linkage-fix", version = "0.15.0-rc.3" }
 
 # miden-protocol dependencies. These should be updated in sync.
 # Requires the v0.15.2 patch release, which carries the network-account tx-script
@@ -69,10 +69,6 @@ miden-standards       = { version = "0.15.2" }
 miden-testing         = { version = "0.15.2" }
 miden-tx              = { default-features = false, version = "0.15.2" }
 miden-tx-batch-prover = { version = "0.15.2" }
-
-# v0.5.3 includes a bugfix for ARM which caused AMD and ARM to disagree.
-# Can be removed once downstream adds this restriction.
-p3-goldilocks = { version = ">= 0.5.3" }
 
 # Other miden dependencies. These should align with those expected by miden-protocol.
 miden-crypto = { version = "0.25" }
@@ -137,9 +133,8 @@ url                = { features = ["serde"], version = "2.5" }
 
 [workspace.metadata.cargo-shear]
 # libsqlite3-sys is kept to control the bundled SQLite linkage.
-# p3-goldilocks is a transient dependency which contains a bugfix in v0.5.3.
 # tonic-prost is used by generated gRPC code rather than handwritten Rust.
-ignored = ["libsqlite3-sys", "p3-goldilocks", "tonic-prost"]
+ignored = ["libsqlite3-sys",  "tonic-prost"]
 
 # Lints are set to warn for development, which are promoted to errors in CI.
 [workspace.lints.clippy]


### PR DESCRIPTION
v0.15.0-rc.2 didn't actually update the lockfile for the `p3-goldilocks` transient dependency.

The toml change didn't actually do anything because its a transient dep. We would need to depend on it directly in some workspace crate to get any benefit. I chose to simply update the lockfile directly.