### PR TITLE
refactor(rpc): use proper encode()/decode() for some methods

### DIFF
--- a/crates/proto/src/domain/account.rs
+++ b/crates/proto/src/domain/account.rs
@@ -139,6 +139,7 @@ impl TryFrom<proto::account::AccountStorageHeader> for AccountStorageHeader {
 // ================================================================================================
 
 /// Represents a request for an account proof.
+#[derive(Debug)]
 pub struct AccountRequest {
     pub account_id: AccountId,
     // If not present, the latest account proof references the latest available

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -1,4 +1,9 @@
-use miden_node_proto::domain::account::{AccountRequest, AccountStorageRequest, SlotData};
+use miden_node_proto::domain::account::{
+    AccountRequest,
+    AccountResponse,
+    AccountStorageRequest,
+    SlotData,
+};
 use miden_node_proto::generated as proto;
 use miden_node_store::GetAccountError;
 use miden_node_utils::limiter::QueryParamStorageMapKeyTotalLimit;
@@ -10,21 +15,19 @@ use super::{COMPONENT, RpcService, check};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetAccount for RpcService {
-    type Input = proto::rpc::AccountRequest;
-    type Output = proto::rpc::AccountResponse;
+    type Input = AccountRequest;
+    type Output = AccountResponse;
 
     fn decode(request: proto::rpc::AccountRequest) -> tonic::Result<Self::Input> {
-        Ok(request)
+        AccountRequest::try_from(request).map_err(Into::into)
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::rpc::AccountResponse> {
-        Ok(output)
+        Ok(output.into())
     }
 
-    async fn handle(&self, raw_request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, ?raw_request);
-
-        let request = AccountRequest::try_from(raw_request.clone())?;
+    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+        debug!(target: COMPONENT, ?request);
 
         let span = Span::current();
         span.set_attribute("account.id", request.account_id);
@@ -50,7 +53,7 @@ impl proto::server::rpc_api::GetAccount for RpcService {
 
         let account_data =
             self.store.get_account(request).await.map_err(get_account_error_to_status)?;
-        Ok(account_data.into())
+        Ok(account_data)
     }
 }
 

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -1,5 +1,6 @@
 use miden_node_proto::decode::read_root;
 use miden_node_proto::generated as proto;
+use miden_protocol::note::NoteScript;
 use tonic::Status;
 use tracing::debug;
 
@@ -8,14 +9,14 @@ use super::{COMPONENT, RpcService, database_error_to_status};
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
     type Input = proto::note::NoteScriptRoot;
-    type Output = proto::rpc::MaybeNoteScript;
+    type Output = Option<NoteScript>;
 
     fn decode(request: proto::note::NoteScriptRoot) -> tonic::Result<Self::Input> {
         Ok(request)
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::rpc::MaybeNoteScript> {
-        Ok(output)
+        Ok(proto::rpc::MaybeNoteScript { script: output.map(Into::into) })
     }
 
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
@@ -28,6 +29,6 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
             .await
             .map_err(|err| database_error_to_status(&err))?;
 
-        Ok(proto::rpc::MaybeNoteScript { script: script.map(Into::into) })
+        Ok(script)
     }
 }

--- a/crates/rpc/src/server/api/get_notes_by_id.rs
+++ b/crates/rpc/src/server/api/get_notes_by_id.rs
@@ -1,5 +1,6 @@
 use miden_node_proto::decode::convert_digests_to_words;
 use miden_node_proto::generated as proto;
+use miden_node_proto::generated::note::CommittedNote;
 use miden_node_store::NoteRecord;
 use miden_node_utils::limiter::QueryParamNoteIdLimit;
 use miden_protocol::Word;
@@ -13,14 +14,14 @@ use super::{COMPONENT, RpcService, check, database_error_to_status};
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetNotesById for RpcService {
     type Input = proto::note::NoteIdList;
-    type Output = proto::note::CommittedNoteList;
+    type Output = Vec<CommittedNote>;
 
     fn decode(request: proto::note::NoteIdList) -> tonic::Result<Self::Input> {
         Ok(request)
     }
 
-    fn encode(output: Self::Output) -> tonic::Result<proto::note::CommittedNoteList> {
-        Ok(output)
+    fn encode(notes: Self::Output) -> tonic::Result<proto::note::CommittedNoteList> {
+        Ok(proto::note::CommittedNoteList { notes })
     }
 
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
@@ -39,7 +40,7 @@ impl proto::server::rpc_api::GetNotesById for RpcService {
             .map(note_record_to_proto)
             .collect();
 
-        Ok(proto::note::CommittedNoteList { notes })
+        Ok(notes)
     }
 }
 


### PR DESCRIPTION

## Summary

The response message for these methods can be converted from a single domain type, so we can just make handle() return the domain type and do the conversion in encode()/decode().

Closes #1971

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```
