### PR TITLE
Validator block backup

### DIFF
--- a/bin/validator/src/commands/bootstrap.rs
+++ b/bin/validator/src/commands/bootstrap.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use miden_node_store::BlockStore;
 use miden_node_store::genesis::config::{AccountFileWithName, GenesisConfig};
 use miden_node_utils::fs::ensure_empty_directory;
 use miden_protocol::utils::serde::Serializable;
@@ -83,6 +84,8 @@ async fn build_and_write_genesis(
     let block_bytes = genesis_block.inner().to_bytes();
     let genesis_block_path = genesis_block_directory.join(GENESIS_BLOCK_FILENAME);
     fs_err::write(&genesis_block_path, block_bytes).context("failed to write genesis block")?;
+
+    let _ = BlockStore::bootstrap(data_directory.to_path_buf(), &genesis_block)?;
 
     let (genesis_header, ..) = genesis_block.into_inner().into_parts();
     let db = miden_validator::db::setup_with_pool_size(

--- a/bin/validator/src/commands/bootstrap.rs
+++ b/bin/validator/src/commands/bootstrap.rs
@@ -85,7 +85,7 @@ async fn build_and_write_genesis(
     let genesis_block_path = genesis_block_directory.join(GENESIS_BLOCK_FILENAME);
     fs_err::write(&genesis_block_path, block_bytes).context("failed to write genesis block")?;
 
-    let _ = BlockStore::bootstrap(data_directory.to_path_buf(), &genesis_block)?;
+    let _ = BlockStore::bootstrap(data_directory.to_path_buf().join("blocks"), &genesis_block)?;
 
     let (genesis_header, ..) = genesis_block.into_inner().into_parts();
     let db = miden_validator::db::setup_with_pool_size(

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use miden_node_proto::generated::validator::api_server;
 use miden_node_proto_build::validator_api_descriptor;
+use miden_node_store::BlockStore;
 use miden_node_utils::clap::GrpcOptionsInternal;
 use miden_node_utils::panic::catch_panic_layer_fn;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
@@ -65,6 +66,10 @@ impl ValidatorServer {
         .await
         .context("failed to initialize validator database")?;
 
+        // Initialize block store.
+        let block_store =
+            BlockStore::load(self.data_directory.clone()).context("failed to load block store")?;
+
         // Load initial metrics from the database for the in-memory counters.
         let (initial_chain_tip, initial_tx_count, initial_block_count) = db
             .query("load_initial_metrics", |conn| {
@@ -94,6 +99,7 @@ impl ValidatorServer {
                 Validator::new(
                     self.signer,
                     db,
+                    block_store,
                     initial_chain_tip,
                     initial_tx_count,
                     initial_block_count,

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -67,8 +67,8 @@ impl ValidatorServer {
         .context("failed to initialize validator database")?;
 
         // Initialize block store.
-        let block_store =
-            BlockStore::load(self.data_directory.clone()).context("failed to load block store")?;
+        let block_store = BlockStore::load(self.data_directory.join("blocks").clone())
+            .context("failed to load block store")?;
 
         // Load initial metrics from the database for the in-memory counters.
         let (initial_chain_tip, initial_tx_count, initial_block_count) = db

--- a/bin/validator/src/server/validator/mod.rs
+++ b/bin/validator/src/server/validator/mod.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64};
 
 use miden_node_db::{DatabaseError, Db};
+use miden_node_store::BlockStore;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
-use miden_protocol::block::{BlockHeader, BlockNumber, ProposedBlock};
+use miden_protocol::block::{BlockHeader, BlockNumber, ProposedBlock, SignedBlock};
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::{PublicKey, Signature};
+use miden_protocol::crypto::utils::Serializable;
 use miden_protocol::errors::ProposedBlockError;
 use miden_protocol::transaction::{TransactionHeader, TransactionId};
 use tokio::sync::Semaphore;
@@ -48,6 +50,8 @@ pub enum ValidatorError {
     ValidatorKeyMismatch { expected: PublicKey, actual: PublicKey },
     #[error("no chain tip exists")]
     NoChainTip,
+    #[error("failed to backup block")]
+    BlockBackupFailed(#[source] std::io::Error),
 }
 
 // VALIDATOR
@@ -59,6 +63,7 @@ pub enum ValidatorError {
 pub(crate) struct Validator {
     signer: ValidatorSigner,
     db: Arc<Db>,
+    block_store: BlockStore,
     /// Serializes `sign_block` requests so that concurrent calls are processed sequentially,
     /// ensuring consistent chain tip reads and preventing race conditions.
     sign_block_semaphore: Semaphore,
@@ -74,6 +79,7 @@ impl Validator {
     pub(crate) async fn new(
         signer: ValidatorSigner,
         db: Db,
+        block_store: BlockStore,
         initial_chain_tip: u32,
         initial_tx_count: u64,
         initial_block_count: u64,
@@ -97,6 +103,7 @@ impl Validator {
         Ok(Self {
             signer,
             db: db.into(),
+            block_store,
             sign_block_semaphore: Semaphore::new(1),
             chain_tip: AtomicU32::new(initial_chain_tip),
             validated_transactions_count: AtomicU64::new(initial_tx_count),
@@ -135,7 +142,7 @@ impl Validator {
         }
 
         // Build the block header.
-        let (proposed_header, _) = proposed_block
+        let (proposed_header, proposed_body) = proposed_block
             .into_header_and_body()
             .map_err(ValidatorError::BlockBuildingFailed)?;
 
@@ -186,7 +193,16 @@ impl Validator {
         }
 
         let signature = self.sign_header(&proposed_header).await?;
-        Ok((signature, proposed_header))
+
+        // Back up the signed block to disk.
+        let signed_block = SignedBlock::new_unchecked(proposed_header, proposed_body, signature);
+        self.block_store
+            .save_block(signed_block.header().block_num(), &signed_block.to_bytes())
+            .await
+            .map_err(ValidatorError::BlockBackupFailed)?;
+
+        let (header, _, signature) = signed_block.into_parts();
+        Ok((signature, header))
     }
 
     /// Signs a block header using the validator's signer.

--- a/bin/validator/src/server/validator/mod.rs
+++ b/bin/validator/src/server/validator/mod.rs
@@ -196,13 +196,21 @@ impl Validator {
 
         // Back up the signed block to disk.
         let signed_block = SignedBlock::new_unchecked(proposed_header, proposed_body, signature);
-        self.block_store
-            .save_block(signed_block.header().block_num(), &signed_block.to_bytes())
-            .await
-            .map_err(ValidatorError::BlockBackupFailed)?;
+        // Ignore errors; we don't want to fail the block validation if the block cannot be backed
+        // up. The span of the function will record any errors that occur during backup.
+        let _ = self.save_block(&signed_block).await;
 
         let (header, _, signature) = signed_block.into_parts();
         Ok((signature, header))
+    }
+
+    /// Saves a signed block to disk.
+    #[instrument(target = COMPONENT, name = "save_block", skip_all, err, fields(block.number = block.header().block_num().as_u32()))]
+    async fn save_block(&self, block: &SignedBlock) -> Result<(), ValidatorError> {
+        self.block_store
+            .save_block(block.header().block_num(), &block.to_bytes())
+            .await
+            .map_err(ValidatorError::BlockBackupFailed)
     }
 
     /// Signs a block header using the validator's signer.

--- a/bin/validator/src/server/validator/tests.rs
+++ b/bin/validator/src/server/validator/tests.rs
@@ -89,7 +89,8 @@ async fn setup_db_with_genesis(key: &SigningKey) -> (miden_node_db::Db, BlockSto
 
     let dir = tempfile::tempdir().unwrap();
     let db = setup(dir.path().join("validator.sqlite3")).await.unwrap();
-    let block_store = BlockStore::bootstrap(dir.path().to_path_buf(), &genesis_block).unwrap();
+    let block_store =
+        BlockStore::bootstrap(dir.path().join("blocks").clone(), &genesis_block).unwrap();
 
     db.transact("upsert_genesis", {
         let h = genesis_header.clone();

--- a/bin/validator/src/server/validator/tests.rs
+++ b/bin/validator/src/server/validator/tests.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use miden_node_proto::generated::validator::api_server;
 use miden_node_proto::generated::{self as proto};
-use miden_node_store::GenesisState;
+use miden_node_store::{BlockStore, GenesisState};
 use miden_node_utils::fee::test_fee_params;
 use miden_protocol::Word;
 use miden_protocol::block::{BlockHeader, BlockInputs, ProposedBlock};
@@ -32,10 +32,10 @@ impl TestValidator {
     async fn new() -> Self {
         let key = random_secret_key();
         let signer = ValidatorSigner::new_local(key.clone());
-        let (db, genesis_header) = setup_db_with_genesis(&key).await;
+        let (db, block_store, genesis_header) = setup_db_with_genesis(&key).await;
 
         Self {
-            server: Validator::new(signer, db, 0, 0, 0).await.unwrap(),
+            server: Validator::new(signer, db, block_store, 0, 0, 0).await.unwrap(),
             chain: PartialBlockchain::default(),
             chain_tip: genesis_header,
         }
@@ -82,13 +82,14 @@ impl TestValidator {
 
 /// Creates a validator database seeded with a genesis block whose `validator_key` is the public key
 /// of `key`. Returns the database handle and the genesis block header.
-async fn setup_db_with_genesis(key: &SigningKey) -> (miden_node_db::Db, BlockHeader) {
+async fn setup_db_with_genesis(key: &SigningKey) -> (miden_node_db::Db, BlockStore, BlockHeader) {
     let genesis_state = GenesisState::new(vec![], test_fee_params(), 1, 0, key.public_key());
     let genesis_block = genesis_state.into_block(key).unwrap();
     let genesis_header = genesis_block.inner().header().clone();
 
     let dir = tempfile::tempdir().unwrap();
     let db = setup(dir.path().join("validator.sqlite3")).await.unwrap();
+    let block_store = BlockStore::bootstrap(dir.path().to_path_buf(), &genesis_block).unwrap();
 
     db.transact("upsert_genesis", {
         let h = genesis_header.clone();
@@ -97,7 +98,7 @@ async fn setup_db_with_genesis(key: &SigningKey) -> (miden_node_db::Db, BlockHea
     .await
     .unwrap();
 
-    (db, genesis_header)
+    (db, block_store, genesis_header)
 }
 
 /// Builds an empty [`ProposedBlock`] that extends the given parent block header using the provided
@@ -123,7 +124,7 @@ fn empty_block(parent_header: &BlockHeader, chain: &PartialBlockchain) -> Propos
 async fn signing_key_mismatch_rejected() {
     // Seed a database whose genesis designates `genesis_key` as the validator key.
     let genesis_key = random_secret_key();
-    let (db, genesis_header) = setup_db_with_genesis(&genesis_key).await;
+    let (db, block_store, genesis_header) = setup_db_with_genesis(&genesis_key).await;
 
     // Start a validator with a different key, modelling a validator configured with the wrong key.
     let rogue_signer = ValidatorSigner::new_local(random_secret_key());
@@ -133,7 +134,7 @@ async fn signing_key_mismatch_rejected() {
         "test requires a signing key that differs from the genesis validator key",
     );
 
-    let result = Validator::new(rogue_signer, db, 0, 0, 0).await;
+    let result = Validator::new(rogue_signer, db, block_store, 0, 0, 0).await;
     assert!(
         matches!(result, Err(ValidatorError::ValidatorKeyMismatch { .. })),
         "expected ValidatorKeyMismatch error",

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -196,21 +196,13 @@ impl ValidatorService {
 
         // Back up the signed block to disk.
         let signed_block = SignedBlock::new_unchecked(proposed_header, proposed_body, signature);
-        // Ignore errors; we don't want to fail the block validation if the block cannot be backed
-        // up. The span of the function will record any errors that occur during backup.
-        let _ = self.save_block(&signed_block).await;
+        self.block_store
+            .save_block(signed_block.header().block_num(), &signed_block.to_bytes())
+            .await
+            .map_err(ValidatorError::BlockBackupFailed)?;
 
         let (header, _, signature) = signed_block.into_parts();
         Ok((signature, header))
-    }
-
-    /// Saves a signed block to disk.
-    #[instrument(target = COMPONENT, name = "save_block", skip_all, err, fields(block.number = block.header().block_num().as_u32()))]
-    async fn save_block(&self, block: &SignedBlock) -> Result<(), ValidatorError> {
-        self.block_store
-            .save_block(block.header().block_num(), &block.to_bytes())
-            .await
-            .map_err(ValidatorError::BlockBackupFailed)
     }
 
     /// Signs a block header using the validator's signer.

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -11,6 +11,7 @@ pub mod state;
 #[cfg(feature = "rocksdb")]
 pub use accounts::PersistentAccountTree;
 pub use accounts::{AccountTreeWithHistory, HistoricalError, InMemoryAccountTree};
+pub use blocks::BlockStore;
 pub use data_directory::DataDirectory;
 pub use db::models::conv::SqlTypeConvert;
 pub use db::models::queries::StorageMapValuesPage;


### PR DESCRIPTION
Stacked PR.

Relates to #2169.

Validator storing blocks via `run-node.sh`:
```
/tmp/validator 
➜ ls blocks/0000/
block_00000000.dat	block_00000002.dat	block_00000004.dat	block_00000006.dat	block_00000008.dat
block_00000001.dat	block_00000003.dat	block_00000005.dat	block_00000007.dat	block_00000009.dat
```