### PR TITLE
feat: enable TLS for gRPC clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed the store dropping a fungible asset's callback flag when applying partial account deltas ([#2222](https://github.com/0xMiden/node/pull/2222)).
 - Improved `GetAccount` performance if number of vault assets exceeds the limit. ([#2227](https://github.com/0xMiden/node/pull/2227)).
 - Improved `GetAccount` performance if number of storage map entries exceeds the limit. ([#2228](https://github.com/0xMiden/node/pull/2228)).
-
+- Enabled TLS support for gRPC clients ([#2233](https://github.com/0xMiden/node/pull/2233)).
 
 ## v0.15.0-rc.4 (2026-06-09)
 

--- a/bin/node/src/commands/modes.rs
+++ b/bin/node/src/commands/modes.rs
@@ -60,8 +60,8 @@ impl SequencerCommand {
         let rpc = Rpc {
             listener: bind_rpc(runtime.rpc_listen).await?,
             store: state,
-            mode: RpcMode::sequencer(block_producer, self.external_services.validator_client()),
-            ntx_builder: Some(self.external_services.ntx_builder_client()),
+            mode: RpcMode::sequencer(block_producer, self.external_services.validator_client()?),
+            ntx_builder: Some(self.external_services.ntx_builder_client()?),
             grpc_options: runtime.external_grpc_options,
             network_tx_auth,
         };
@@ -85,24 +85,24 @@ pub struct SequencerExternalServiceOptions {
 }
 
 impl SequencerExternalServiceOptions {
-    fn validator_client(&self) -> ValidatorClient {
-        Builder::new(self.validator_url.clone())
-            .without_tls()
+    fn validator_client(&self) -> anyhow::Result<ValidatorClient> {
+        Ok(Builder::new(self.validator_url.clone())
+            .with_tls()?
             .without_timeout()
             .without_metadata_version()
             .without_metadata_genesis()
             .with_otel_context_injection()
-            .connect_lazy::<ValidatorClient>()
+            .connect_lazy::<ValidatorClient>())
     }
 
-    fn ntx_builder_client(&self) -> NtxBuilderClient {
-        Builder::new(self.ntx_builder_url.clone())
-            .without_tls()
+    fn ntx_builder_client(&self) -> anyhow::Result<NtxBuilderClient> {
+        Ok(Builder::new(self.ntx_builder_url.clone())
+            .with_tls()?
             .without_timeout()
             .without_metadata_version()
             .without_metadata_genesis()
             .with_otel_context_injection()
-            .connect_lazy::<NtxBuilderClient>()
+            .connect_lazy::<NtxBuilderClient>())
     }
 }
 
@@ -121,7 +121,7 @@ pub struct FullNodeCommand {
 impl FullNodeCommand {
     pub async fn handle(self) -> anyhow::Result<()> {
         let runtime = self.runtime.runtime_config(&self.store);
-        let source_rpc = self.sync.source_rpc_client();
+        let source_rpc = self.sync.source_rpc_client()?;
         let network_tx_auth = self.runtime.rpc.network_tx_auth()?;
         let state = load_state(&runtime).await?;
         let _disk_monitor = state.spawn_disk_monitor();
@@ -142,14 +142,14 @@ impl FullNodeCommand {
 }
 
 impl SyncOptions {
-    fn source_rpc_client(&self) -> RpcClient {
-        Builder::new(self.block_source_url.clone())
-            .without_tls()
+    fn source_rpc_client(&self) -> anyhow::Result<RpcClient> {
+        Ok(Builder::new(self.block_source_url.clone())
+            .with_tls()?
             .without_timeout()
             .without_metadata_version()
             .without_metadata_genesis()
             .with_otel_context_injection()
-            .connect_lazy::<RpcClient>()
+            .connect_lazy::<RpcClient>())
     }
 }
 

--- a/bin/ntx-builder/src/actor/mod.rs
+++ b/bin/ntx-builder/src/actor/mod.rs
@@ -155,7 +155,8 @@ impl AccountActorContext {
                     miden_protocol::Word::default(),
                     Duration::from_millis(100),
                     Duration::from_secs(30),
-                ),
+                )
+                .expect("rpc client should be constructed"),
                 prover: RemoteTransactionProver::new(url.as_str()),
             },
             state: State {

--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -61,7 +61,7 @@ impl RpcClient {
         genesis_commitment: Word,
         backoff_initial: Duration,
         backoff_max: Duration,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         Self::new_with_auth(rpc_url, None, genesis_commitment, backoff_initial, backoff_max)
     }
 
@@ -75,11 +75,11 @@ impl RpcClient {
         genesis_commitment: Word,
         backoff_initial: Duration,
         backoff_max: Duration,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         info!(target: COMPONENT, rpc_endpoint = %rpc_url, "Initializing RPC client");
 
         let builder = Builder::new(rpc_url)
-            .without_tls()
+            .with_tls()?
             .without_timeout()
             .without_metadata_version()
             .with_metadata_genesis(genesis_commitment.to_hex());
@@ -91,7 +91,7 @@ impl RpcClient {
 
         let backoff = retry::exponential(backoff_initial, backoff_max);
 
-        Self { inner: rpc, backoff }
+        Ok(Self { inner: rpc, backoff })
     }
 
     /// Opens a committed-block subscription starting at `block_from`, retrying indefinitely with

--- a/bin/ntx-builder/src/lib.rs
+++ b/bin/ntx-builder/src/lib.rs
@@ -397,7 +397,7 @@ impl NtxBuilderConfig {
                 self.request_backoff_initial,
                 self.request_backoff_max,
             ),
-        };
+        }?;
 
         // The database is bootstrapped with the genesis block before startup (see
         // `miden-ntx-builder bootstrap`), so a persisted chain state is always present. Load it and

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -101,7 +101,7 @@ impl Sequencer {
     pub async fn spawn(self) -> Result<SequencerHandle> {
         info!(target: COMPONENT, "Initializing sequencer");
         let store = self.store;
-        let validator = BlockProducerValidatorClient::new(self.validator_url.clone());
+        let validator = BlockProducerValidatorClient::new(self.validator_url.clone())?;
         let chain_tip = store.chain_tip(Finality::Committed).await;
 
         info!(target: COMPONENT, "Sequencer initialized");

--- a/crates/block-producer/src/validator/mod.rs
+++ b/crates/block-producer/src/validator/mod.rs
@@ -35,18 +35,18 @@ pub struct BlockProducerValidatorClient {
 
 impl BlockProducerValidatorClient {
     /// Creates a new validator client with a lazy connection.
-    pub fn new(validator_url: Url) -> Self {
+    pub fn new(validator_url: Url) -> anyhow::Result<Self> {
         info!(target: COMPONENT, validator_endpoint = %validator_url, "Initializing validator client");
 
         let validator = Builder::new(validator_url)
-            .without_tls()
+            .with_tls()?
             .without_timeout()
             .without_metadata_version()
             .without_metadata_genesis()
             .with_otel_context_injection()
             .connect_lazy::<ValidatorClient>();
 
-        Self { client: validator }
+        Ok(Self { client: validator })
     }
 
     /// Signs the proposed block via the validator, returning the signature and the block commitment

--- a/crates/proto/src/clients/mod.rs
+++ b/crates/proto/src/clients/mod.rs
@@ -30,12 +30,11 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
 use http::header::ACCEPT;
 use miden_node_utils::tracing::grpc::OtelInterceptor;
 use tonic::metadata::AsciiMetadataValue;
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Error as TransportError};
 use tonic::{Request, Status};
 use url::Url;
 
@@ -375,11 +374,8 @@ impl Builder<WantsTls> {
     }
 
     /// Explicitly enable TLS.
-    pub fn with_tls(mut self) -> Result<Builder<WantsTimeout>> {
-        self.endpoint = self
-            .endpoint
-            .tls_config(ClientTlsConfig::new().with_native_roots())
-            .context("Failed to configure TLS")?;
+    pub fn with_tls(mut self) -> Result<Builder<WantsTimeout>, TransportError> {
+        self.endpoint = self.endpoint.tls_config(ClientTlsConfig::new().with_native_roots())?;
 
         Ok(self.next_state())
     }
@@ -460,7 +456,7 @@ impl Builder<WantsOTel> {
 
 impl Builder<WantsConnection> {
     /// Establish an eager connection and return a fully configured client.
-    pub async fn connect<T>(self) -> Result<T>
+    pub async fn connect<T>(self) -> Result<T, TransportError>
     where
         T: GrpcClient,
     {


### PR DESCRIPTION
This PR enables TLS support for all production gRPC clients. Without this change full nodes cannot connect to the upstream RPC server (as that is exposed exclusively over TLS).