### PR TITLE
fix(rpc): preserve original RPC Accept metadata when full nodes forward requests upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed missing certificates in the Docker runtime image ([#2221](https://github.com/0xMiden/node/pull/2221)).
+- Accept header is now forwarded to the upstream on full nodes ([#2225](https://github.com/0xMiden/node/pull/2225)).
 
 ## v0.15.0-rc.3 (2026-06-08)
 

--- a/crates/proto/src/clients/mod.rs
+++ b/crates/proto/src/clients/mod.rs
@@ -108,13 +108,47 @@ impl tonic::service::Interceptor for Interceptor {
             request = otel.call(request)?;
         }
 
-        request.metadata_mut().insert(ACCEPT.as_str(), self.accept.clone());
+        if request.metadata().get(ACCEPT.as_str()).is_none() {
+            request.metadata_mut().insert(ACCEPT.as_str(), self.accept.clone());
+        }
 
         if let Some(value) = &self.auth_header_value {
             request.metadata_mut().insert(Self::NETWORK_TX_AUTH_HEADER_NAME, value.clone());
         }
 
         Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interceptor_preserves_existing_accept_metadata() {
+        let original_accept =
+            AsciiMetadataValue::from_static("application/vnd.miden; version=1.2; genesis=0x1234");
+        let mut request = Request::new(());
+        request.metadata_mut().insert(ACCEPT.as_str(), original_accept.clone());
+
+        let mut interceptor = Interceptor::new(false, Some("9.9"), Some("0xabcd"), None);
+        let request = tonic::service::Interceptor::call(&mut interceptor, request)
+            .expect("interceptor should succeed");
+
+        assert_eq!(request.metadata().get(ACCEPT.as_str()), Some(&original_accept));
+    }
+
+    #[test]
+    fn interceptor_inserts_accept_metadata_when_missing() {
+        let mut interceptor = Interceptor::new(false, Some("9.9"), Some("0xabcd"), None);
+
+        let request = tonic::service::Interceptor::call(&mut interceptor, Request::new(()))
+            .expect("interceptor should succeed");
+
+        assert_eq!(
+            request.metadata().get(ACCEPT.as_str()).and_then(|value| value.to_str().ok()),
+            Some("application/vnd.miden; version=9.9, genesis=0xabcd"),
+        );
     }
 }
 

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -5,6 +5,7 @@ use std::task::{Context as TaskContext, Poll};
 use std::time::Duration;
 
 use anyhow::Context as AnyhowContext;
+use http::header::ACCEPT;
 use miden_node_block_producer::{BlockProducerStatus, MempoolStats as BlockProducerMempoolStats};
 use miden_node_proto::clients::NtxBuilderClient;
 use miden_node_proto::decode::{
@@ -723,6 +724,7 @@ impl api_server::Api for RpcService {
         debug!(target: COMPONENT, request = ?request.get_ref());
 
         let is_authorized_network_tx = self.is_authorized_network_tx(request.metadata());
+        let original_accept = request.metadata().get(ACCEPT.as_str()).cloned();
 
         let request = request.into_inner();
 
@@ -799,7 +801,11 @@ impl api_server::Api for RpcService {
                 (block_producer.as_ref(), validator.as_ref())
             },
             RpcMode::FullNode { source_rpc } => {
-                return source_rpc.as_ref().clone().submit_proven_tx(request).await;
+                let mut forwarded_request = Request::new(request);
+                if let Some(accept) = original_accept {
+                    forwarded_request.metadata_mut().insert(ACCEPT.as_str(), accept);
+                }
+                return source_rpc.as_ref().clone().submit_proven_tx(forwarded_request).await;
             },
         };
 
@@ -826,6 +832,7 @@ impl api_server::Api for RpcService {
         request: tonic::Request<proto::transaction::TransactionBatch>,
     ) -> Result<tonic::Response<proto::blockchain::BlockNumber>, Status> {
         let is_authorized_network_tx = self.is_authorized_network_tx(request.metadata());
+        let original_accept = request.metadata().get(ACCEPT.as_str()).cloned();
         let request = request.into_inner();
 
         let proven_batch = ProvenBatch::read_from_bytes(&request.batch_proof).map_err(|err| {
@@ -916,7 +923,11 @@ impl api_server::Api for RpcService {
                 (block_producer.as_ref(), validator.as_ref())
             },
             RpcMode::FullNode { source_rpc } => {
-                return source_rpc.as_ref().clone().submit_proven_tx_batch(request).await;
+                let mut forwarded_request = Request::new(request);
+                if let Some(accept) = original_accept {
+                    forwarded_request.metadata_mut().insert(ACCEPT.as_str(), accept);
+                }
+                return source_rpc.as_ref().clone().submit_proven_tx_batch(forwarded_request).await;
             },
         };
 

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -469,28 +469,37 @@ fn source_rpc_client() -> RpcClient {
 struct FixedNtxBuilder {
     response: proto::rpc::GetNetworkNoteStatusResponse,
     call_count: Arc<AtomicUsize>,
+    last_accept: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 #[tonic::async_trait]
 impl proto::ntx_builder::api_server::Api for FixedNtxBuilder {
     async fn get_network_note_status(
         &self,
-        _request: Request<proto::note::NoteId>,
+        request: Request<proto::note::NoteId>,
     ) -> Result<tonic::Response<proto::rpc::GetNetworkNoteStatusResponse>, tonic::Status> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
+        let accept = request
+            .metadata()
+            .get(ACCEPT.as_str())
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        *self.last_accept.lock().expect("last_accept mutex should not be poisoned") = accept;
         Ok(tonic::Response::new(self.response.clone()))
     }
 }
 
 async fn start_ntx_builder(
     response: proto::rpc::GetNetworkNoteStatusResponse,
-) -> (NtxBuilderClient, Arc<AtomicUsize>) {
+) -> (NtxBuilderClient, Arc<AtomicUsize>, Arc<std::sync::Mutex<Option<String>>>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind ntx-builder");
     let addr = listener.local_addr().expect("Failed to get ntx-builder address");
     let call_count = Arc::new(AtomicUsize::new(0));
+    let last_accept = Arc::new(std::sync::Mutex::new(None));
     let service = FixedNtxBuilder {
         response,
         call_count: Arc::clone(&call_count),
+        last_accept: Arc::clone(&last_accept),
     };
 
     task::spawn(async move {
@@ -509,7 +518,7 @@ async fn start_ntx_builder(
         .without_otel_context_injection()
         .connect_lazy::<NtxBuilderClient>();
 
-    (client, call_count)
+    (client, call_count, last_accept)
 }
 
 async fn start_source_rpc(ntx_builder: NtxBuilderClient) -> (RpcClient, TestStore) {
@@ -572,7 +581,8 @@ async fn full_node_forwards_get_network_note_status_to_source_rpc() {
         attempt_count: 7,
         last_attempt_block_num: Some(42),
     };
-    let (ntx_builder, ntx_builder_call_count) = start_ntx_builder(expected.clone()).await;
+    let (ntx_builder, ntx_builder_call_count, _last_accept) =
+        start_ntx_builder(expected.clone()).await;
     let (source_rpc, _source_store) = start_source_rpc(ntx_builder).await;
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
@@ -591,6 +601,47 @@ async fn full_node_forwards_get_network_note_status_to_source_rpc() {
 
     assert_eq!(response, expected);
     assert_eq!(ntx_builder_call_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn full_node_preserves_original_accept_metadata_when_forwarding() {
+    let expected = proto::rpc::GetNetworkNoteStatusResponse {
+        status: proto::rpc::NetworkNoteStatus::Discarded.into(),
+        last_error: Some("execution failed".to_string()),
+        attempt_count: 7,
+        last_attempt_block_num: Some(42),
+    };
+    let (ntx_builder, _ntx_builder_call_count, last_accept) =
+        start_ntx_builder(expected.clone()).await;
+    let (source_rpc, source_store) = start_source_rpc(ntx_builder).await;
+    let local_store = TestStore::start().await;
+    let full_node = RpcService::new(
+        Arc::clone(&local_store.state),
+        RpcMode::full_node(source_rpc),
+        None,
+        NonZeroUsize::new(1_000).unwrap(),
+        None,
+    );
+
+    let original_accept = format!(
+        "application/vnd.miden; version={}; genesis={}",
+        env!("CARGO_PKG_VERSION"),
+        source_store.genesis_commitment().to_hex(),
+    );
+    let mut request = Request::new(Word::empty().into());
+    request.metadata_mut().insert(ACCEPT.as_str(), original_accept.parse().unwrap());
+
+    let response = full_node
+        .get_network_note_status(request)
+        .await
+        .expect("full-node RPC should forward network note status request")
+        .into_inner();
+
+    assert_eq!(response, expected);
+    assert_eq!(
+        *last_accept.lock().expect("last_accept mutex should not be poisoned"),
+        Some(original_accept),
+    );
 }
 
 // Batch-path coverage for the network-account gate is provided manually. Building a valid


### PR DESCRIPTION
This fixes full-node RPC forwarding to keep the original client’s version/genesis negotiation metadata instead of letting the upstream client overwrite it with its own default Accept header.

Changes:

- Updated the shared gRPC client interceptor to only insert configured Accept metadata when the request does not already provide one.
- Left source_rpc_client() configured with .without_metadata_version() and .without_metadata_genesis(), since forwarded metadata should come from the original client request.
- Preserved inbound Accept metadata when full-node forwarding rebuilds submit_proven_tx and submit_proven_tx_batch requests.
- Added regression coverage for preserving original Accept metadata through full-node forwarding.
