### PR TITLE
Fix docker certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed missing certificates in the Docker runtime image ([#0000](https://github.com/0xMiden/node/pull/0000)).
+- Fixed missing certificates in the Docker runtime image ([#2221](https://github.com/0xMiden/node/pull/2221)).
 
 ## v0.15.0-rc.3 (2026-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed missing certificates in the Docker runtime image ([#0000](https://github.com/0xMiden/node/pull/0000)).
+
 ## v0.15.0-rc.3 (2026-06-08)
 
 - Actually upgrade the `p3-*` transient dependency to `0.5.3` ([#2213](https://github.com/0xMiden/node/pull/2213)).

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN --mount=type=cache,sharing=locked,target=/usr/local/cargo/registry \
 FROM debian:${DEBIAN_RELEASE}-slim AS runtime-base
 RUN apt-get update && \
     apt-get -y upgrade && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 FROM runtime-base AS runtime


### PR DESCRIPTION
These were missing in the runtime image, causing https calls to fail with the vague `Transport error`