### PR TITLE
feat(genesis): register the native faucet in the AggLayer bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Register the Miden native faucet in the AggLayer bridge at genesis ([#2220](https://github.com/0xMiden/node/pull/2220)).
+
 ## v0.15.0-rc.3 (2026-06-08)
 
 - Actually upgrade the `p3-*` transient dependency to `0.5.3` ([#2213](https://github.com/0xMiden/node/pull/2213)).

--- a/bin/genesis/src/main.rs
+++ b/bin/genesis/src/main.rs
@@ -129,9 +129,11 @@ timestamp = {timestamp}
 [fee_parameters]
 verification_base_fee = 0
 
-[[account]]
+[bridge]
 path = "bridge.mac"
+admin_id = "{bridge_admin}"
 "#,
+        bridge_admin = bridge_admin_id.to_hex(),
     );
 
     fs_err::write(output_dir.join("genesis.toml"), genesis_toml)
@@ -197,7 +199,12 @@ mod tests {
     /// Parses the generated genesis.toml, builds a genesis block, and asserts the bridge account is
     /// included with nonce=1.
     fn assert_valid_genesis_block(dir: &Path) {
+        use miden_agglayer::ConfigAggBridgeNote;
+        use miden_protocol::transaction::OutputNote;
+        use miden_standards::note::AccountTargetNetworkNote;
+
         let bridge_id = AccountFile::read(dir.join("bridge.mac")).unwrap().account.id();
+        let admin_id = AccountFile::read(dir.join("bridge_admin.mac")).unwrap().account.id();
 
         let config = GenesisConfig::read_toml_file(&dir.join("genesis.toml")).unwrap();
         let signer = SigningKey::read_from_bytes(&[0x01; 32]).unwrap();
@@ -206,7 +213,22 @@ mod tests {
         let bridge = state.accounts.iter().find(|a| a.id() == bridge_id).unwrap();
         assert_eq!(bridge.nonce(), ONE);
 
-        state.into_block(&signer).expect("genesis block should build");
+        // Genesis emits a single CONFIG_AGG_BRIDGE note registering the native faucet, sent by the
+        // bridge admin and targeting the bridge.
+        assert_eq!(state.output_notes.len(), 1);
+        let OutputNote::Public(public) = &state.output_notes[0] else {
+            panic!("registration note must be public");
+        };
+        let note = public.as_note();
+        assert_eq!(note.script().root(), ConfigAggBridgeNote::script_root());
+        assert_eq!(note.metadata().sender(), admin_id);
+        let network_note = AccountTargetNetworkNote::try_from(note.clone()).unwrap();
+        assert_eq!(network_note.target_account_id(), bridge_id);
+
+        let block = state.into_block(&signer).expect("genesis block should build");
+        let note_count: usize =
+            block.inner().body().output_note_batches().iter().map(Vec::len).sum();
+        assert_eq!(note_count, 1);
     }
 
     #[tokio::test]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -26,6 +26,7 @@ fs-err                          = { workspace = true }
 hex                             = { workspace = true }
 indexmap                        = { workspace = true }
 libsqlite3-sys                  = { workspace = true }
+miden-agglayer                  = { workspace = true }
 miden-crypto                    = { features = ["concurrent"], workspace = true }
 miden-large-smt-backend-rocksdb = { optional = true, workspace = true }
 miden-node-db                   = { workspace = true }

--- a/crates/store/src/genesis/config/errors.rs
+++ b/crates/store/src/genesis/config/errors.rs
@@ -1,7 +1,15 @@
 use std::path::PathBuf;
 
 use miden_protocol::account::AccountId;
-use miden_protocol::errors::{AccountDeltaError, AccountError, AssetError, TokenSymbolError};
+use miden_protocol::errors::{
+    AccountDeltaError,
+    AccountError,
+    AccountIdError,
+    AssetError,
+    NoteError,
+    OutputNoteError,
+    TokenSymbolError,
+};
 use miden_protocol::utils::serde::DeserializationError;
 use miden_standards::account::faucets::FungibleFaucetError;
 use miden_standards::account::policies::TokenPolicyManagerError;
@@ -69,4 +77,10 @@ pub enum GenesisConfigError {
     UnsupportedSignerConfig,
     #[error("token policy manager error")]
     TokenPolicyManager(#[from] TokenPolicyManagerError),
+    #[error("invalid bridge admin account id")]
+    InvalidBridgeAdminId(#[source] AccountIdError),
+    #[error("failed to create the CONFIG_AGG_BRIDGE note registering the native faucet")]
+    ConfigNoteCreation(#[source] NoteError),
+    #[error("failed to build the genesis output note")]
+    GenesisOutputNote(#[source] OutputNoteError),
 }

--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -5,6 +5,13 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use indexmap::IndexMap;
+use miden_agglayer::{
+    AggLayerBridge,
+    ConfigAggBridgeNote,
+    ConversionMetadata,
+    EthEmbeddedAccountId,
+    MetadataHash,
+};
 use miden_node_utils::crypto::get_random_coin;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{
@@ -24,6 +31,7 @@ use miden_protocol::block::FeeParameters;
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::PublicKey;
 use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey as RpoSecretKey;
 use miden_protocol::errors::TokenSymbolError;
+use miden_protocol::transaction::{OutputNote, PublicOutputNote};
 use miden_protocol::{Felt, ONE};
 use miden_standards::AuthMethod;
 use miden_standards::account::auth::AuthSingleSig;
@@ -65,6 +73,76 @@ struct GenericAccountConfig {
     path: PathBuf,
 }
 
+/// `AggLayer` bridge account configuration.
+///
+/// When present, the bridge account is loaded from `path` and included in the genesis accounts,
+/// and a `CONFIG_AGG_BRIDGE` note is emitted in the genesis block registering the native faucet as
+/// a native (lock/unlock) faucet. The note's sender is the bridge admin (`admin_id`): the bridge's
+/// `register_faucet` guard only accepts notes whose sender equals the stored admin id. At genesis
+/// the note sender is unauthenticated metadata we set directly, so no deployed admin account is
+/// required.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BridgeConfig {
+    /// Path to the bridge account `.mac` file, relative to the genesis config directory.
+    path: PathBuf,
+    /// Hex-encoded account id of the bridge admin (the `CONFIG_AGG_BRIDGE` note sender).
+    admin_id: String,
+}
+
+impl BridgeConfig {
+    /// Loads the bridge account and builds the `CONFIG_AGG_BRIDGE` output note that registers
+    /// `native_faucet_account` as a native faucet.
+    ///
+    /// Returns the loaded bridge account (to be included in the genesis accounts) and the output
+    /// note (to be included in the genesis block).
+    fn load_and_build_registration_note(
+        self,
+        config_dir: &Path,
+        native_faucet_account: &Account,
+    ) -> Result<(Account, OutputNote), GenesisConfigError> {
+        let full_path = config_dir.join(&self.path);
+        let bridge_account = AccountFile::read(&full_path)
+            .map_err(|e| GenesisConfigError::AccountFileRead(e, full_path.clone()))?
+            .account;
+        let bridge_id = bridge_account.id();
+
+        let admin_id = AccountId::from_hex(&self.admin_id)
+            .map_err(GenesisConfigError::InvalidBridgeAdminId)?;
+
+        let native_faucet_id = native_faucet_account.id();
+        let faucet = FungibleFaucet::try_from(native_faucet_account)?;
+        let metadata_hash = MetadataHash::from_token_info(
+            faucet.token_name().as_str(),
+            &faucet.symbol().to_string(),
+            faucet.decimals(),
+        );
+
+        let metadata = ConversionMetadata {
+            faucet_account_id: native_faucet_id,
+            // A native token has no L1 origin contract; encode the faucet's own account id as the
+            // origin token address.
+            origin_token_address: EthEmbeddedAccountId::from_account_id(native_faucet_id)
+                .to_eth_address(),
+            // The native token originates on Miden, so there is no decimal scaling.
+            scale: 0,
+            origin_network: AggLayerBridge::MIDEN_NETWORK_ID,
+            is_native: true,
+            metadata_hash,
+        };
+
+        let mut rng = ChaCha20Rng::from_seed(rand::random());
+        let mut coin = get_random_coin(&mut rng);
+        let note = ConfigAggBridgeNote::create(metadata, admin_id, bridge_id, &mut coin)
+            .map_err(GenesisConfigError::ConfigNoteCreation)?;
+        let output_note = OutputNote::Public(
+            PublicOutputNote::new(note).map_err(GenesisConfigError::GenesisOutputNote)?,
+        );
+
+        Ok((bridge_account, output_note))
+    }
+}
+
 /// Specify a set of faucets and wallets with assets for easier test deployments.
 ///
 /// Notice: Any faucet must be declared _before_ it's use in a wallet/regular account.
@@ -91,6 +169,10 @@ pub struct GenesisConfig {
     fungible_faucet: Vec<FungibleFaucetConfig>,
     #[serde(default)]
     account: Vec<GenericAccountConfig>,
+    /// Optional `AggLayer` bridge account. When present, genesis loads the bridge account and emits
+    /// a `CONFIG_AGG_BRIDGE` note registering the native faucet as a native (lock/unlock) faucet.
+    #[serde(default)]
+    bridge: Option<BridgeConfig>,
     #[serde(skip)]
     config_dir: PathBuf,
 }
@@ -111,6 +193,7 @@ impl Default for GenesisConfig {
             fee_parameters: FeeParameterConfig { verification_base_fee: 0 },
             fungible_faucet: vec![],
             account: vec![],
+            bridge: None,
             config_dir: PathBuf::from("."),
         }
     }
@@ -157,6 +240,7 @@ impl GenesisConfig {
             fungible_faucet: fungible_faucet_configs,
             wallet: wallet_configs,
             account: account_entries,
+            bridge: bridge_config,
             config_dir,
         } = self;
 
@@ -333,10 +417,28 @@ impl GenesisConfig {
         // Append file-loaded accounts as-is
         all_accounts.extend(file_loaded_accounts);
 
+        // If a bridge is configured, load it and emit a CONFIG_AGG_BRIDGE note that registers the
+        // native faucet as a native (lock/unlock) faucet. The note is consumed by the bridge after
+        // genesis (via the network-transaction builder), mirroring how non-native faucets are
+        // registered.
+        let output_notes = if let Some(bridge_config) = bridge_config {
+            let native_faucet_account = all_accounts
+                .iter()
+                .find(|account| account.id() == native_faucet_account_id)
+                .expect("native faucet account is always part of the genesis accounts");
+            let (bridge_account, note) = bridge_config
+                .load_and_build_registration_note(&config_dir, native_faucet_account)?;
+            all_accounts.push(bridge_account);
+            vec![note]
+        } else {
+            Vec::new()
+        };
+
         Ok((
             GenesisState {
                 fee_parameters,
                 accounts: all_accounts,
+                output_notes,
                 version,
                 timestamp,
                 validator_key,

--- a/crates/store/src/genesis/config/tests.rs
+++ b/crates/store/src/genesis/config/tests.rs
@@ -382,3 +382,139 @@ async fn parsing_agglayer_sample_with_account_files() -> TestResult {
 
     Ok(())
 }
+
+/// Builds a bridge account (and its admin) and writes the bridge `.mac` to `dir`, returning the
+/// file name and the admin account id. Mirrors the deterministic setup in the crate's build script.
+fn write_bridge_account(dir: &Path) -> (String, AccountId) {
+    use miden_agglayer::create_existing_bridge_account;
+    use miden_protocol::Word;
+    use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey;
+    use miden_protocol::crypto::rand::RandomCoin;
+
+    let make_wallet = |seed: u32, init: u8| {
+        let key = SecretKey::with_rng(&mut RandomCoin::new(Word::new([Felt::from_u32(seed); 4])));
+        create_basic_wallet(
+            [init; 32],
+            AuthMethod::SingleSig {
+                approver: (key.public_key().into(), AuthScheme::Falcon512Poseidon2),
+            },
+            AccountType::Public,
+        )
+        .expect("wallet account should be valid")
+    };
+
+    let admin = make_wallet(4, 4);
+    let ger_manager = make_wallet(5, 5);
+    let bridge = create_existing_bridge_account(
+        Word::new([Felt::from_u32(1u32); 4]),
+        admin.id(),
+        ger_manager.id(),
+    );
+
+    let file_name = "bridge.mac".to_string();
+    AccountFile::new(bridge, vec![])
+        .write(dir.join(&file_name))
+        .expect("writing bridge account file should succeed");
+
+    (file_name, admin.id())
+}
+
+#[test]
+#[miden_node_test_macro::enable_logging]
+fn bridge_config_registers_native_faucet() -> TestResult {
+    use miden_standards::note::AccountTargetNetworkNote;
+
+    let temp_dir = tempfile::tempdir()?;
+    let (bridge_file, admin_id) = write_bridge_account(temp_dir.path());
+
+    let toml_content = format!(
+        r#"timestamp = 1717344256
+version   = 1
+
+[fee_parameters]
+verification_base_fee = 0
+
+[bridge]
+path     = "{bridge_file}"
+admin_id = "{admin_id}"
+"#,
+        admin_id = admin_id.to_hex(),
+    );
+    let config_path = write_toml_file(temp_dir.path(), &toml_content);
+
+    let signer = SigningKey::new();
+    let gcfg = GenesisConfig::read_toml_file(&config_path)?;
+    let (state, _secrets) = gcfg.into_state(signer.public_key())?;
+
+    // The native faucet and the bridge account are both part of the genesis state.
+    let native_faucet = state
+        .accounts
+        .iter()
+        .find(|account| FungibleFaucet::try_from(*account).is_ok())
+        .expect("native faucet should be present");
+    let native_faucet_id = native_faucet.id();
+    let bridge_id = state
+        .accounts
+        .iter()
+        .find(|account| FungibleFaucet::try_from(*account).is_err())
+        .expect("bridge account should be present")
+        .id();
+
+    // Exactly one genesis output note: the CONFIG_AGG_BRIDGE registration note.
+    assert_eq!(state.output_notes.len(), 1, "expected exactly one genesis output note");
+    let note = match &state.output_notes[0] {
+        OutputNote::Public(public) => public.as_note(),
+        OutputNote::Private(_) => panic!("registration note must be public"),
+    };
+
+    // It is the CONFIG_AGG_BRIDGE script, sent by the bridge admin, targeting the bridge.
+    assert_eq!(note.script().root(), ConfigAggBridgeNote::script_root());
+    assert_eq!(note.metadata().sender(), admin_id, "note sender must be the bridge admin");
+    let network_note = AccountTargetNetworkNote::try_from(note.clone())
+        .expect("registration note must be a single-target network note");
+    assert_eq!(network_note.target_account_id(), bridge_id, "note must target the bridge");
+
+    // The 18-felt payload registers the native faucet as a native faucet.
+    let items = note.storage().items();
+    assert_eq!(items.len(), 18, "CONFIG_AGG_BRIDGE payload must have 18 felts");
+    assert_eq!(items[5], native_faucet_id.suffix(), "faucet id suffix");
+    assert_eq!(items[6], native_faucet_id.prefix().as_felt(), "faucet id prefix");
+    assert_eq!(items[7], Felt::from(0u8), "native token has no decimal scaling");
+    assert_eq!(
+        items[8],
+        Felt::from(AggLayerBridge::MIDEN_NETWORK_ID),
+        "origin network must be the Miden network id"
+    );
+    assert_eq!(items[9], Felt::from(1u8), "is_native must be set");
+
+    // The genesis block builds and carries the note in its body.
+    let block = state.into_block(&signer)?;
+    let note_count: usize = block.inner().body().output_note_batches().iter().map(Vec::len).sum();
+    assert_eq!(note_count, 1, "genesis block body must carry the registration note");
+
+    Ok(())
+}
+
+#[test]
+fn bridge_config_with_invalid_admin_id_errors() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (bridge_file, _admin_id) = write_bridge_account(temp_dir.path());
+
+    let toml_content = format!(
+        r#"timestamp = 1717344256
+version   = 1
+
+[fee_parameters]
+verification_base_fee = 0
+
+[bridge]
+path     = "{bridge_file}"
+admin_id = "not-a-valid-account-id"
+"#,
+    );
+    let config_path = write_toml_file(temp_dir.path(), &toml_content);
+
+    let gcfg = GenesisConfig::read_toml_file(&config_path).unwrap();
+    let result = gcfg.into_state(SigningKey::new().public_key());
+    assert_matches!(result, Err(GenesisConfigError::InvalidBridgeAdminId(_)));
+}

--- a/crates/store/src/genesis/mod.rs
+++ b/crates/store/src/genesis/mod.rs
@@ -6,9 +6,9 @@ use miden_protocol::block::{
     BlockAccountUpdate,
     BlockBody,
     BlockHeader,
-    BlockNoteTree,
     BlockNumber,
     FeeParameters,
+    OutputNoteBatch,
     SignedBlock,
 };
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::{PublicKey, Signature, SigningKey};
@@ -16,7 +16,7 @@ use miden_protocol::crypto::merkle::mmr::{Forest, MmrPeaks};
 use miden_protocol::crypto::merkle::smt::Smt;
 use miden_protocol::errors::AccountError;
 use miden_protocol::note::Nullifier;
-use miden_protocol::transaction::{OrderedTransactionHeaders, TransactionKernel};
+use miden_protocol::transaction::{OrderedTransactionHeaders, OutputNote, TransactionKernel};
 
 pub mod config;
 
@@ -27,6 +27,9 @@ pub mod config;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenesisState {
     pub accounts: Vec<Account>,
+    /// Notes created in the genesis block (e.g. the `CONFIG_AGG_BRIDGE` note that registers the
+    /// native faucet with the bridge). Empty unless explicitly populated.
+    pub output_notes: Vec<OutputNote>,
     pub fee_parameters: FeeParameters,
     pub version: u32,
     pub timestamp: u32,
@@ -99,6 +102,7 @@ impl GenesisState {
     ) -> Self {
         Self {
             accounts,
+            output_notes: Vec::new(),
             fee_parameters,
             version,
             timestamp,
@@ -142,10 +146,23 @@ impl GenesisState {
         let empty_nullifiers: Vec<Nullifier> = Vec::new();
         let empty_nullifier_tree = Smt::new();
 
-        let empty_output_notes = Vec::new();
-        let empty_block_note_tree = BlockNoteTree::empty();
+        // Wrap any genesis output notes into a single batch (batch index 0). The block note tree is
+        // derived from the body below so the note index mapping stays consistent.
+        let output_note_batches: Vec<OutputNoteBatch> = if self.output_notes.is_empty() {
+            Vec::new()
+        } else {
+            vec![self.output_notes.iter().cloned().enumerate().collect()]
+        };
 
         let empty_transactions = OrderedTransactionHeaders::new_unchecked(Vec::new());
+
+        // Build the body first so the block note tree root can be derived from it.
+        let body = BlockBody::new_unchecked(
+            accounts,
+            output_note_batches,
+            empty_nullifiers,
+            empty_transactions,
+        );
 
         let header = BlockHeader::new(
             self.version,
@@ -154,19 +171,12 @@ impl GenesisState {
             MmrPeaks::new(Forest::empty(), Vec::new()).unwrap().hash_peaks(),
             account_smt.root(),
             empty_nullifier_tree.root(),
-            empty_block_note_tree.root(),
+            body.compute_block_note_tree().root(),
             Word::empty(),
             TransactionKernel.to_commitment(),
             self.validator_key,
             self.fee_parameters,
             self.timestamp,
-        );
-
-        let body = BlockBody::new_unchecked(
-            accounts,
-            empty_output_notes,
-            empty_nullifiers,
-            empty_transactions,
         );
 
         Ok(UnsignedGenesisBlock { header, body })


### PR DESCRIPTION
## Summary

Closes #2217.

With [protocol#2771](https://github.com/0xMiden/protocol/pull/2771), Miden-native faucet tokens can be bridged out via the AggLayer bridge. Faucets are registered with the bridge through a `CONFIG_AGG_BRIDGE` note targeting the bridge account. Since genesis already deploys the bridge and knows the native faucet's account id, genesis now registers the native faucet as a native (lock/unlock) faucet (`is_native = true`).

## Approach

Registration uses the same path non-native faucets use: a `CONFIG_AGG_BRIDGE` note. The note is emitted as a **genesis output note** and consumed by the bridge after genesis via the network-transaction builder (which already ingests genesis output notes in `bin/ntx-builder/src/committed_block.rs`). The bridge's `register_faucet` guard requires the note sender to equal the stored bridge admin id; at genesis the note sender is unauthenticated metadata we set directly, so no deployed admin account is required.

- The genesis tool (`bin/genesis`) now writes an optional `[bridge]` section to `genesis.toml` (bridge account path + admin id) in place of the bare `[[account]]` bridge entry.
- `GenesisConfig::into_state` parses `[bridge]`, loads the bridge account, and builds the `CONFIG_AGG_BRIDGE` note for the native faucet, including it as a genesis output note. The whole section is optional, so existing `genesis.toml` files (and the `02-with-account-files` sample) are unaffected and emit no note.
- `GenesisState` now carries `output_notes`, and `into_unsigned_block` builds a real `BlockNoteTree` from them.
- `miden-agglayer` is now a runtime dependency of `crates/store` (previously build/dev only).

### Native faucet conversion metadata

- `origin_network = AggLayerBridge::MIDEN_NETWORK_ID`
- `origin_token_address = EthEmbeddedAccountId::from_account_id(native_faucet_id)` (a native token has no L1 origin contract)
- `scale = 0` (no decimal delta; the token originates on Miden)
- `metadata_hash = MetadataHash::from_token_info(name, symbol, decimals)`
- `is_native = true`

## Testing

- `cargo test -p miden-node-store genesis` and `cargo test -p miden-genesis` pass, including:
  - a new test asserting `into_state` emits exactly one public `CONFIG_AGG_BRIDGE` note targeting the bridge, sent by the admin, with `is_native = 1`, the native faucet id, `MIDEN_NETWORK_ID`, and `scale = 0`, and that the genesis block carries it;
  - a negative test for an invalid `admin_id`;
  - the existing genesis tool tests, extended to assert the registration note is present in the generated genesis block.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, rustfmt, taplo, cargo-shear, and the doc build are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)