### PR TITLE
fix(store): fix compilation with Rust 1.96

### DIFF
--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -140,7 +140,7 @@ pub trait TreeStorageLoader: SmtStorage + Sized {
 /// For `ForestInMemoryBackend`, the forest is rebuilt from database entries on each startup. For
 /// `ForestPersistentBackend`, the forest is loaded directly from disk if data exists, otherwise it
 /// is rebuilt from the database and persisted.
-pub trait AccountForestLoader: Backend + Sized {
+pub(crate) trait AccountForestLoader: Backend + Sized {
     /// A configuration type for the implementation.
     type Config: std::fmt::Debug + std::default::Default;
 


### PR DESCRIPTION
## Summary

Compiling with Rust 1.96 fails with the following error:

```
error[E0446]: crate-private type `AccountStateForest<Self>` in public interface
   --> crates/store/src/state/loader.rs:159:10
    |
159 |     ) -> impl Future<Output = Result<AccountStateForest<Self>, StateInitializationError>> + Send;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
    |
   ::: crates/store/src/account_state_forest/mod.rs:93:1
    |
 93 | pub(crate) struct AccountStateForest<B: Backend = ForestInMemoryBackend> {
    | ------------------------------------------------------------------------ `AccountStateForest<Self>` declared as crate-private
```

This change makes the AccountForestLoader trait crate-private to fix the issue.

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```
