### PR TITLE
refactor(store/db): optimize indexes

### DIFF
--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -76,9 +76,10 @@ mod tests {
 
     use super::*;
 
-    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 1] = [SchemaHash::from_hex(
-        "d8f0b2f5c2d7011c2a806ebdb7ddf3d957a6edeed065ccf21019205ebc1a01a4",
-    )];
+    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 2] = [
+        SchemaHash::from_hex("d8f0b2f5c2d7011c2a806ebdb7ddf3d957a6edeed065ccf21019205ebc1a01a4"),
+        SchemaHash::from_hex("c68edd8e9f345926b9bde34e2651ca70ee5665ac10c0002f78f589647f7a0d11"),
+    ];
 
     #[test]
     fn migration_schema_hashes_are_stable() -> Result<()> {

--- a/crates/store/src/db/migrations/002_index_optimizations.sql
+++ b/crates/store/src/db/migrations/002_index_optimizations.sql
@@ -1,0 +1,58 @@
+-- Generic latest-account lookups and account-tree pagination.
+DROP INDEX IF EXISTS idx_accounts_latest;
+CREATE INDEX idx_accounts_latest_by_account
+    ON accounts(account_id)
+    WHERE is_latest = 1;
+-- Public-account pagination and public-account state-root pagination.
+CREATE INDEX idx_accounts_latest_public_by_account
+    ON accounts(account_id)
+    WHERE is_latest = 1 AND code_commitment IS NOT NULL;
+-- Network-account subset filtering.
+DROP INDEX IF EXISTS idx_accounts_network_type;
+CREATE INDEX idx_accounts_latest_network_by_account
+    ON accounts(account_id)
+    WHERE is_latest = 1 AND network_account_type = 1;
+-- Latest storage map lookups and update-old-latest paths.
+DROP INDEX IF EXISTS idx_account_storage_latest;
+DROP INDEX IF EXISTS idx_account_storage_map_latest_by_account_slot_key;
+CREATE INDEX idx_account_storage_map_latest_by_account_slot_key
+    ON account_storage_map_values(account_id, slot_name, key)
+    WHERE is_latest = 1;
+-- Latest vault lookups and update-old-latest paths.
+DROP INDEX IF EXISTS idx_vault_assets_latest;
+DROP INDEX IF EXISTS idx_account_vault_assets_latest_by_account_key;
+CREATE INDEX idx_account_vault_assets_latest_by_account_key
+    ON account_vault_assets(account_id, vault_key)
+    WHERE is_latest = 1;
+
+-- The current nullifier prefix sync query filters by `nullifier_prefix IN (...)`,
+-- filters a block range, orders by `block_num`, and returns `nullifier, block_num`.
+-- The existing `idx_nullifiers_prefix(nullifier_prefix)` cannot constrain the block
+-- range inside each prefix, so we replace it with a composite index.
+DROP INDEX IF EXISTS idx_nullifiers_prefix;
+CREATE INDEX idx_nullifiers_prefix_block_num
+    ON nullifiers(nullifier_prefix, block_num);
+DROP INDEX IF EXISTS idx_nullifiers_block_num;
+
+-- `insert_nullifiers_for_block` first updates notes by `nullifier IN (...)`, then
+-- inserts into `nullifiers`.  Since private notes have `nullifier IS NULL`, the
+-- current full `idx_notes_nullifier` should be partial instead.
+DROP INDEX IF EXISTS idx_notes_nullifier;
+CREATE INDEX idx_notes_public_nullifier
+    ON notes(nullifier)
+    WHERE nullifier IS NOT NULL;
+
+-- Unused indexes
+DROP INDEX IF EXISTS idx_accounts_created_at_block;
+DROP INDEX IF EXISTS idx_accounts_block_num;
+-- `idx_accounts_code_commitment` is not needed for `select_full_account`, because
+-- that query starts from `accounts` filtered by `account_id` and `is_latest`, then
+-- joins to `account_codes` by the `account_codes` primary key.
+DROP INDEX IF EXISTS idx_accounts_code_commitment;
+
+DROP INDEX IF EXISTS idx_notes_sender;
+DROP INDEX IF EXISTS idx_notes_target_account;
+-- The left join to `note_scripts` is reached from notes filtered by `note_id`,
+-- then probes `note_scripts` by its primary key.
+DROP INDEX IF EXISTS idx_notes_script_root;
+DROP INDEX IF EXISTS idx_notes_consumed_at;


### PR DESCRIPTION
## Summary

This PR removes unused indexes, redundant indexes and redundant columns from indexes. For some of the removed indexes we're adding a new composite index instead.

### Replace redundant `is_latest` partial indexes

Several current indexes include `is_latest` as an indexed column even though the index is already partial on `WHERE is_latest = 1`. That trailing column adds index width without adding selectivity for the current predicates. The accounts, vault, and storage query paths repeatedly filter `is_latest = true`; public-account pagination orders by `account_id`; network-account subset filters `account_id IN (...)`, `network_account_type = 1`, and `is_latest = true`; latest vault/storage updates filter by account and key.

### Replace nullifier prefix-only index with prefix+block index

The current nullifier prefix sync query filters by `nullifier_prefix IN (...)`, filters a block range, orders by `block_num`, and returns `nullifier, block_num`.  The existing `idx_nullifiers_prefix(nullifier_prefix)` cannot constrain the block range inside each prefix. 

### Make note-nullifier update index partial

`insert_nullifiers_for_block` first updates notes by `nullifier IN (...)`, then inserts into `nullifiers`.  Since private notes have `nullifier IS NULL`, the current full `idx_notes_nullifier` should be partial.

### Remove indexes whose supporting current query paths are gone

`idx_accounts_code_commitment` is not needed for `select_full_account`, because that query starts from `accounts` filtered by `account_id` and `is_latest`, then joins to `account_codes` by the `account_codes` primary key.

For notes, current sync uses `tag` and `committed_at`; note lookups use `note_id`; nullifier consumption uses `nullifier`; the left join to `note_scripts` is reached from notes filtered by `note_id`, then probes `note_scripts` by its primary key.  The code still inserts `network_note_type` and `target_account_id`, but I did not find a current reader using them. 

## Changelog

```toml
[[entry]]
scope       = "node"
impact      = "migration"
description = "Modified SQLite indexes to match our current query set"
```
