### PR TITLE
feat: Add ban list for slow clients

### DIFF
--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -33,6 +33,7 @@ use tonic::metadata::MetadataMap;
 use tonic::{IntoRequest, Request, Status};
 
 use crate::COMPONENT;
+use crate::server::api::subscription_ban::SubscriptionBan;
 use crate::server::{NetworkTxAuth, RpcMode};
 
 const NETWORK_TX_AUTH_HEADER_NAME: &str = "x-miden-network-tx-auth";
@@ -100,6 +101,7 @@ pub struct RpcService {
     block_commitment_cache: LruCache<BlockNumber, Word>,
     block_subscription_semaphore: Arc<Semaphore>,
     proof_subscription_semaphore: Arc<Semaphore>,
+    subscription_ban: Arc<SubscriptionBan>,
 }
 
 impl RpcService {
@@ -119,6 +121,7 @@ impl RpcService {
             block_commitment_cache: LruCache::new(commitment_cache_capacity),
             block_subscription_semaphore: Arc::new(Semaphore::new(MAX_REPLICA_SUBSCRIPTIONS)),
             proof_subscription_semaphore: Arc::new(Semaphore::new(MAX_REPLICA_SUBSCRIPTIONS)),
+            subscription_ban: Arc::new(SubscriptionBan::default()),
         }
     }
 
@@ -272,6 +275,7 @@ mod proof_subscription;
 mod status;
 mod submit_proven_tx;
 mod submit_proven_tx_batch;
+mod subscription_ban;
 mod sync_account_storage_maps;
 mod sync_account_vault;
 mod sync_chain_mmr;
@@ -318,6 +322,16 @@ fn state_subscription_error_to_status(err: StateSubscriptionError) -> Status {
             Status::resource_exhausted("subscriber is too slow to keep up with the chain")
         },
     }
+}
+
+/// Builds the status returned to a client that is temporarily banned from subscribing for having
+/// previously been disconnected as too slow.
+fn subscription_ban_status(remaining: Duration) -> Status {
+    Status::resource_exhausted(format!(
+        "temporarily banned from subscribing for being too slow; retry in {} seconds",
+        // Round up so the reported wait never undershoots the actual remaining ban.
+        remaining.as_secs() + 1,
+    ))
 }
 
 fn invalid_block_range_to_status(RpcInvalidBlockRange(err): RpcInvalidBlockRange) -> Status {

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -33,7 +33,7 @@ use tonic::metadata::MetadataMap;
 use tonic::{IntoRequest, Request, Status};
 
 use crate::COMPONENT;
-use crate::server::api::subscription_ban::SubscriptionBan;
+use crate::server::api::subscription_ban::IpBanList;
 use crate::server::{NetworkTxAuth, RpcMode};
 
 const NETWORK_TX_AUTH_HEADER_NAME: &str = "x-miden-network-tx-auth";
@@ -101,7 +101,7 @@ pub struct RpcService {
     block_commitment_cache: LruCache<BlockNumber, Word>,
     block_subscription_semaphore: Arc<Semaphore>,
     proof_subscription_semaphore: Arc<Semaphore>,
-    subscription_ban: Arc<SubscriptionBan>,
+    subscription_ban: Arc<IpBanList>,
 }
 
 impl RpcService {
@@ -121,7 +121,7 @@ impl RpcService {
             block_commitment_cache: LruCache::new(commitment_cache_capacity),
             block_subscription_semaphore: Arc::new(Semaphore::new(MAX_REPLICA_SUBSCRIPTIONS)),
             proof_subscription_semaphore: Arc::new(Semaphore::new(MAX_REPLICA_SUBSCRIPTIONS)),
-            subscription_ban: Arc::new(SubscriptionBan::default()),
+            subscription_ban: Arc::new(IpBanList::default()),
         }
     }
 

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
 use std::task::{Context as TaskContext, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Context as AnyhowContext;
 use miden_node_proto::clients::NtxBuilderClient;
@@ -326,7 +326,8 @@ fn state_subscription_error_to_status(err: StateSubscriptionError) -> Status {
 
 /// Builds the status returned to a client that is temporarily banned from subscribing for having
 /// previously been disconnected as too slow.
-fn subscription_ban_status(remaining: Duration) -> Status {
+fn subscription_ban_status(until: Instant) -> Status {
+    let remaining = until.saturating_duration_since(Instant::now());
     Status::resource_exhausted(format!(
         "temporarily banned from subscribing for being too slow; retry in {} seconds",
         // Round up so the reported wait never undershoots the actual remaining ban.

--- a/crates/rpc/src/server/api/block_subscription.rs
+++ b/crates/rpc/src/server/api/block_subscription.rs
@@ -1,10 +1,12 @@
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use miden_node_proto::generated as proto;
+use miden_node_store::state::StateSubscriptionError;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
-use tonic::Status;
+use tonic::{Request, Status};
 use tracing::{Span, debug};
 
 use super::{
@@ -13,39 +15,70 @@ use super::{
     GuardedStream,
     RpcService,
     state_subscription_error_to_status,
+    subscription_ban_status,
 };
+
+pub struct BlockSubscriptionInput {
+    request: proto::rpc::BlockSubscriptionRequest,
+    client_ip: Option<IpAddr>,
+}
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::BlockSubscription for RpcService {
-    type Input = proto::rpc::BlockSubscriptionRequest;
+    type Input = BlockSubscriptionInput;
     type Item = proto::rpc::BlockSubscriptionResponse;
     type ItemStream = BlockSubscriptionStream;
 
     fn decode(request: proto::rpc::BlockSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(request)
+        Ok(BlockSubscriptionInput { request, client_ip: None })
     }
 
     fn encode(item: Self::Item) -> tonic::Result<proto::rpc::BlockSubscriptionResponse> {
         Ok(item)
     }
 
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
+    async fn full(
+        &self,
+        request: Request<proto::rpc::BlockSubscriptionRequest>,
+    ) -> tonic::Result<Self::ItemStream> {
+        let client_ip = request.remote_addr().map(|addr| addr.ip());
+        let mut input = Self::decode(request.into_inner())?;
+        input.client_ip = client_ip;
+        self.handle(input).await
+    }
+
+    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream> {
+        let BlockSubscriptionInput { request, client_ip } = input;
         Span::current().set_attribute("block.from", request.block_from);
 
         debug!(target: COMPONENT, ?request);
+
+        // Reject clients that were recently disconnected for being too slow.
+        if let Some(remaining) = client_ip.and_then(|ip| self.subscription_ban.remaining(ip)) {
+            return Err(subscription_ban_status(remaining));
+        }
 
         let permit = Arc::clone(&self.block_subscription_semaphore)
             .try_acquire_owned()
             .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
 
         let from = BlockNumber::from(request.block_from);
-        let stream = self.store.block_subscription(from).map(|event| {
+        let ban = Arc::clone(&self.subscription_ban);
+        let stream = self.store.block_subscription(from).map(move |event| {
             event
                 .map(|event| proto::rpc::BlockSubscriptionResponse {
                     block: event.block,
                     committed_chain_tip: event.committed_chain_tip.as_u32(),
                 })
-                .map_err(state_subscription_error_to_status)
+                .map_err(|err| {
+                    // Ban slow subscribers so they cannot immediately reconnect and re-stall.
+                    if matches!(err, StateSubscriptionError::TooSlow) {
+                        if let Some(ip) = client_ip {
+                            ban.ban(ip);
+                        }
+                    }
+                    state_subscription_error_to_status(err)
+                })
         });
         let stream: Self::ItemStream = Box::pin(GuardedStream::new(Box::pin(stream), permit));
         Ok(stream)

--- a/crates/rpc/src/server/api/block_subscription.rs
+++ b/crates/rpc/src/server/api/block_subscription.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 
 use miden_node_proto::generated as proto;
 use miden_node_store::state::StateSubscriptionError;
-use miden_node_utils::{grpc::ClientIp, tracing::OpenTelemetrySpanExt};
+use miden_node_utils::grpc::ClientIp;
+use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
 use tonic::{Request, Status};
@@ -63,7 +64,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
             .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
 
         let from = BlockNumber::from(request.block_from);
-        let ban = Arc::clone(&self.subscription_ban);
+        let ban_list = Arc::clone(&self.subscription_ban);
         let stream = self.store.block_subscription(from).map(move |event| {
             event
                 .map(|event| proto::rpc::BlockSubscriptionResponse {
@@ -74,7 +75,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
                     // Ban slow subscribers so they cannot immediately reconnect and re-stall.
                     if matches!(err, StateSubscriptionError::TooSlow) {
                         if let Some(ip) = client_ip {
-                            ban.ban(ip);
+                            ban_list.ban(ip);
                         }
                     }
                     state_subscription_error_to_status(err)

--- a/crates/rpc/src/server/api/block_subscription.rs
+++ b/crates/rpc/src/server/api/block_subscription.rs
@@ -55,8 +55,8 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         debug!(target: COMPONENT, ?request);
 
         // Reject clients that were recently disconnected for being too slow.
-        if let Some(remaining) = client_ip.and_then(|ip| self.subscription_ban.remaining(ip)) {
-            return Err(subscription_ban_status(remaining));
+        if let Some(until) = client_ip.and_then(|ip| self.subscription_ban.banned_until(ip)) {
+            return Err(subscription_ban_status(until));
         }
 
         let permit = Arc::clone(&self.block_subscription_semaphore)
@@ -75,7 +75,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
                     // Ban slow subscribers so they cannot immediately reconnect and re-stall.
                     if matches!(err, StateSubscriptionError::TooSlow) {
                         if let Some(ip) = client_ip {
-                            ban_list.ban(ip);
+                            ban_list.add(ip);
                         }
                     }
                     state_subscription_error_to_status(err)

--- a/crates/rpc/src/server/api/block_subscription.rs
+++ b/crates/rpc/src/server/api/block_subscription.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use miden_node_proto::generated as proto;
 use miden_node_store::state::StateSubscriptionError;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
+use miden_node_utils::{grpc::ClientIp, tracing::OpenTelemetrySpanExt};
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
 use tonic::{Request, Status};
@@ -41,7 +41,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         &self,
         request: Request<proto::rpc::BlockSubscriptionRequest>,
     ) -> tonic::Result<Self::ItemStream> {
-        let client_ip = request.remote_addr().map(|addr| addr.ip());
+        let client_ip = ClientIp::from_request(&request);
         let mut input = Self::decode(request.into_inner())?;
         input.client_ip = client_ip;
         self.handle(input).await

--- a/crates/rpc/src/server/api/proof_subscription.rs
+++ b/crates/rpc/src/server/api/proof_subscription.rs
@@ -1,10 +1,12 @@
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use miden_node_proto::generated as proto;
+use miden_node_store::state::StateSubscriptionError;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
-use tonic::Status;
+use tonic::{Request, Status};
 use tracing::{Span, debug};
 
 use super::{
@@ -13,40 +15,71 @@ use super::{
     ProofSubscriptionStream,
     RpcService,
     state_subscription_error_to_status,
+    subscription_ban_status,
 };
+
+pub struct ProofSubscriptionInput {
+    request: proto::rpc::ProofSubscriptionRequest,
+    client_ip: Option<IpAddr>,
+}
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::ProofSubscription for RpcService {
-    type Input = proto::rpc::ProofSubscriptionRequest;
+    type Input = ProofSubscriptionInput;
     type Item = proto::rpc::ProofSubscriptionResponse;
     type ItemStream = ProofSubscriptionStream;
 
     fn decode(request: proto::rpc::ProofSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(request)
+        Ok(ProofSubscriptionInput { request, client_ip: None })
     }
 
     fn encode(item: Self::Item) -> tonic::Result<proto::rpc::ProofSubscriptionResponse> {
         Ok(item)
     }
 
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
+    async fn full(
+        &self,
+        request: Request<proto::rpc::ProofSubscriptionRequest>,
+    ) -> tonic::Result<Self::ItemStream> {
+        let client_ip = request.remote_addr().map(|addr| addr.ip());
+        let mut input = Self::decode(request.into_inner())?;
+        input.client_ip = client_ip;
+        self.handle(input).await
+    }
+
+    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream> {
+        let ProofSubscriptionInput { request, client_ip } = input;
         Span::current().set_attribute("block.from", request.block_from);
 
         debug!(target: COMPONENT, ?request);
+
+        // Reject clients that were recently disconnected for being too slow.
+        if let Some(remaining) = client_ip.and_then(|ip| self.subscription_ban.remaining(ip)) {
+            return Err(subscription_ban_status(remaining));
+        }
 
         let permit = Arc::clone(&self.proof_subscription_semaphore)
             .try_acquire_owned()
             .map_err(|_| Status::resource_exhausted("maximum proof subscriptions reached"))?;
 
         let from = BlockNumber::from(request.block_from);
-        let stream = self.store.proof_subscription(from).map(|event| {
+        let ban = Arc::clone(&self.subscription_ban);
+        let stream = self.store.proof_subscription(from).map(move |event| {
             event
                 .map(|event| proto::rpc::ProofSubscriptionResponse {
                     block_num: event.block_num.as_u32(),
                     proof: event.proof,
                     proven_chain_tip: event.proven_chain_tip.as_u32(),
                 })
-                .map_err(state_subscription_error_to_status)
+                .map_err(|err| {
+                    // Ban slow subscribers so they cannot immediately reconnect and re-stall.
+                    if matches!(err, StateSubscriptionError::TooSlow) {
+                        if let Some(ip) = client_ip {
+                            ban.ban(ip);
+                        }
+                    }
+                    state_subscription_error_to_status(err)
+                })
         });
         let stream: Self::ItemStream = Box::pin(GuardedStream::new(Box::pin(stream), permit));
         Ok(stream)

--- a/crates/rpc/src/server/api/proof_subscription.rs
+++ b/crates/rpc/src/server/api/proof_subscription.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 
 use miden_node_proto::generated as proto;
 use miden_node_store::state::StateSubscriptionError;
-use miden_node_utils::{grpc::ClientIp, tracing::OpenTelemetrySpanExt};
+use miden_node_utils::grpc::ClientIp;
+use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
 use tonic::{Request, Status};
@@ -63,7 +64,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
             .map_err(|_| Status::resource_exhausted("maximum proof subscriptions reached"))?;
 
         let from = BlockNumber::from(request.block_from);
-        let ban = Arc::clone(&self.subscription_ban);
+        let ban_list = Arc::clone(&self.subscription_ban);
         let stream = self.store.proof_subscription(from).map(move |event| {
             event
                 .map(|event| proto::rpc::ProofSubscriptionResponse {
@@ -75,7 +76,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
                     // Ban slow subscribers so they cannot immediately reconnect and re-stall.
                     if matches!(err, StateSubscriptionError::TooSlow) {
                         if let Some(ip) = client_ip {
-                            ban.ban(ip);
+                            ban_list.ban(ip);
                         }
                     }
                     state_subscription_error_to_status(err)

--- a/crates/rpc/src/server/api/proof_subscription.rs
+++ b/crates/rpc/src/server/api/proof_subscription.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use miden_node_proto::generated as proto;
 use miden_node_store::state::StateSubscriptionError;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
+use miden_node_utils::{grpc::ClientIp, tracing::OpenTelemetrySpanExt};
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
 use tonic::{Request, Status};
@@ -41,7 +41,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         &self,
         request: Request<proto::rpc::ProofSubscriptionRequest>,
     ) -> tonic::Result<Self::ItemStream> {
-        let client_ip = request.remote_addr().map(|addr| addr.ip());
+        let client_ip = ClientIp::from_request(&request);
         let mut input = Self::decode(request.into_inner())?;
         input.client_ip = client_ip;
         self.handle(input).await

--- a/crates/rpc/src/server/api/proof_subscription.rs
+++ b/crates/rpc/src/server/api/proof_subscription.rs
@@ -55,8 +55,8 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         debug!(target: COMPONENT, ?request);
 
         // Reject clients that were recently disconnected for being too slow.
-        if let Some(remaining) = client_ip.and_then(|ip| self.subscription_ban.remaining(ip)) {
-            return Err(subscription_ban_status(remaining));
+        if let Some(until) = client_ip.and_then(|ip| self.subscription_ban.banned_until(ip)) {
+            return Err(subscription_ban_status(until));
         }
 
         let permit = Arc::clone(&self.proof_subscription_semaphore)
@@ -76,7 +76,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
                     // Ban slow subscribers so they cannot immediately reconnect and re-stall.
                     if matches!(err, StateSubscriptionError::TooSlow) {
                         if let Some(ip) = client_ip {
-                            ban_list.ban(ip);
+                            ban_list.add(ip);
                         }
                     }
                     state_subscription_error_to_status(err)

--- a/crates/rpc/src/server/api/subscription_ban.rs
+++ b/crates/rpc/src/server/api/subscription_ban.rs
@@ -1,0 +1,136 @@
+use std::collections::VecDeque;
+use std::net::IpAddr;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// How long a slow subscriber is banned from re-subscribing after being disconnected.
+const BAN_DURATION: Duration = Duration::from_mins(10);
+
+/// Maximum number of banned clients tracked at once.
+const BAN_CAPACITY: usize = 100;
+
+/// A bounded, time-based ban list keyed by client IP.
+///
+/// Subscribers that are disconnected for being too slow are temporarily banned from re-subscribing.
+/// Entries are a simple FIFO queue of `(ip, expiry)` pairs. Because every ban uses the same fixed
+/// [`BAN_DURATION`], entries are naturally ordered by expiry, so the most recent ban for an IP is
+/// the last matching entry. Expired entries are not actively pruned; they are simply ignored on
+/// lookup and eventually evicted once the queue reaches capacity.
+#[derive(Debug)]
+pub struct SubscriptionBan {
+    banned: Mutex<VecDeque<(IpAddr, Instant)>>,
+    duration: Duration,
+    capacity: usize,
+}
+
+impl Default for SubscriptionBan {
+    fn default() -> Self {
+        Self::new(BAN_DURATION, BAN_CAPACITY)
+    }
+}
+
+impl SubscriptionBan {
+    fn new(duration: Duration, capacity: usize) -> Self {
+        Self {
+            banned: Mutex::new(VecDeque::new()),
+            duration,
+            capacity,
+        }
+    }
+
+    /// Bans `ip` for [`BAN_DURATION`] starting now.
+    ///
+    /// If the list is at capacity, the oldest entry is evicted first.
+    pub fn ban(&self, ip: IpAddr) {
+        let expiry = Instant::now() + self.duration;
+        let mut banned = self
+            .banned
+            .lock()
+            .expect("ban mutex should not be poisoned");
+        if banned.len() == self.capacity {
+            banned.pop_front();
+        }
+        banned.push_back((ip, expiry));
+    }
+
+    /// Returns the remaining ban duration for `ip`, or `None` if it is not currently banned.
+    pub fn remaining(&self, ip: IpAddr) -> Option<Duration> {
+        let now = Instant::now();
+        let banned = self
+            .banned
+            .lock()
+            .expect("ban mutex should not be poisoned");
+        // Entries are ordered by expiry, so the last match is the most recent (longest-lived) ban.
+        banned
+            .iter()
+            .rev()
+            .find(|(banned_ip, _)| *banned_ip == ip)
+            .map(|(_, expiry)| expiry.saturating_duration_since(now))
+            .filter(|remaining| !remaining.is_zero())
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    fn ip(n: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, n))
+    }
+
+    #[test]
+    fn unknown_ip_is_not_banned() {
+        let ban = SubscriptionBan::default();
+        assert!(ban.remaining(ip(1)).is_none());
+    }
+
+    #[test]
+    fn banned_ip_reports_remaining_time() {
+        let ban = SubscriptionBan::new(Duration::from_secs(600), 16);
+        ban.ban(ip(1));
+
+        let remaining = ban.remaining(ip(1)).expect("ip should be banned");
+        assert!(remaining <= Duration::from_secs(600));
+        assert!(ban.remaining(ip(2)).is_none());
+    }
+
+    #[test]
+    fn expired_ban_is_ignored() {
+        // A zero-length ban is already expired by the time it is queried.
+        let ban = SubscriptionBan::new(Duration::ZERO, 16);
+        ban.ban(ip(1));
+        assert!(ban.remaining(ip(1)).is_none());
+    }
+
+    #[test]
+    fn most_recent_ban_wins_over_stale_entry() {
+        let ban = SubscriptionBan::new(Duration::from_secs(600), 16);
+        let now = Instant::now();
+        {
+            let mut banned = ban.banned.lock().unwrap();
+            // A stale, already-expired entry followed by a fresh, live ban for the same IP. The
+            // live entry must take precedence over the leftover stale one.
+            banned.push_back((ip(1), now));
+            banned.push_back((ip(1), now + Duration::from_secs(600)));
+        }
+        assert!(ban.remaining(ip(1)).is_some());
+    }
+
+    #[test]
+    fn oldest_entry_is_evicted_at_capacity() {
+        let ban = SubscriptionBan::new(Duration::from_secs(600), 2);
+        ban.ban(ip(1));
+        ban.ban(ip(2));
+        ban.ban(ip(3));
+
+        // The first ban was evicted to make room for the third.
+        assert!(ban.remaining(ip(1)).is_none());
+        assert!(ban.remaining(ip(2)).is_some());
+        assert!(ban.remaining(ip(3)).is_some());
+    }
+}

--- a/crates/rpc/src/server/api/subscription_ban.rs
+++ b/crates/rpc/src/server/api/subscription_ban.rs
@@ -41,7 +41,7 @@ impl IpBanList {
     /// Bans `ip` for [`BAN_DURATION`] starting now.
     ///
     /// If the list is at capacity, the oldest entry is evicted first.
-    pub fn ban(&self, ip: IpAddr) {
+    pub fn add(&self, ip: IpAddr) {
         let expiry = Instant::now() + self.duration;
         let mut banned = self.banned.lock().expect("ban mutex should not be poisoned");
         if banned.len() == self.capacity {
@@ -50,8 +50,9 @@ impl IpBanList {
         banned.push_back((ip, expiry));
     }
 
-    /// Returns the remaining ban duration for `ip`, or `None` if it is not currently banned.
-    pub fn remaining(&self, ip: IpAddr) -> Option<Duration> {
+    /// Returns the [`Instant`] at which the ban for `ip` expires, or `None` if it is not currently
+    /// banned.
+    pub fn banned_until(&self, ip: IpAddr) -> Option<Instant> {
         let now = Instant::now();
         let banned = self.banned.lock().expect("ban mutex should not be poisoned");
         // Entries are ordered by expiry, so the last match is the most recent (longest-lived) ban.
@@ -59,8 +60,8 @@ impl IpBanList {
             .iter()
             .rev()
             .find(|(banned_ip, _)| *banned_ip == ip)
-            .map(|(_, expiry)| expiry.saturating_duration_since(now))
-            .filter(|remaining| !remaining.is_zero())
+            .map(|(_, expiry)| *expiry)
+            .filter(|expiry| *expiry > now)
     }
 }
 
@@ -80,25 +81,30 @@ mod tests {
     #[test]
     fn unknown_ip_is_not_banned() {
         let ban = IpBanList::default();
-        assert!(ban.remaining(ip(1)).is_none());
+        assert!(ban.banned_until(ip(1)).is_none());
     }
 
     #[test]
-    fn banned_ip_reports_remaining_time() {
+    fn banned_ip_reports_expiry() {
         let ban = IpBanList::new(Duration::from_secs(600), 16);
-        ban.ban(ip(1));
+        let before = Instant::now();
+        ban.add(ip(1));
+        let after = Instant::now();
 
-        let remaining = ban.remaining(ip(1)).expect("ip should be banned");
-        assert!(remaining <= Duration::from_secs(600));
-        assert!(ban.remaining(ip(2)).is_none());
+        // The ban expires `BAN_DURATION` after the instant it was added, which lies somewhere
+        // between `before` and `after`.
+        let until = ban.banned_until(ip(1)).expect("ip should be banned");
+        assert!(until >= before + Duration::from_secs(600));
+        assert!(until <= after + Duration::from_secs(600));
+        assert!(ban.banned_until(ip(2)).is_none());
     }
 
     #[test]
     fn expired_ban_is_ignored() {
         // A zero-length ban is already expired by the time it is queried.
         let ban = IpBanList::new(Duration::ZERO, 16);
-        ban.ban(ip(1));
-        assert!(ban.remaining(ip(1)).is_none());
+        ban.add(ip(1));
+        assert!(ban.banned_until(ip(1)).is_none());
     }
 
     #[test]
@@ -112,19 +118,19 @@ mod tests {
             banned.push_back((ip(1), now));
             banned.push_back((ip(1), now + Duration::from_secs(600)));
         }
-        assert!(ban.remaining(ip(1)).is_some());
+        assert!(ban.banned_until(ip(1)).is_some());
     }
 
     #[test]
     fn oldest_entry_is_evicted_at_capacity() {
         let ban = IpBanList::new(Duration::from_secs(600), 2);
-        ban.ban(ip(1));
-        ban.ban(ip(2));
-        ban.ban(ip(3));
+        ban.add(ip(1));
+        ban.add(ip(2));
+        ban.add(ip(3));
 
         // The first ban was evicted to make room for the third.
-        assert!(ban.remaining(ip(1)).is_none());
-        assert!(ban.remaining(ip(2)).is_some());
-        assert!(ban.remaining(ip(3)).is_some());
+        assert!(ban.banned_until(ip(1)).is_none());
+        assert!(ban.banned_until(ip(2)).is_some());
+        assert!(ban.banned_until(ip(3)).is_some());
     }
 }

--- a/crates/rpc/src/server/api/subscription_ban.rs
+++ b/crates/rpc/src/server/api/subscription_ban.rs
@@ -43,10 +43,7 @@ impl SubscriptionBan {
     /// If the list is at capacity, the oldest entry is evicted first.
     pub fn ban(&self, ip: IpAddr) {
         let expiry = Instant::now() + self.duration;
-        let mut banned = self
-            .banned
-            .lock()
-            .expect("ban mutex should not be poisoned");
+        let mut banned = self.banned.lock().expect("ban mutex should not be poisoned");
         if banned.len() == self.capacity {
             banned.pop_front();
         }
@@ -56,10 +53,7 @@ impl SubscriptionBan {
     /// Returns the remaining ban duration for `ip`, or `None` if it is not currently banned.
     pub fn remaining(&self, ip: IpAddr) -> Option<Duration> {
         let now = Instant::now();
-        let banned = self
-            .banned
-            .lock()
-            .expect("ban mutex should not be poisoned");
+        let banned = self.banned.lock().expect("ban mutex should not be poisoned");
         // Entries are ordered by expiry, so the last match is the most recent (longest-lived) ban.
         banned
             .iter()

--- a/crates/rpc/src/server/api/subscription_ban.rs
+++ b/crates/rpc/src/server/api/subscription_ban.rs
@@ -17,19 +17,19 @@ const BAN_CAPACITY: usize = 100;
 /// the last matching entry. Expired entries are not actively pruned; they are simply ignored on
 /// lookup and eventually evicted once the queue reaches capacity.
 #[derive(Debug)]
-pub struct SubscriptionBan {
+pub struct IpBanList {
     banned: Mutex<VecDeque<(IpAddr, Instant)>>,
     duration: Duration,
     capacity: usize,
 }
 
-impl Default for SubscriptionBan {
+impl Default for IpBanList {
     fn default() -> Self {
         Self::new(BAN_DURATION, BAN_CAPACITY)
     }
 }
 
-impl SubscriptionBan {
+impl IpBanList {
     fn new(duration: Duration, capacity: usize) -> Self {
         Self {
             banned: Mutex::new(VecDeque::new()),
@@ -79,13 +79,13 @@ mod tests {
 
     #[test]
     fn unknown_ip_is_not_banned() {
-        let ban = SubscriptionBan::default();
+        let ban = IpBanList::default();
         assert!(ban.remaining(ip(1)).is_none());
     }
 
     #[test]
     fn banned_ip_reports_remaining_time() {
-        let ban = SubscriptionBan::new(Duration::from_secs(600), 16);
+        let ban = IpBanList::new(Duration::from_secs(600), 16);
         ban.ban(ip(1));
 
         let remaining = ban.remaining(ip(1)).expect("ip should be banned");
@@ -96,14 +96,14 @@ mod tests {
     #[test]
     fn expired_ban_is_ignored() {
         // A zero-length ban is already expired by the time it is queried.
-        let ban = SubscriptionBan::new(Duration::ZERO, 16);
+        let ban = IpBanList::new(Duration::ZERO, 16);
         ban.ban(ip(1));
         assert!(ban.remaining(ip(1)).is_none());
     }
 
     #[test]
     fn most_recent_ban_wins_over_stale_entry() {
-        let ban = SubscriptionBan::new(Duration::from_secs(600), 16);
+        let ban = IpBanList::new(Duration::from_secs(600), 16);
         let now = Instant::now();
         {
             let mut banned = ban.banned.lock().unwrap();
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn oldest_entry_is_evicted_at_capacity() {
-        let ban = SubscriptionBan::new(Duration::from_secs(600), 2);
+        let ban = IpBanList::new(Duration::from_secs(600), 2);
         ban.ban(ip(1));
         ban.ban(ip(2));
         ban.ban(ip(3));

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -167,6 +167,9 @@ impl Rpc {
             .layer(GrpcWebLayer::new())
             .layer(grpc::rate_limit_concurrent_connections(self.grpc_options))
             .layer(grpc::rate_limit_per_ip(self.grpc_options)?)
+            // Resolve the (load-balancer-aware) client IP once here so handlers can read it from
+            // request extensions instead of re-deriving it from headers.
+            .layer(grpc::ResolveClientIpLayer)
             // Note: must come after the CORS layer, as otherwise accept rejections do _not_ get
             // CORS headers applied, masking the accept error in web-clients (which would experience
             // CORS rejection).

--- a/crates/utils/src/grpc/layers.rs
+++ b/crates/utils/src/grpc/layers.rs
@@ -1,9 +1,11 @@
 use std::net::{IpAddr, SocketAddr};
+use std::task::{Context as TaskContext, Poll};
 use std::time::Duration;
 
 use anyhow::{Context, ensure};
 use governor::middleware::StateInformationMiddleware;
 use tower::limit::GlobalConcurrencyLimitLayer;
+use tower::{Layer, Service};
 use tower_governor::GovernorError;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::key_extractor::{KeyExtractor, SmartIpKeyExtractor};
@@ -51,6 +53,66 @@ pub fn rate_limit_per_ip(
         }
     });
     Ok(tower_governor::GovernorLayer::new(config))
+}
+
+/// The originating client IP, resolved by [`ResolveClientIpLayer`] and stored in a request's
+/// extensions.
+///
+/// gRPC handlers can read this via `request.extensions().get::<ClientIp>()` to obtain the
+/// load-balancer-aware client address without re-implementing IP extraction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClientIp(pub IpAddr);
+
+impl ClientIp {
+    /// Returns the client IP resolved for `request` by [`ResolveClientIpLayer`], or `None` if it
+    /// could not be determined.
+    pub fn from_request<T>(request: &tonic::Request<T>) -> Option<IpAddr> {
+        request.extensions().get::<Self>().map(|ip| ip.0)
+    }
+}
+
+/// A [`tower::Layer`] that resolves the originating client IP and stores it in the request's
+/// extensions as [`ClientIp`].
+///
+/// IP resolution reuses [`GrpcIpExtractor`], so clients behind a load balancer or reverse proxy are
+/// identified by their forwarded IP (via `X-Forwarded-For` / `X-Real-Ip` / `Forwarded` headers),
+/// falling back to the peer address. Resolving once at the transport layer keeps this consistent
+/// with the per-IP rate limiter and lets handlers read the result instead of re-deriving it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResolveClientIpLayer;
+
+impl<S> Layer<S> for ResolveClientIpLayer {
+    type Service = ResolveClientIp<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ResolveClientIp { inner }
+    }
+}
+
+/// The service produced by [`ResolveClientIpLayer`].
+#[derive(Debug, Clone, Copy)]
+pub struct ResolveClientIp<S> {
+    inner: S,
+}
+
+impl<S, B> Service<http::Request<B>> for ResolveClientIp<S>
+where
+    S: Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
+        if let Ok(ip) = GrpcIpExtractor::default().extract(&request) {
+            request.extensions_mut().insert(ClientIp(ip));
+        }
+        self.inner.call(request)
+    }
 }
 
 /// Wraps [`SmartIpKeyExtractor`] by providing a fallback to the client IP address provided by the


### PR DESCRIPTION
## Summary

Adds a mechanism to `RpcService` to ban slow clients for a period of time for block and proof streaming endpoints.

Closes #2234.

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog


```toml
[[entry]]
scope = "node"
impact = "added"
description = "Slow subscribers are now timed out for 10 minutes"
```
