### PR TITLE
Add `migration` changelog type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ reason    = "Internal change only."
 ```
 
 Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
-Allowed impacts: breaking, added, changed, fixed, removed, deprecated
+Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
 -->
 
 ```toml

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -55,6 +55,7 @@ enum Scope {
 #[serde(rename_all = "kebab-case")]
 enum Impact {
     Breaking,
+    Migration,
     Added,
     Changed,
     Fixed,
@@ -290,6 +291,19 @@ description = "Changed the RPC response shape."
 scope       = "node"
 impact      = "added"
 description = "Added a bootstrap command."
+"#,
+        );
+
+        verify_pr_body(&body).unwrap();
+    }
+
+    #[test]
+    fn accepts_migration_impact() {
+        let body = valid_body(
+            r#"[[entry]]
+scope       = "node"
+impact      = "migration"
+description = "Added a storage migration for node databases."
 "#,
         );
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Storage migrations did not have a clear changelog entry since they are not considered breaking; but should stand out for users since they are not rollbackable.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "internal"
impact      = "added"
description = "migration added to list of changelog impacts"
```
