### PR TITLE
fix(store): get_account() now checks number of entries in the vault tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improved `GetAccount` performance if number of vault assets exceeds the limit. ([#2227](https://github.com/0xMiden/node/pull/2227)).
+
 ## v0.15.0-rc.4 (2026-06-09)
 
 - Fixed missing certificates in the Docker runtime image ([#2221](https://github.com/0xMiden/node/pull/2221)).

--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -13,7 +13,7 @@ use miden_protocol::account::{
     StorageSlotName,
     StorageSlotType,
 };
-use miden_protocol::asset::{Asset, AssetVault};
+use miden_protocol::asset::Asset;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::block::account_tree::AccountWitness;
 use miden_protocol::crypto::merkle::SparseMerklePath;
@@ -367,14 +367,6 @@ impl AccountVaultDetails {
     /// more assets will have `LimitExceeded` variant.
     pub const MAX_RETURN_ENTRIES: usize = 1000;
 
-    pub fn new(vault: &AssetVault) -> Self {
-        if vault.assets().nth(Self::MAX_RETURN_ENTRIES).is_some() {
-            Self::LimitExceeded
-        } else {
-            Self::Assets(Vec::from_iter(vault.assets()))
-        }
-    }
-
     pub fn empty() -> Self {
         Self::Assets(Vec::new())
     }
@@ -706,7 +698,9 @@ fn storage_slot_type_from_raw(slot_type: u32) -> Result<StorageSlotType, Convers
     Ok(match slot_type {
         0 => StorageSlotType::Value,
         1 => StorageSlotType::Map,
-        _ => return Err(ConversionError::message("enum variant discriminant out of range")),
+        _ => {
+            return Err(ConversionError::message("enum variant discriminant out of range"));
+        },
     })
 }
 

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -303,12 +303,16 @@ impl<B: Backend> AccountStateForest<B> {
     ) -> Result<AccountVaultDetails, WitnessError> {
         let lineage = Self::vault_lineage_id(account_id);
         let tree = self.get_tree_id(lineage, block_num).ok_or(WitnessError::RootNotFound)?;
-        // TODO: we should be checking `.entry_count()` instead of pulling entries from the tree
-        // once the optimization making `.entry_count()` cheap once `miden-crypto` is upgraded to
-        // > 0.23.
+
+        // Return "limit exceeded" if the number of vault entries is above the limit.
+        let num_input_notes =
+            self.forest.entry_count(tree).map_err(Self::map_forest_error_to_witness)?;
+        if num_input_notes > AccountVaultDetails::MAX_RETURN_ENTRIES {
+            return Ok(AccountVaultDetails::LimitExceeded);
+        }
+
         let entries = self.forest.entries(tree).map_err(Self::map_forest_error_to_witness)?;
         let assets = entries
-            .take(AccountVaultDetails::MAX_RETURN_ENTRIES + 1)
             .map(|entry| {
                 let entry = entry.map_err(Self::map_forest_error_to_witness)?;
                 Asset::from_key_value_words(entry.key, entry.value).map_err(WitnessError::from)


### PR DESCRIPTION
After having upgraded to `miden-crypto` `0.25` we can utilize the fact that `LargeSmtForest` trees now track the number of entries efficiently.

This enables us to optimize `GetAccount` for the case where the number of vault assets in the account exceeds the limit: instead of collecting `MAX_RETURN_ENTRIES + 1` elements and then throwing all of those away, the code now utilizes `.entry_count()` to efficiently get the number of entries in the tree as a pre-check.