### PR TITLE
refactor(store/db): declare block_headers as WITHOUT ROWID

### DIFF
--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -76,9 +76,10 @@ mod tests {
 
     use super::*;
 
-    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 1] = [SchemaHash::from_hex(
-        "d8f0b2f5c2d7011c2a806ebdb7ddf3d957a6edeed065ccf21019205ebc1a01a4",
-    )];
+    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 2] = [
+        SchemaHash::from_hex("d8f0b2f5c2d7011c2a806ebdb7ddf3d957a6edeed065ccf21019205ebc1a01a4"),
+        SchemaHash::from_hex("c68edd8e9f345926b9bde34e2651ca70ee5665ac10c0002f78f589647f7a0d11"),
+    ];
 
     #[test]
     fn migration_schema_hashes_are_stable() -> Result<()> {

--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -76,9 +76,10 @@ mod tests {
 
     use super::*;
 
-    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 2] = [
+    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 3] = [
         SchemaHash::from_hex("d8f0b2f5c2d7011c2a806ebdb7ddf3d957a6edeed065ccf21019205ebc1a01a4"),
         SchemaHash::from_hex("c68edd8e9f345926b9bde34e2651ca70ee5665ac10c0002f78f589647f7a0d11"),
+        SchemaHash::from_hex("9dd91717599abe702e8727f72369ea78302154acf4fdaa5b0f811e405030c7d6"),
     ];
 
     #[test]

--- a/crates/store/src/db/migrations/002_index_optimizations.sql
+++ b/crates/store/src/db/migrations/002_index_optimizations.sql
@@ -1,0 +1,58 @@
+-- Generic latest-account lookups and account-tree pagination.
+DROP INDEX IF EXISTS idx_accounts_latest;
+CREATE INDEX idx_accounts_latest_by_account
+    ON accounts(account_id)
+    WHERE is_latest = 1;
+-- Public-account pagination and public-account state-root pagination.
+CREATE INDEX idx_accounts_latest_public_by_account
+    ON accounts(account_id)
+    WHERE is_latest = 1 AND code_commitment IS NOT NULL;
+-- Network-account subset filtering.
+DROP INDEX IF EXISTS idx_accounts_network_type;
+CREATE INDEX idx_accounts_latest_network_by_account
+    ON accounts(account_id)
+    WHERE is_latest = 1 AND network_account_type = 1;
+-- Latest storage map lookups and update-old-latest paths.
+DROP INDEX IF EXISTS idx_account_storage_latest;
+DROP INDEX IF EXISTS idx_account_storage_map_latest_by_account_slot_key;
+CREATE INDEX idx_account_storage_map_latest_by_account_slot_key
+    ON account_storage_map_values(account_id, slot_name, key)
+    WHERE is_latest = 1;
+-- Latest vault lookups and update-old-latest paths.
+DROP INDEX IF EXISTS idx_vault_assets_latest;
+DROP INDEX IF EXISTS idx_account_vault_assets_latest_by_account_key;
+CREATE INDEX idx_account_vault_assets_latest_by_account_key
+    ON account_vault_assets(account_id, vault_key)
+    WHERE is_latest = 1;
+
+-- The current nullifier prefix sync query filters by `nullifier_prefix IN (...)`,
+-- filters a block range, orders by `block_num`, and returns `nullifier, block_num`.
+-- The existing `idx_nullifiers_prefix(nullifier_prefix)` cannot constrain the block
+-- range inside each prefix, so we replace it with a composite index.
+DROP INDEX IF EXISTS idx_nullifiers_prefix;
+CREATE INDEX idx_nullifiers_prefix_block_num
+    ON nullifiers(nullifier_prefix, block_num);
+DROP INDEX IF EXISTS idx_nullifiers_block_num;
+
+-- `insert_nullifiers_for_block` first updates notes by `nullifier IN (...)`, then
+-- inserts into `nullifiers`.  Since private notes have `nullifier IS NULL`, the
+-- current full `idx_notes_nullifier` should be partial instead.
+DROP INDEX IF EXISTS idx_notes_nullifier;
+CREATE INDEX idx_notes_public_nullifier
+    ON notes(nullifier)
+    WHERE nullifier IS NOT NULL;
+
+-- Unused indexes
+DROP INDEX IF EXISTS idx_accounts_created_at_block;
+DROP INDEX IF EXISTS idx_accounts_block_num;
+-- `idx_accounts_code_commitment` is not needed for `select_full_account`, because
+-- that query starts from `accounts` filtered by `account_id` and `is_latest`, then
+-- joins to `account_codes` by the `account_codes` primary key.
+DROP INDEX IF EXISTS idx_accounts_code_commitment;
+
+DROP INDEX IF EXISTS idx_notes_sender;
+DROP INDEX IF EXISTS idx_notes_target_account;
+-- The left join to `note_scripts` is reached from notes filtered by `note_id`,
+-- then probes `note_scripts` by its primary key.
+DROP INDEX IF EXISTS idx_notes_script_root;
+DROP INDEX IF EXISTS idx_notes_consumed_at;

--- a/crates/store/src/db/migrations/003_block_headers_without_rowid.sql
+++ b/crates/store/src/db/migrations/003_block_headers_without_rowid.sql
@@ -1,0 +1,30 @@
+-- Make `block_headers` a WITHOUT ROWID table. Due to SQLite not handling our BIGINT primary
+-- key as a row id `block_headers` was using a `rowid` under the hood. Declaring it explicitly
+-- as `WITHOUT ROWID` avoids that issue.
+CREATE TABLE block_headers_new (
+    block_num    BIGINT NOT NULL,
+    block_header BLOB   NOT NULL,
+    signature    BLOB   NOT NULL,
+    commitment   BLOB   NOT NULL,
+
+    PRIMARY KEY (block_num),
+    CONSTRAINT block_header_block_num_is_u32 CHECK (block_num BETWEEN 0 AND 0xFFFFFFFF)
+) WITHOUT ROWID;
+
+INSERT INTO block_headers_new (
+    block_num,
+    block_header,
+    signature,
+    commitment
+)
+SELECT
+    block_num,
+    block_header,
+    signature,
+    commitment
+FROM block_headers
+ORDER BY block_num;
+
+DROP TABLE block_headers;
+
+ALTER TABLE block_headers_new RENAME TO block_headers;


### PR DESCRIPTION
## Summary

This PR converts `block_headers` to a `WITHOUT ROWID` table.

Current key is `BIGINT PRIMARY KEY`, which in SQLite is not the special rowid alias. It therefore stores a hidden rowid plus a unique index on `block_num`. All current access is by `block_num`, latest `ORDER BY block_num DESC LIMIT 1`, `IN`, or full ordered scan.

## Changelog

```toml
[[entry]]
scope       = "node"
impact      = "migration"
description = "The block_headers table was converted to a WITHOUT ROWID table"
```
