### PR TITLE
ci: address workflow warnings

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -36,7 +36,7 @@ jobs:
       pages: write
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -53,14 +53,15 @@ jobs:
       - name: Setup Pages
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         id: pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload book artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # We specify multiple [output] sections in our book.toml which causes mdbook to create separate folders for each. This moves the generated `html` into its own `html` subdirectory.
           path: ./docs/internal/book/html
+          include-hidden-files: true
 
   # Deployment job only runs on push to next.
   deploy:
@@ -78,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - name: cargo build
         run: cargo build --workspace --all-targets --locked
@@ -106,6 +107,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - name: clippy
         run: cargo clippy --locked --all-targets --all-features --workspace -- -D warnings
@@ -126,6 +128,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - name: Build tests
         run: cargo nextest run --all-features --workspace --no-run
@@ -149,6 +152,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
@@ -170,6 +174,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - name: Build docs
         run: cargo doc --no-deps --workspace --all-features --locked
@@ -186,7 +191,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "22.18.0"
           cache: "npm"
@@ -215,6 +220,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
@@ -265,6 +271,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: warpbuild
           save-if: ${{ env.SAVE_CACHE }}
       - name: cargo build
         run: |
@@ -290,9 +297,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "22.18.0"
+          package-manager-cache: false
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: typos@1.42.0
@@ -316,6 +324,7 @@ jobs:
         with:
           shared-key: ${{ github.job }}
           prefix-key: ${{ env.CACHE_PREFIX }}
+          cache-provider: github
           save-if: ${{ env.SAVE_CACHE }}
       - name: Install Markdown tools
         run: npm install --global prettier@3.8.3 markdownlint-cli2@0.22.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install binstall
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-binstall@1.16.6
+          tool: cargo-binstall
       - name: Install cargo-msrv
         run: cargo binstall --no-confirm cargo-msrv
       - name: Get manifest path for package

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish-debian-all.yml
+++ b/.github/workflows/publish-debian-all.yml
@@ -42,7 +42,7 @@ jobs:
       labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish-debian.yml
+++ b/.github/workflows/publish-debian.yml
@@ -33,7 +33,7 @@ jobs:
       labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/publish-external-docs.yml
+++ b/.github/workflows/publish-external-docs.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Send repository_dispatch to aggregator
-        uses: peter-evans/repository-dispatch@a628c95fd17070f003ea24579a56e6bc89b25766
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           # PAT (Personal Access Token) that grants permission to trigger the rebuild workflow at the docs repository
           token: ${{ secrets.DOCS_REPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,12 @@ jobs:
               | sort_by(.name)
             ' <<< "${metadata}"
           )"
-          publishable_crates="$(jq -r '[.packages[] | select(.publish != []) | .name] | sort | join(" ")' <<< "${metadata}")"
+          publishable_crates="$(
+            jq -c '
+              [.packages[] | select(.publish != []) | { name }]
+              | sort_by(.name)
+            ' <<< "${metadata}"
+          )"
 
           if [[ "${#versions[@]}" -ne 1 ]]; then
             printf '%s\n' "${versions[@]}"
@@ -112,13 +117,17 @@ jobs:
           fi
 
   check-crate-builds:
-    name: Check crate builds
+    name: cargo check ${{ matrix.name }}
     runs-on: warp-ubuntu-latest-x64-8x
     needs: preflight
     if: ${{ github.repository_owner == '0xMiden' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.preflight.outputs.publishable_crates) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.tag }}
           fetch-depth: 0
@@ -136,19 +145,13 @@ jobs:
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: release-dry-run-crates
+          cache-provider: warpbuild
           save-if: false
 
       - name: Check package builds
         env:
-          PUBLISHABLE_CRATES: ${{ needs.preflight.outputs.publishable_crates }}
-        run: |
-          set -euo pipefail
-
-          for crate in ${PUBLISHABLE_CRATES}; do
-            echo "::group::cargo check -p ${crate}"
-            cargo check -p "${crate}" --locked
-            echo "::endgroup::"
-          done
+          PACKAGE: ${{ matrix.name }}
+        run: cargo check -p "${PACKAGE}" --locked
 
   dry-run-crates:
     name: Dry-run crates.io publish
@@ -157,7 +160,7 @@ jobs:
     if: ${{ github.repository_owner == '0xMiden' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.tag }}
           fetch-depth: 0
@@ -169,6 +172,7 @@ jobs:
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: release-dry-run-crates
+          cache-provider: warpbuild
           save-if: false
 
       - name: Dry-run cargo publish without verification
@@ -189,7 +193,7 @@ jobs:
       RUSTUP_TOOLCHAIN: stable
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.tag }}
           fetch-depth: 0
@@ -207,12 +211,13 @@ jobs:
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           shared-key: release-msrv
+          cache-provider: warpbuild
           save-if: false
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
-          tool: cargo-binstall@1.16.6
+          tool: cargo-binstall
 
       - name: Install cargo-msrv
         run: cargo binstall --no-confirm cargo-msrv

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Address the warning annotations, mostly outdated pinned versions which run old nodejs.

Also improved the release workflow speed by running `cargo check -p` in a matrix instead of sequentially.