### PR TITLE
Fix release triggers

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -78,7 +78,7 @@ jobs:
           remaining_crates=()
 
           for crate in "${publishable_crates[@]}"; do
-            if cargo info --quiet "${crate}@${version}" >/dev/null 2>&1; then
+            if cargo info --quiet --registry crates-io "${crate}@${version}" >/dev/null 2>&1; then
               echo "${crate} ${version} already exists on crates.io; excluding it."
               exclude_args+=(--exclude "${crate}")
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,7 @@ jobs:
     needs: [preflight, publish-docker]
     if: ${{ github.repository_owner == '0xMiden' }}
     permissions:
+      actions: write
       contents: write
     steps:
       - name: Re-check GitHub release absence
@@ -398,3 +399,24 @@ jobs:
             --title "${TAG}" \
             --notes "Release ${TAG}" \
             "${prerelease_flag[@]}"
+
+      - name: Trigger post-release publishing workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.preflight.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # The GitHub release is created with GITHUB_TOKEN, so its release
+          # event does not start follow-up workflows. workflow_dispatch events
+          # are allowed for GITHUB_TOKEN, so trigger those workflows directly.
+          gh workflow run publish-crates.yml \
+            --repo "${REPO}" \
+            --ref "${TAG}" \
+            --field "version=${TAG}"
+
+          gh workflow run publish-debian-all.yml \
+            --repo "${REPO}" \
+            --ref "${TAG}" \
+            --field "version=${TAG}"


### PR DESCRIPTION
Fixes the following:

- crates never publishing because the check is done _locally_ so it always thinks the creates already exist
- debian publish can't trigger off a github workflow release
- crates publish can't trigger off a github workflow release