### PR TITLE
Add block stream to validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,7 +3175,9 @@ dependencies = [
  "miden-node-utils",
  "miden-protocol",
  "tokio",
+ "tokio-stream",
  "tonic",
+ "tracing",
  "url",
 ]
 

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -28,7 +28,9 @@ miden-node-store          = { workspace = true }
 miden-node-utils          = { workspace = true }
 miden-protocol            = { workspace = true }
 tokio                     = { features = ["macros", "net", "rt-multi-thread"], workspace = true }
+tokio-stream              = { workspace = true }
 tonic                     = { default-features = false, workspace = true }
+tracing                   = { workspace = true }
 url                       = { workspace = true }
 
 [dev-dependencies]

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -52,15 +52,17 @@ pub enum Command {
     /// Cannot be run on an empty data directory; use `bootstrap` first.
     Migrate(MigrateCommand),
 
-    /// Recover a full node's chain state from a validator's block backup.
+    /// Recover missing chain data from the validator.
     ///
-    /// Streams the validator's signed blocks into the local store until the chain tip is reached,
-    /// then exits. This is used to promote a full node to sequencer after the original sequencer is
-    /// lost: shut down the sequencer and the full node, run this command pointed at the validator,
-    /// then restart the full node as a sequencer.
+    /// Use this during emergency recovery, or before promoting a full node to sequencer,
+    /// to fill any committed blocks that the node did not receive from the sequencer.
     ///
-    /// Recovered blocks carry no proofs, so these must be commissioned separately as part of
-    /// recovery.
+    /// Full nodes receive sequencer data asynchronously, so if the sequencer fails they
+    /// may be missing the most recent committed blocks. The validator can be used as the
+    /// recovery source because every committed block must have been signed by the validator.
+    ///
+    /// This command synchronizes the node with the validator's committed chain state,
+    /// ensuring the node has a complete view of the chain before it is promoted.
     Recover(RecoverCommand),
 }
 

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod block_producer;
 mod lifecycle;
 mod modes;
+mod recover;
 mod rpc;
 mod runtime;
 pub(crate) mod section;
@@ -10,6 +11,7 @@ use clap::Subcommand;
 pub use lifecycle::{BootstrapCommand, MigrateCommand};
 use miden_node_utils::logging::OpenTelemetry;
 pub use modes::{FullNodeCommand, SequencerCommand};
+pub use recover::RecoverCommand;
 
 const ENV_DATA_DIRECTORY: &str = "MIDEN_NODE_DATA_DIRECTORY";
 
@@ -49,6 +51,17 @@ pub enum Command {
     ///
     /// Cannot be run on an empty data directory; use `bootstrap` first.
     Migrate(MigrateCommand),
+
+    /// Recover a full node's chain state from a validator's block backup.
+    ///
+    /// Streams the validator's signed blocks into the local store until the chain tip is reached,
+    /// then exits. This is used to promote a full node to sequencer after the original sequencer is
+    /// lost: shut down the sequencer and the full node, run this command pointed at the validator,
+    /// then restart the full node as a sequencer.
+    ///
+    /// Recovered blocks carry no proofs, so these must be commissioned separately as part of
+    /// recovery.
+    Recover(RecoverCommand),
 }
 
 impl Command {
@@ -60,7 +73,9 @@ impl Command {
             Command::Full(_) => OpenTelemetry::from_env()
                 .with_name("node")
                 .with_attribute("miden.node.role", "full"),
-            Command::Bootstrap(_) | Command::Migrate(_) => OpenTelemetry::Disabled,
+            Command::Bootstrap(_) | Command::Migrate(_) | Command::Recover(_) => {
+                OpenTelemetry::Disabled
+            },
         }
     }
 
@@ -70,6 +85,7 @@ impl Command {
             Command::Migrate(migrate_command) => migrate_command.handle(),
             Command::Sequencer(sequencer_command) => sequencer_command.handle().await,
             Command::Full(full_node_command) => full_node_command.handle().await,
+            Command::Recover(recover_command) => recover_command.handle().await,
         }
     }
 }

--- a/bin/node/src/commands/recover.rs
+++ b/bin/node/src/commands/recover.rs
@@ -19,18 +19,6 @@ use super::store::StoreOptions;
 // RECOVER
 // ================================================================================================
 
-/// Recovers a full node's chain state from a validator's block backup.
-///
-/// Streams the validator's signed blocks into the local store until the chain tip is reached, then
-/// exits. This is the first step in promoting a full node to sequencer after the original sequencer
-/// is lost:
-///
-/// 1. Shut down the sequencer (if it is not down already) and the designated full node.
-/// 2. Run this command, pointing it at the validator.
-/// 3. Restart the full node as a sequencer.
-///
-/// Recovered blocks carry no proofs (the validator only backs up signed blocks), so these must be
-/// commissioned separately as part of recovery.
 #[derive(clap::Args, Clone, Debug)]
 pub struct RecoverCommand {
     /// Directory containing the node's local data storage.

--- a/bin/node/src/commands/recover.rs
+++ b/bin/node/src/commands/recover.rs
@@ -1,0 +1,142 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use miden_node_proto::clients::{Builder, ValidatorClient};
+use miden_node_proto::generated::validator::BlockSubscriptionRequest;
+use miden_node_store::State;
+use miden_node_store::state::Finality;
+use miden_protocol::block::{BlockNumber, SignedBlock};
+use miden_protocol::utils::serde::Deserializable;
+use tokio_stream::StreamExt;
+use tracing::info;
+use url::Url;
+
+use super::ENV_DATA_DIRECTORY;
+use super::store::StoreOptions;
+
+// RECOVER
+// ================================================================================================
+
+/// Recovers a full node's chain state from a validator's block backup.
+///
+/// Streams the validator's signed blocks into the local store until the chain tip is reached, then
+/// exits. This is the first step in promoting a full node to sequencer after the original sequencer
+/// is lost:
+///
+/// 1. Shut down the sequencer (if it is not down already) and the designated full node.
+/// 2. Run this command, pointing it at the validator.
+/// 3. Restart the full node as a sequencer.
+///
+/// Recovered blocks carry no proofs (the validator only backs up signed blocks), so these must be
+/// commissioned separately as part of recovery.
+#[derive(clap::Args, Clone, Debug)]
+pub struct RecoverCommand {
+    /// Directory containing the node's local data storage.
+    #[arg(long, env = ENV_DATA_DIRECTORY, value_name = "DIR")]
+    data_directory: PathBuf,
+
+    /// The validator service gRPC URL to recover blocks from.
+    #[arg(long = "validator.url", env = "MIDEN_NODE_VALIDATOR_URL", value_name = "URL")]
+    validator_url: Url,
+
+    #[command(flatten)]
+    store: StoreOptions,
+}
+
+impl RecoverCommand {
+    pub async fn handle(self) -> anyhow::Result<()> {
+        let state = self.load_state().await?;
+        let validator = self.validator_client()?;
+        recover_from_validator(&state, validator).await
+    }
+
+    async fn load_state(&self) -> anyhow::Result<Arc<State>> {
+        let state = State::load_with_database_options(
+            &self.data_directory,
+            self.store.storage.clone().into(),
+            self.store.sqlite.database_options(),
+        )
+        .await
+        .context("failed to load state")?;
+
+        Ok(Arc::new(state))
+    }
+
+    fn validator_client(&self) -> anyhow::Result<ValidatorClient> {
+        Ok(Builder::new(self.validator_url.clone())
+            .with_tls()?
+            .without_timeout()
+            .without_metadata_version()
+            .without_metadata_genesis()
+            .with_otel_context_injection()
+            .connect_lazy::<ValidatorClient>())
+    }
+}
+
+/// Streams blocks from the validator into the local store until the chain tip is reached.
+async fn recover_from_validator(
+    state: &Arc<State>,
+    mut validator: ValidatorClient,
+) -> anyhow::Result<()> {
+    // Capture the validator's chain tip as the recovery target. The validator's block stream
+    // follows live blocks indefinitely, so without a fixed target we could never tell when to stop.
+    // The sequencer must be shut down during recovery, so this tip does not advance.
+    let validator_tip = BlockNumber::from(
+        validator
+            .status(())
+            .await
+            .context("failed to query validator status")?
+            .into_inner()
+            .chain_tip,
+    );
+
+    let local_tip = state.chain_tip(Finality::Committed).await;
+    if local_tip >= validator_tip {
+        info!(
+            local.tip = local_tip.as_u32(),
+            validator.tip = validator_tip.as_u32(),
+            "Local chain is already at the validator's chain tip; nothing to recover",
+        );
+        return Ok(());
+    }
+
+    let block_from = local_tip.child().as_u32();
+    info!(
+        block_from,
+        validator.tip = validator_tip.as_u32(),
+        "Recovering blocks from validator",
+    );
+
+    let mut stream = validator
+        .block_subscription(BlockSubscriptionRequest { block_from })
+        .await
+        .context("failed to open validator block subscription")?
+        .into_inner();
+
+    while let Some(result) = stream.next().await {
+        let event = result.context("validator block stream returned an error")?;
+        let block = SignedBlock::read_from_bytes(&event.block)
+            .context("failed to deserialize block from validator")?;
+        let block_num = block.header().block_num();
+        state.apply_block(block).await.context("failed to apply recovered block")?;
+        info!(block.number = block_num.as_u32(), "Applied recovered block");
+
+        // Stop once we reach the tip captured at the start of recovery.
+        if block_num >= validator_tip {
+            break;
+        }
+    }
+
+    // The stream can end before reaching the tip if the validator restarts or drops the connection.
+    let final_tip = state.chain_tip(Finality::Committed).await;
+    anyhow::ensure!(
+        final_tip >= validator_tip,
+        "validator block stream ended at block {} before reaching the chain tip {}",
+        final_tip.as_u32(),
+        validator_tip.as_u32(),
+    );
+
+    info!(chain_tip = final_tip.as_u32(), "Block recovery complete");
+    Ok(())
+}

--- a/bin/node/src/commands/recover.rs
+++ b/bin/node/src/commands/recover.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use miden_node_proto::clients::{Builder, ValidatorClient};
@@ -66,7 +67,7 @@ impl RecoverCommand {
     fn validator_client(&self) -> anyhow::Result<ValidatorClient> {
         Ok(Builder::new(self.validator_url.clone())
             .with_tls()?
-            .without_timeout()
+            .with_timeout(Duration::from_secs(20))
             .without_metadata_version()
             .without_metadata_genesis()
             .with_otel_context_injection()

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -1,9 +1,14 @@
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use miden_node_proto::generated as grpc;
 use miden_node_store::BlockStore;
+use miden_node_store::state::{
+    SUBSCRIBER_CHANNEL_CAPACITY,
+    StateSubscriptionError,
+    SubscriptionSource,
+    run_stream,
+};
 use miden_node_utils::ErrorReport;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
@@ -14,12 +19,6 @@ use tonic::Status;
 use tracing::Span;
 
 use super::ValidatorService;
-
-/// Buffered blocks per subscriber before back-pressure begins.
-const SUBSCRIBER_CHANNEL_CAPACITY: usize = 32;
-/// Safety-net timeout for a single send when the client has stalled. A subscriber that fails to
-/// drain a buffered block within this window is disconnected so it cannot pin validator resources.
-const SEND_TIMEOUT: Duration = Duration::from_secs(10);
 
 type BlockSubscriptionStream = Pin<
     Box<
@@ -68,18 +67,37 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
 // STREAM
 // ================================================================================================
 
-#[derive(Debug, thiserror::Error)]
-enum BlockSubscriptionError {
-    #[error("failed to load block {block_num}")]
-    BlockLoad {
-        block_num: BlockNumber,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("block {0} not found")]
-    BlockNotFound(BlockNumber),
-    #[error("subscriber is too slow to keep up with the chain")]
-    TooSlow,
+/// Streams committed blocks from the validator's [`BlockStore`], emitting each as a
+/// [`grpc::validator::BlockSubscriptionResponse`].
+struct BlockStoreSource {
+    block_store: BlockStore,
+}
+
+impl SubscriptionSource for BlockStoreSource {
+    type Event = grpc::validator::BlockSubscriptionResponse;
+
+    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, StateSubscriptionError> {
+        self.block_store
+            .load_block(block_num)
+            .await
+            .map_err(|source| StateSubscriptionError::BlockLoad {
+                block_num,
+                source: source.into(),
+            })?
+            .ok_or(StateSubscriptionError::BlockNotFound(block_num))
+    }
+
+    fn build_event(
+        &self,
+        _block_num: BlockNumber,
+        block: Vec<u8>,
+        committed_chain_tip: BlockNumber,
+    ) -> grpc::validator::BlockSubscriptionResponse {
+        grpc::validator::BlockSubscriptionResponse {
+            block,
+            committed_chain_tip: committed_chain_tip.as_u32(),
+        }
+    }
 }
 
 /// Spawns a task that replays backed-up blocks from `from` and then follows live signed blocks,
@@ -89,72 +107,32 @@ fn build_block_stream(
     tip_rx: watch::Receiver<BlockNumber>,
     block_store: BlockStore,
     permit: tokio::sync::OwnedSemaphorePermit,
-) -> impl Stream<Item = Result<grpc::validator::BlockSubscriptionResponse, BlockSubscriptionError>>
+) -> impl Stream<Item = Result<grpc::validator::BlockSubscriptionResponse, StateSubscriptionError>>
 + Send
 + 'static {
     let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
     tokio::spawn(async move {
         // Hold the subscription permit for the lifetime of the streaming task.
         let _permit = permit;
-        if let Err(err) = run_block_stream(from, tip_rx, &tx, &block_store).await {
+        let source = BlockStoreSource { block_store };
+        if let Err(err) = run_stream(from, tip_rx, &tx, source).await {
             let _ = tx.send(Err(err)).await;
         }
     });
     ReceiverStream::new(rx)
 }
 
-/// Drives a block subscription, replaying history then following live tip advances.
-///
-/// Loads each block in sequence starting from `from` and sends it to `tx`. Disconnects the
-/// subscriber with [`BlockSubscriptionError::TooSlow`] if a single send blocks for longer than
-/// [`SEND_TIMEOUT`], which can only happen once [`SUBSCRIBER_CHANNEL_CAPACITY`] blocks are queued.
-async fn run_block_stream(
-    from: BlockNumber,
-    mut tip_rx: watch::Receiver<BlockNumber>,
-    tx: &mpsc::Sender<Result<grpc::validator::BlockSubscriptionResponse, BlockSubscriptionError>>,
-    block_store: &BlockStore,
-) -> Result<(), BlockSubscriptionError> {
-    let mut next = from;
-    loop {
-        let mut tip = *tip_rx.borrow_and_update();
-
-        while next <= tip {
-            let block = block_store
-                .load_block(next)
-                .await
-                .map_err(|source| BlockSubscriptionError::BlockLoad { block_num: next, source })?
-                .ok_or(BlockSubscriptionError::BlockNotFound(next))?;
-            // Re-read the tip so the emitted value reflects any blocks signed during the load.
-            tip = *tip_rx.borrow_and_update();
-            let permit = match tokio::time::timeout(SEND_TIMEOUT, tx.reserve()).await {
-                Ok(Ok(permit)) => permit,
-                // The subscriber disconnected; end the stream cleanly.
-                Ok(Err(_)) => return Ok(()),
-                Err(_) => return Err(BlockSubscriptionError::TooSlow),
-            };
-            permit.send(Ok(grpc::validator::BlockSubscriptionResponse {
-                block,
-                committed_chain_tip: tip.as_u32(),
-            }));
-            next = next.child();
-        }
-
-        // Wait for the next signed block. An error means all senders dropped, i.e. shutdown.
-        if tip_rx.changed().await.is_err() {
-            return Ok(());
-        }
-    }
-}
-
-fn subscription_error_to_status(err: BlockSubscriptionError) -> Status {
+fn subscription_error_to_status(err: StateSubscriptionError) -> Status {
     match err {
-        BlockSubscriptionError::BlockNotFound(block_num) => {
+        StateSubscriptionError::BlockNotFound(block_num)
+        | StateSubscriptionError::ProofNotFound(block_num) => {
             Status::not_found(format!("block {block_num} not found"))
         },
-        BlockSubscriptionError::BlockLoad { block_num, source } => {
+        StateSubscriptionError::BlockLoad { block_num, source }
+        | StateSubscriptionError::ProofLoad { block_num, source } => {
             Status::internal(format!("failed to load block {block_num}: {}", source.as_report()))
         },
-        BlockSubscriptionError::TooSlow => {
+        StateSubscriptionError::TooSlow => {
             Status::resource_exhausted("subscriber is too slow to keep up with the chain")
         },
     }

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -1,19 +1,11 @@
 use std::pin::Pin;
-use std::sync::Arc;
 
 use miden_node_proto::generated as grpc;
 use miden_node_store::BlockStore;
-use miden_node_store::state::{
-    SUBSCRIBER_CHANNEL_CAPACITY,
-    StateSubscriptionError,
-    SubscriptionSource,
-    run_stream,
-};
+use miden_node_store::state::{SubscriptionSource, SubscriptionStreamError, run_stream};
 use miden_node_utils::ErrorReport;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
-use tokio::sync::{mpsc, watch};
-use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::{Stream, StreamExt};
 use tonic::Status;
 use tracing::Span;
@@ -45,20 +37,10 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
         Span::current().set_attribute("block.from", request.block_from);
 
-        // Cap concurrent subscriptions. The permit is moved into the streaming task and released
-        // once the stream ends or the client disconnects.
-        let permit = Arc::clone(&self.block_subscription_semaphore)
-            .try_acquire_owned()
-            .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
-
         let from = BlockNumber::from(request.block_from);
-        let stream = build_block_stream(
-            from,
-            self.committed_tip.subscribe(),
-            self.block_store.clone(),
-            permit,
-        )
-        .map(|event| event.map_err(subscription_error_to_status));
+        let source = BlockStoreSource { block_store: self.block_store.clone() };
+        let stream = run_stream(from, self.committed_tip.subscribe(), source)
+            .map(|event| event.map_err(subscription_error_to_status));
 
         Ok(Box::pin(stream))
     }
@@ -66,6 +48,19 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
 
 // STREAM
 // ================================================================================================
+
+/// Error raised while loading a block from the validator's [`BlockStore`].
+#[derive(Debug, thiserror::Error)]
+enum BlockSubscriptionError {
+    #[error("failed to load block {block_num}")]
+    Load {
+        block_num: BlockNumber,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("block {0} not found")]
+    NotFound(BlockNumber),
+}
 
 /// Streams committed blocks from the validator's [`BlockStore`], emitting each as a
 /// [`grpc::validator::BlockSubscriptionResponse`].
@@ -75,16 +70,14 @@ struct BlockStoreSource {
 
 impl SubscriptionSource for BlockStoreSource {
     type Event = grpc::validator::BlockSubscriptionResponse;
+    type Error = BlockSubscriptionError;
 
-    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, StateSubscriptionError> {
+    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, BlockSubscriptionError> {
         self.block_store
             .load_block(block_num)
             .await
-            .map_err(|source| StateSubscriptionError::BlockLoad {
-                block_num,
-                source: source.into(),
-            })?
-            .ok_or(StateSubscriptionError::BlockNotFound(block_num))
+            .map_err(|source| BlockSubscriptionError::Load { block_num, source })?
+            .ok_or(BlockSubscriptionError::NotFound(block_num))
     }
 
     fn build_event(
@@ -100,40 +93,16 @@ impl SubscriptionSource for BlockStoreSource {
     }
 }
 
-/// Spawns a task that replays backed-up blocks from `from` and then follows live signed blocks,
-/// emitting each as a [`grpc::validator::BlockSubscriptionResponse`] on the returned stream.
-fn build_block_stream(
-    from: BlockNumber,
-    tip_rx: watch::Receiver<BlockNumber>,
-    block_store: BlockStore,
-    permit: tokio::sync::OwnedSemaphorePermit,
-) -> impl Stream<Item = Result<grpc::validator::BlockSubscriptionResponse, StateSubscriptionError>>
-+ Send
-+ 'static {
-    let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
-    tokio::spawn(async move {
-        // Hold the subscription permit for the lifetime of the streaming task.
-        let _permit = permit;
-        let source = BlockStoreSource { block_store };
-        if let Err(err) = run_stream(from, tip_rx, &tx, source).await {
-            let _ = tx.send(Err(err)).await;
-        }
-    });
-    ReceiverStream::new(rx)
-}
-
-fn subscription_error_to_status(err: StateSubscriptionError) -> Status {
+fn subscription_error_to_status(err: SubscriptionStreamError<BlockSubscriptionError>) -> Status {
     match err {
-        StateSubscriptionError::BlockNotFound(block_num)
-        | StateSubscriptionError::ProofNotFound(block_num) => {
+        SubscriptionStreamError::TooSlow => {
+            Status::resource_exhausted("subscriber is too slow to keep up with the chain")
+        },
+        SubscriptionStreamError::Source(BlockSubscriptionError::NotFound(block_num)) => {
             Status::not_found(format!("block {block_num} not found"))
         },
-        StateSubscriptionError::BlockLoad { block_num, source }
-        | StateSubscriptionError::ProofLoad { block_num, source } => {
+        SubscriptionStreamError::Source(BlockSubscriptionError::Load { block_num, source }) => {
             Status::internal(format!("failed to load block {block_num}: {}", source.as_report()))
-        },
-        StateSubscriptionError::TooSlow => {
-            Status::resource_exhausted("subscriber is too slow to keep up with the chain")
         },
     }
 }

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -1,0 +1,161 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use miden_node_proto::generated as grpc;
+use miden_node_store::BlockStore;
+use miden_node_utils::ErrorReport;
+use miden_node_utils::tracing::OpenTelemetrySpanExt;
+use miden_protocol::block::BlockNumber;
+use tokio::sync::{mpsc, watch};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::{Stream, StreamExt};
+use tonic::Status;
+use tracing::Span;
+
+use super::ValidatorService;
+
+/// Buffered blocks per subscriber before back-pressure begins.
+const SUBSCRIBER_CHANNEL_CAPACITY: usize = 32;
+/// Safety-net timeout for a single send when the client has stalled. A subscriber that fails to
+/// drain a buffered block within this window is disconnected so it cannot pin validator resources.
+const SEND_TIMEOUT: Duration = Duration::from_secs(10);
+
+type BlockSubscriptionStream = Pin<
+    Box<
+        dyn Stream<Item = tonic::Result<grpc::validator::BlockSubscriptionResponse>>
+            + Send
+            + 'static,
+    >,
+>;
+
+#[tonic::async_trait]
+impl grpc::server::validator_api::BlockSubscription for ValidatorService {
+    type Input = grpc::validator::BlockSubscriptionRequest;
+    type Item = grpc::validator::BlockSubscriptionResponse;
+    type ItemStream = BlockSubscriptionStream;
+
+    fn decode(request: grpc::validator::BlockSubscriptionRequest) -> tonic::Result<Self::Input> {
+        Ok(request)
+    }
+
+    fn encode(item: Self::Item) -> tonic::Result<grpc::validator::BlockSubscriptionResponse> {
+        Ok(item)
+    }
+
+    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
+        Span::current().set_attribute("block.from", request.block_from);
+
+        // Cap concurrent subscriptions. The permit is moved into the streaming task and released
+        // once the stream ends or the client disconnects.
+        let permit = Arc::clone(&self.block_subscription_semaphore)
+            .try_acquire_owned()
+            .map_err(|_| Status::resource_exhausted("maximum block subscriptions reached"))?;
+
+        let from = BlockNumber::from(request.block_from);
+        let stream = build_block_stream(
+            from,
+            self.committed_tip.subscribe(),
+            self.block_store.clone(),
+            permit,
+        )
+        .map(|event| event.map_err(subscription_error_to_status));
+
+        Ok(Box::pin(stream))
+    }
+}
+
+// STREAM
+// ================================================================================================
+
+#[derive(Debug, thiserror::Error)]
+enum BlockSubscriptionError {
+    #[error("failed to load block {block_num}")]
+    BlockLoad {
+        block_num: BlockNumber,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("block {0} not found")]
+    BlockNotFound(BlockNumber),
+    #[error("subscriber is too slow to keep up with the chain")]
+    TooSlow,
+}
+
+/// Spawns a task that replays backed-up blocks from `from` and then follows live signed blocks,
+/// emitting each as a [`grpc::validator::BlockSubscriptionResponse`] on the returned stream.
+fn build_block_stream(
+    from: BlockNumber,
+    tip_rx: watch::Receiver<BlockNumber>,
+    block_store: BlockStore,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) -> impl Stream<Item = Result<grpc::validator::BlockSubscriptionResponse, BlockSubscriptionError>>
++ Send
++ 'static {
+    let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
+    tokio::spawn(async move {
+        // Hold the subscription permit for the lifetime of the streaming task.
+        let _permit = permit;
+        if let Err(err) = run_block_stream(from, tip_rx, &tx, &block_store).await {
+            let _ = tx.send(Err(err)).await;
+        }
+    });
+    ReceiverStream::new(rx)
+}
+
+/// Drives a block subscription, replaying history then following live tip advances.
+///
+/// Loads each block in sequence starting from `from` and sends it to `tx`. Disconnects the
+/// subscriber with [`BlockSubscriptionError::TooSlow`] if a single send blocks for longer than
+/// [`SEND_TIMEOUT`], which can only happen once [`SUBSCRIBER_CHANNEL_CAPACITY`] blocks are queued.
+async fn run_block_stream(
+    from: BlockNumber,
+    mut tip_rx: watch::Receiver<BlockNumber>,
+    tx: &mpsc::Sender<Result<grpc::validator::BlockSubscriptionResponse, BlockSubscriptionError>>,
+    block_store: &BlockStore,
+) -> Result<(), BlockSubscriptionError> {
+    let mut next = from;
+    loop {
+        let mut tip = *tip_rx.borrow_and_update();
+
+        while next <= tip {
+            let block = block_store
+                .load_block(next)
+                .await
+                .map_err(|source| BlockSubscriptionError::BlockLoad { block_num: next, source })?
+                .ok_or(BlockSubscriptionError::BlockNotFound(next))?;
+            // Re-read the tip so the emitted value reflects any blocks signed during the load.
+            tip = *tip_rx.borrow_and_update();
+            let permit = match tokio::time::timeout(SEND_TIMEOUT, tx.reserve()).await {
+                Ok(Ok(permit)) => permit,
+                // The subscriber disconnected; end the stream cleanly.
+                Ok(Err(_)) => return Ok(()),
+                Err(_) => return Err(BlockSubscriptionError::TooSlow),
+            };
+            permit.send(Ok(grpc::validator::BlockSubscriptionResponse {
+                block,
+                committed_chain_tip: tip.as_u32(),
+            }));
+            next = next.child();
+        }
+
+        // Wait for the next signed block. An error means all senders dropped, i.e. shutdown.
+        if tip_rx.changed().await.is_err() {
+            return Ok(());
+        }
+    }
+}
+
+fn subscription_error_to_status(err: BlockSubscriptionError) -> Status {
+    match err {
+        BlockSubscriptionError::BlockNotFound(block_num) => {
+            Status::not_found(format!("block {block_num} not found"))
+        },
+        BlockSubscriptionError::BlockLoad { block_num, source } => {
+            Status::internal(format!("failed to load block {block_num}: {}", source.as_report()))
+        },
+        BlockSubscriptionError::TooSlow => {
+            Status::resource_exhausted("subscriber is too slow to keep up with the chain")
+        },
+    }
+}

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::AtomicU64;
 
 use miden_node_db::{DatabaseError, Db};
 use miden_node_store::BlockStore;
@@ -9,7 +9,7 @@ use miden_protocol::crypto::dsa::ecdsa_k256_keccak::{PublicKey, Signature};
 use miden_protocol::crypto::utils::Serializable;
 use miden_protocol::errors::ProposedBlockError;
 use miden_protocol::transaction::{TransactionHeader, TransactionId};
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, watch};
 use tracing::{Span, instrument};
 
 use crate::db::{find_unvalidated_transactions, load_block_header, load_chain_tip};
@@ -18,9 +18,13 @@ use crate::{COMPONENT, ValidatorSigner};
 #[cfg(test)]
 mod tests;
 
+mod block_subscription;
 mod sign_block;
 mod status;
 mod submit_proven_transaction;
+
+/// Maximum number of concurrent block subscriptions served by this validator.
+const MAX_BLOCK_SUBSCRIPTIONS: usize = 10;
 
 // VALIDATOR ERROR
 // ================================================================================================
@@ -67,8 +71,11 @@ pub(crate) struct ValidatorService {
     /// Serializes `sign_block` requests so that concurrent calls are processed sequentially,
     /// ensuring consistent chain tip reads and preventing race conditions.
     sign_block_semaphore: Semaphore,
-    /// In-memory chain tip, updated atomically after each signed block.
-    chain_tip: AtomicU32,
+    /// In-memory chain tip, updated after each signed block. Block subscriptions follow this to
+    /// stream live blocks as they are signed.
+    committed_tip: watch::Sender<BlockNumber>,
+    /// Caps the number of concurrent block subscriptions to protect validator resources.
+    block_subscription_semaphore: Arc<Semaphore>,
     /// In-memory count of validated transactions, incremented after each new insert.
     validated_transactions_count: AtomicU64,
     /// In-memory count of signed blocks, incremented after each signed block.
@@ -105,7 +112,8 @@ impl ValidatorService {
             db: db.into(),
             block_store,
             sign_block_semaphore: Semaphore::new(1),
-            chain_tip: AtomicU32::new(initial_chain_tip),
+            committed_tip: watch::Sender::new(BlockNumber::from(initial_chain_tip)),
+            block_subscription_semaphore: Arc::new(Semaphore::new(MAX_BLOCK_SUBSCRIPTIONS)),
             validated_transactions_count: AtomicU64::new(initial_tx_count),
             signed_blocks_count: AtomicU64::new(initial_block_count),
         })

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -23,9 +23,6 @@ mod sign_block;
 mod status;
 mod submit_proven_transaction;
 
-/// Maximum number of concurrent block subscriptions served by this validator.
-const MAX_BLOCK_SUBSCRIPTIONS: usize = 10;
-
 // VALIDATOR ERROR
 // ================================================================================================
 
@@ -74,8 +71,6 @@ pub(crate) struct ValidatorService {
     /// In-memory chain tip, updated after each signed block. Block subscriptions follow this to
     /// stream live blocks as they are signed.
     committed_tip: watch::Sender<BlockNumber>,
-    /// Caps the number of concurrent block subscriptions to protect validator resources.
-    block_subscription_semaphore: Arc<Semaphore>,
     /// In-memory count of validated transactions, incremented after each new insert.
     validated_transactions_count: AtomicU64,
     /// In-memory count of signed blocks, incremented after each signed block.
@@ -113,7 +108,6 @@ impl ValidatorService {
             block_store,
             sign_block_semaphore: Semaphore::new(1),
             committed_tip: watch::Sender::new(BlockNumber::from(initial_chain_tip)),
-            block_subscription_semaphore: Arc::new(Semaphore::new(MAX_BLOCK_SUBSCRIPTIONS)),
             validated_transactions_count: AtomicU64::new(initial_tx_count),
             signed_blocks_count: AtomicU64::new(initial_block_count),
         })

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::Ordering;
 use miden_node_proto::generated as grpc;
 use miden_node_utils::ErrorReport;
 use miden_protocol::Word;
-use miden_protocol::block::ProposedBlock;
+use miden_protocol::block::{BlockNumber, ProposedBlock};
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::Signature;
 use miden_tx::utils::serde::{Deserializable, Serializable};
 
@@ -73,8 +73,10 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
                 ))
             })?;
 
-        // Update the in-memory counters after successful persistence.
-        self.chain_tip.store(new_block_num, Ordering::Relaxed);
+        // Update the in-memory counters after successful persistence. The block has already been
+        // backed up to the block store by `validate_block`, so it is available to subscribers by
+        // the time they observe this new tip.
+        self.committed_tip.send_replace(BlockNumber::from(new_block_num));
         self.signed_blocks_count.fetch_add(1, Ordering::Relaxed);
 
         Ok((signature, block_commitment))

--- a/bin/validator/src/server/validator_service/status.rs
+++ b/bin/validator/src/server/validator_service/status.rs
@@ -16,7 +16,7 @@ impl grpc::server::validator_api::Status for ValidatorService {
         Ok(grpc::validator::ValidatorStatus {
             version: env!("CARGO_PKG_VERSION").to_string(),
             status: "OK".to_string(),
-            chain_tip: self.chain_tip.load(Ordering::Relaxed),
+            chain_tip: self.committed_tip.borrow().as_u32(),
             validated_transactions_count: self.validated_transactions_count.load(Ordering::Relaxed),
             signed_blocks_count: self.signed_blocks_count.load(Ordering::Relaxed),
         })

--- a/bin/validator/src/server/validator_service/tests.rs
+++ b/bin/validator/src/server/validator_service/tests.rs
@@ -57,6 +57,19 @@ impl TestValidator {
         api_server::Api::sign_block(&self.server, request).await
     }
 
+    /// Opens a block subscription starting from `block_from`.
+    async fn call_block_subscription(
+        &self,
+        block_from: u32,
+    ) -> <ValidatorService as proto::server::validator_api::BlockSubscription>::ItemStream {
+        let request =
+            tonic::Request::new(proto::validator::BlockSubscriptionRequest { block_from });
+        api_server::Api::block_subscription(&self.server, request)
+            .await
+            .expect("subscription should open")
+            .into_inner()
+    }
+
     /// Loads the current chain tip from the validator's database.
     async fn load_chain_tip(&self) -> BlockHeader {
         self.server
@@ -489,4 +502,45 @@ async fn validate_block_number_mismatch() {
         matches!(result.unwrap_err(), ValidatorError::BlockNumberMismatch { .. }),
         "expected BlockNumberMismatch error"
     );
+}
+
+/// A block subscription replays the backed-up blocks from the requested height and then streams
+/// newly signed blocks as they arrive.
+#[tokio::test]
+async fn block_subscription_replays_then_follows() {
+    use std::time::Duration;
+
+    use miden_protocol::block::SignedBlock;
+    use miden_tx::utils::serde::Deserializable;
+    use tokio_stream::StreamExt;
+
+    let mut tv = TestValidator::new().await;
+
+    // Sign blocks 1 and 2 so the validator backs them up to its block store.
+    tv.apply_empty_block().await;
+    tv.apply_empty_block().await;
+
+    // Subscribe from the first signed block and confirm the backed-up blocks are replayed in order.
+    let mut stream = tv.call_block_subscription(1).await;
+    for expected in 1..=2 {
+        let response = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("replayed block should arrive promptly")
+            .expect("stream should not end")
+            .expect("stream item should not be an error");
+        let block = SignedBlock::read_from_bytes(&response.block).expect("valid signed block");
+        assert_eq!(block.header().block_num().as_u32(), expected);
+        assert_eq!(response.committed_chain_tip, 2);
+    }
+
+    // Sign a new block and confirm it is streamed live to the existing subscriber.
+    tv.apply_empty_block().await;
+    let response = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("live block should arrive promptly")
+        .expect("stream should not end")
+        .expect("stream item should not be an error");
+    let block = SignedBlock::read_from_bytes(&response.block).expect("valid signed block");
+    assert_eq!(block.header().block_num().as_u32(), 3);
+    assert_eq!(response.committed_chain_tip, 3);
 }

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -11,7 +11,13 @@ use miden_node_proto::domain::block::InvalidBlockRange;
 use miden_node_proto::generated::rpc::MempoolStats as ProtoMempoolStats;
 use miden_node_proto::generated::rpc::api_server::Api;
 use miden_node_proto::generated::{self as proto};
-use miden_node_store::state::{Finality, State, StateSubscriptionError};
+use miden_node_store::state::{
+    BlockSubscriptionError,
+    Finality,
+    ProofSubscriptionError,
+    State,
+    SubscriptionStreamError,
+};
 use miden_node_store::{DatabaseError, GetBlockHeaderError};
 use miden_node_utils::ErrorReport;
 use miden_node_utils::limiter::{
@@ -299,23 +305,37 @@ fn database_error_to_status(err: &DatabaseError) -> Status {
     }
 }
 
-fn state_subscription_error_to_status(err: StateSubscriptionError) -> Status {
+fn block_subscription_error_to_status(
+    err: SubscriptionStreamError<BlockSubscriptionError>,
+) -> Status {
     match err {
-        StateSubscriptionError::BlockNotFound(block_num) => {
+        SubscriptionStreamError::TooSlow => {
+            Status::resource_exhausted("subscriber is too slow to keep up with the chain")
+        },
+        SubscriptionStreamError::Source(BlockSubscriptionError::NotFound(block_num)) => {
             Status::not_found(format!("block {block_num} not found"))
         },
-        StateSubscriptionError::ProofNotFound(block_num) => {
-            Status::not_found(format!("proof for block {block_num} not found"))
-        },
-        StateSubscriptionError::BlockLoad { block_num, source } => {
+        SubscriptionStreamError::Source(BlockSubscriptionError::Load { block_num, source }) => {
             Status::internal(format!("failed to load block {block_num}: {}", source.as_report()))
         },
-        StateSubscriptionError::ProofLoad { block_num, source } => Status::internal(format!(
-            "failed to load proof for block {block_num}: {}",
-            source.as_report()
-        )),
-        StateSubscriptionError::TooSlow => {
+    }
+}
+
+fn proof_subscription_error_to_status(
+    err: SubscriptionStreamError<ProofSubscriptionError>,
+) -> Status {
+    match err {
+        SubscriptionStreamError::TooSlow => {
             Status::resource_exhausted("subscriber is too slow to keep up with the chain")
+        },
+        SubscriptionStreamError::Source(ProofSubscriptionError::NotFound(block_num)) => {
+            Status::not_found(format!("proof for block {block_num} not found"))
+        },
+        SubscriptionStreamError::Source(ProofSubscriptionError::Load { block_num, source }) => {
+            Status::internal(format!(
+                "failed to load proof for block {block_num}: {}",
+                source.as_report()
+            ))
         },
     }
 }

--- a/crates/rpc/src/server/api/block_subscription.rs
+++ b/crates/rpc/src/server/api/block_subscription.rs
@@ -12,7 +12,7 @@ use super::{
     COMPONENT,
     GuardedStream,
     RpcService,
-    state_subscription_error_to_status,
+    block_subscription_error_to_status,
 };
 
 #[tonic::async_trait]
@@ -45,7 +45,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
                     block: event.block,
                     committed_chain_tip: event.committed_chain_tip.as_u32(),
                 })
-                .map_err(state_subscription_error_to_status)
+                .map_err(block_subscription_error_to_status)
         });
         let stream: Self::ItemStream = Box::pin(GuardedStream::new(Box::pin(stream), permit));
         Ok(stream)

--- a/crates/rpc/src/server/api/proof_subscription.rs
+++ b/crates/rpc/src/server/api/proof_subscription.rs
@@ -12,7 +12,7 @@ use super::{
     GuardedStream,
     ProofSubscriptionStream,
     RpcService,
-    state_subscription_error_to_status,
+    proof_subscription_error_to_status,
 };
 
 #[tonic::async_trait]
@@ -46,7 +46,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
                     proof: event.proof,
                     proven_chain_tip: event.proven_chain_tip.as_u32(),
                 })
-                .map_err(state_subscription_error_to_status)
+                .map_err(proof_subscription_error_to_status)
         });
         let stream: Self::ItemStream = Box::pin(GuardedStream::new(Box::pin(stream), permit));
         Ok(stream)

--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 use crate::COMPONENT;
 use crate::genesis::GenesisBlock;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BlockStore {
     store_dir: PathBuf,
 }

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -67,7 +67,10 @@ pub use subscription::{
     BlockSubscriptionStream,
     ProofSubscriptionEvent,
     ProofSubscriptionStream,
+    SUBSCRIBER_CHANNEL_CAPACITY,
     StateSubscriptionError,
+    SubscriptionSource,
+    run_stream,
 };
 
 mod apply_block;

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -63,13 +63,15 @@ mod account;
 
 mod subscription;
 pub use subscription::{
+    BlockSubscriptionError,
     BlockSubscriptionEvent,
     BlockSubscriptionStream,
+    ProofSubscriptionError,
     ProofSubscriptionEvent,
     ProofSubscriptionStream,
     SUBSCRIBER_CHANNEL_CAPACITY,
-    StateSubscriptionError,
     SubscriptionSource,
+    SubscriptionStreamError,
     run_stream,
 };
 

--- a/crates/store/src/state/subscription.rs
+++ b/crates/store/src/state/subscription.rs
@@ -13,7 +13,7 @@ use super::{BlockCache, ProofCache, State};
 use crate::errors::DatabaseError;
 
 /// Buffered messages per subscriber before back-pressure begins.
-const SUBSCRIBER_CHANNEL_CAPACITY: usize = 32;
+pub const SUBSCRIBER_CHANNEL_CAPACITY: usize = 32;
 /// Safety-net timeout for a single send when the client has stalled.
 const SEND_TIMEOUT: Duration = Duration::from_secs(10);
 /// Maximum running block-gap allowed before a subscriber is disconnected.
@@ -94,7 +94,7 @@ impl State {
 // SUBSCRIPTION SOURCE
 // ================================================================================================
 
-trait SubscriptionSource: Send + Sync + 'static {
+pub trait SubscriptionSource: Send + Sync + 'static {
     type Event: Send + 'static;
 
     fn fetch(
@@ -186,7 +186,7 @@ fn build_stream<S: SubscriptionSource>(
 /// event with [`SubscriptionSource::build_event`], and sends it to `tx`. Disconnects the
 /// subscriber with [`StateSubscriptionError::TooSlow`] if a single send blocks for longer than [`SEND_TIMEOUT`]
 /// which may occur only after the buffer has [`SUBSCRIBER_CHANNEL_CAPACITY`] blocks queued.
-async fn run_stream<S: SubscriptionSource>(
+pub async fn run_stream<S: SubscriptionSource>(
     from: BlockNumber,
     mut tip_rx: watch::Receiver<BlockNumber>,
     tx: &mpsc::Sender<Result<S::Event, StateSubscriptionError>>,

--- a/crates/store/src/state/subscription.rs
+++ b/crates/store/src/state/subscription.rs
@@ -236,8 +236,9 @@ async fn run_stream_inner<S: SubscriptionSource>(
         let mut tip = *tip_rx.borrow_and_update();
 
         let current_gap = tip.saturating_sub(next.as_u32()).as_u32();
-        (previous_gap, running_gap) = check_growing_gap(current_gap, previous_gap, running_gap, MAX_RUNNING_GAP)
-            .map_err(|()| SubscriptionStreamError::TooSlow)?;
+        (previous_gap, running_gap) =
+            check_growing_gap(current_gap, previous_gap, running_gap, MAX_RUNNING_GAP)
+                .map_err(|()| SubscriptionStreamError::TooSlow)?;
 
         while next <= tip {
             let data = source.fetch(next).await?;
@@ -267,7 +268,7 @@ fn check_growing_gap(
     current_gap: u32,
     previous_gap: u32,
     running_gap: u32,
-    max_gap: u32
+    max_gap: u32,
 ) -> Result<(u32, u32), ()> {
     let running_gap = if current_gap > previous_gap {
         running_gap + (current_gap - previous_gap)
@@ -291,7 +292,8 @@ mod tests {
         let mut previous_gap = gaps.first().copied().unwrap_or(u32::MAX);
         let mut growth_run = 0u32;
         for &gap in gaps {
-            (previous_gap, growth_run) = check_growing_gap(gap, previous_gap, growth_run, MAX_RUNNING_GAP)?;
+            (previous_gap, growth_run) =
+                check_growing_gap(gap, previous_gap, growth_run, MAX_RUNNING_GAP)?;
         }
         Ok(())
     }

--- a/crates/store/src/state/subscription.rs
+++ b/crates/store/src/state/subscription.rs
@@ -35,39 +35,72 @@ pub struct ProofSubscriptionEvent {
     pub proven_chain_tip: BlockNumber,
 }
 
+/// Error returned by a subscription stream.
+///
+/// Separates the two failure domains: [`TooSlow`](Self::TooSlow) is raised by the streaming
+/// machinery itself when a subscriber falls too far behind, while [`Source`](Self::Source) wraps a
+/// failure of the underlying [`SubscriptionSource`] to produce data.
 #[derive(Debug, Error)]
-pub enum StateSubscriptionError {
+pub enum SubscriptionStreamError<E> {
+    #[error("subscriber is too slow to keep up with the chain")]
+    TooSlow,
+    #[error(transparent)]
+    Source(#[from] E),
+}
+
+/// Error raised while loading a block for a block subscription.
+#[derive(Debug, Error)]
+pub enum BlockSubscriptionError {
     #[error("failed to load block {block_num}")]
-    BlockLoad {
+    Load {
         block_num: BlockNumber,
         #[source]
         source: DatabaseError,
     },
     #[error("block {0} not found")]
-    BlockNotFound(BlockNumber),
+    NotFound(BlockNumber),
+}
+
+/// Error raised while loading a proof for a proof subscription.
+#[derive(Debug, Error)]
+pub enum ProofSubscriptionError {
     #[error("failed to load proof for block {block_num}")]
-    ProofLoad {
+    Load {
         block_num: BlockNumber,
         #[source]
         source: DatabaseError,
     },
     #[error("proof for block {0} not found")]
-    ProofNotFound(BlockNumber),
-    #[error("subscriber is too slow to keep up with the chain")]
-    TooSlow,
+    NotFound(BlockNumber),
 }
 
-pub type BlockSubscriptionStream =
-    Pin<Box<dyn Stream<Item = Result<BlockSubscriptionEvent, StateSubscriptionError>> + Send>>;
+pub type BlockSubscriptionStream = Pin<
+    Box<
+        dyn Stream<
+                Item = Result<
+                    BlockSubscriptionEvent,
+                    SubscriptionStreamError<BlockSubscriptionError>,
+                >,
+            > + Send,
+    >,
+>;
 
-pub type ProofSubscriptionStream =
-    Pin<Box<dyn Stream<Item = Result<ProofSubscriptionEvent, StateSubscriptionError>> + Send>>;
+pub type ProofSubscriptionStream = Pin<
+    Box<
+        dyn Stream<
+                Item = Result<
+                    ProofSubscriptionEvent,
+                    SubscriptionStreamError<ProofSubscriptionError>,
+                >,
+            > + Send,
+    >,
+>;
 
 impl State {
     /// Streams committed blocks starting from `from`, replaying historical blocks first and then
     /// following live commits.
     pub fn block_subscription(self: &Arc<Self>, from: BlockNumber) -> BlockSubscriptionStream {
-        Box::pin(build_stream(
+        Box::pin(run_stream(
             from,
             self.subscribe_committed_tip(),
             BlockSource {
@@ -80,7 +113,7 @@ impl State {
     /// Streams block proofs starting from `from`, replaying historical proofs first and then
     /// following newly proven blocks.
     pub fn proof_subscription(self: &Arc<Self>, from: BlockNumber) -> ProofSubscriptionStream {
-        Box::pin(build_stream(
+        Box::pin(run_stream(
             from,
             self.subscribe_proven_tip(),
             ProofSource {
@@ -96,11 +129,12 @@ impl State {
 
 pub trait SubscriptionSource: Send + Sync + 'static {
     type Event: Send + 'static;
+    type Error: std::error::Error + Send + 'static;
 
     fn fetch(
         &self,
         block_num: BlockNumber,
-    ) -> impl Future<Output = Result<Vec<u8>, StateSubscriptionError>> + Send + '_;
+    ) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + Send + '_;
 
     fn build_event(&self, block_num: BlockNumber, data: Vec<u8>, tip: BlockNumber) -> Self::Event;
 }
@@ -112,16 +146,17 @@ struct BlockSource {
 
 impl SubscriptionSource for BlockSource {
     type Event = BlockSubscriptionEvent;
+    type Error = BlockSubscriptionError;
 
-    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, StateSubscriptionError> {
+    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, BlockSubscriptionError> {
         if let Some(entry) = self.cache.get(block_num) {
             return Ok(entry.block_bytes().to_vec());
         }
         self.state
             .load_block(block_num)
             .await
-            .map_err(|source| StateSubscriptionError::BlockLoad { block_num, source })?
-            .ok_or(StateSubscriptionError::BlockNotFound(block_num))
+            .map_err(|source| BlockSubscriptionError::Load { block_num, source })?
+            .ok_or(BlockSubscriptionError::NotFound(block_num))
     }
 
     fn build_event(
@@ -141,16 +176,17 @@ struct ProofSource {
 
 impl SubscriptionSource for ProofSource {
     type Event = ProofSubscriptionEvent;
+    type Error = ProofSubscriptionError;
 
-    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, StateSubscriptionError> {
+    async fn fetch(&self, block_num: BlockNumber) -> Result<Vec<u8>, ProofSubscriptionError> {
         if let Some(entry) = self.cache.get(block_num) {
             return Ok(entry.proof_bytes().to_vec());
         }
         self.state
             .load_proof(block_num)
             .await
-            .map_err(|source| StateSubscriptionError::ProofLoad { block_num, source })?
-            .ok_or(StateSubscriptionError::ProofNotFound(block_num))
+            .map_err(|source| ProofSubscriptionError::Load { block_num, source })?
+            .ok_or(ProofSubscriptionError::NotFound(block_num))
     }
 
     fn build_event(
@@ -166,32 +202,33 @@ impl SubscriptionSource for ProofSource {
 // STREAM
 // ================================================================================================
 
-fn build_stream<S: SubscriptionSource>(
+/// Drives a generic subscription stream, replaying history then following live tip advances.
+///
+/// Calls [`SubscriptionSource::fetch`] for each block in sequence starting from `from`, builds an
+/// event with [`SubscriptionSource::build_event`], and sends it to `tx`. Disconnects the
+/// subscriber with [`SubscriptionStreamError::TooSlow`] if it falls too far behind the tip or if a
+/// single send blocks for longer than [`SEND_TIMEOUT`], which may occur only after the buffer has
+/// [`SUBSCRIBER_CHANNEL_CAPACITY`] blocks queued.
+pub fn run_stream<S: SubscriptionSource>(
     from: BlockNumber,
     tip_rx: watch::Receiver<BlockNumber>,
     source: S,
-) -> impl Stream<Item = Result<S::Event, StateSubscriptionError>> + Send + 'static {
+) -> impl Stream<Item = Result<S::Event, SubscriptionStreamError<S::Error>>> + Send + 'static {
     let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
     tokio::spawn(async move {
-        if let Err(err) = run_stream(from, tip_rx, &tx, source).await {
+        if let Err(err) = run_stream_inner(from, tip_rx, &tx, source).await {
             let _ = tx.send(Err(err)).await;
         }
     });
     ReceiverStream::new(rx)
 }
 
-/// Drives a generic subscription stream, replaying history then following live tip advances.
-///
-/// Calls [`SubscriptionSource::fetch`] for each block in sequence starting from `from`, builds an
-/// event with [`SubscriptionSource::build_event`], and sends it to `tx`. Disconnects the
-/// subscriber with [`StateSubscriptionError::TooSlow`] if a single send blocks for longer than [`SEND_TIMEOUT`]
-/// which may occur only after the buffer has [`SUBSCRIBER_CHANNEL_CAPACITY`] blocks queued.
-pub async fn run_stream<S: SubscriptionSource>(
+async fn run_stream_inner<S: SubscriptionSource>(
     from: BlockNumber,
     mut tip_rx: watch::Receiver<BlockNumber>,
-    tx: &mpsc::Sender<Result<S::Event, StateSubscriptionError>>,
+    tx: &mpsc::Sender<Result<S::Event, SubscriptionStreamError<S::Error>>>,
     source: S,
-) -> Result<(), StateSubscriptionError> {
+) -> Result<(), SubscriptionStreamError<S::Error>> {
     let mut next = from;
     let mut previous_gap = tip_rx.borrow().as_u32();
     let mut running_gap = 0u32;
@@ -199,7 +236,8 @@ pub async fn run_stream<S: SubscriptionSource>(
         let mut tip = *tip_rx.borrow_and_update();
 
         let current_gap = tip.saturating_sub(next.as_u32()).as_u32();
-        (previous_gap, running_gap) = check_growing_gap(current_gap, previous_gap, running_gap)?;
+        (previous_gap, running_gap) = check_growing_gap(current_gap, previous_gap, running_gap, MAX_RUNNING_GAP)
+            .map_err(|()| SubscriptionStreamError::TooSlow)?;
 
         while next <= tip {
             let data = source.fetch(next).await?;
@@ -207,7 +245,7 @@ pub async fn run_stream<S: SubscriptionSource>(
             let permit = match tokio::time::timeout(SEND_TIMEOUT, tx.reserve()).await {
                 Ok(Ok(permit)) => permit,
                 Ok(Err(_)) => return Ok(()),
-                Err(_) => return Err(StateSubscriptionError::TooSlow),
+                Err(_) => return Err(SubscriptionStreamError::TooSlow),
             };
             permit.send(Ok(source.build_event(next, data, tip)));
             next = next.child();
@@ -224,20 +262,20 @@ pub async fn run_stream<S: SubscriptionSource>(
 ///
 /// The total increases by the block-count delta each time the gap grows, and decreases by the
 /// delta each time it shrinks (saturating at zero). Returns updated `(previous_gap, running_gap)`
-/// on success, or [`StateSubscriptionError::TooSlow`] once the running total exceeds
-/// [`MAX_RUNNING_GAP`].
+/// on success, or `Err(())` once the running total exceeds `max_gap`.
 fn check_growing_gap(
     current_gap: u32,
     previous_gap: u32,
     running_gap: u32,
-) -> Result<(u32, u32), StateSubscriptionError> {
+    max_gap: u32
+) -> Result<(u32, u32), ()> {
     let running_gap = if current_gap > previous_gap {
         running_gap + (current_gap - previous_gap)
     } else {
         running_gap.saturating_sub(previous_gap - current_gap)
     };
-    if running_gap > MAX_RUNNING_GAP {
-        return Err(StateSubscriptionError::TooSlow);
+    if running_gap > max_gap {
+        return Err(());
     }
     Ok((current_gap, running_gap))
 }
@@ -249,11 +287,11 @@ fn check_growing_gap(
 mod tests {
     use super::*;
 
-    fn run(gaps: &[u32]) -> Result<(), StateSubscriptionError> {
+    fn run(gaps: &[u32]) -> Result<(), ()> {
         let mut previous_gap = gaps.first().copied().unwrap_or(u32::MAX);
         let mut growth_run = 0u32;
         for &gap in gaps {
-            (previous_gap, growth_run) = check_growing_gap(gap, previous_gap, growth_run)?;
+            (previous_gap, growth_run) = check_growing_gap(gap, previous_gap, growth_run, MAX_RUNNING_GAP)?;
         }
         Ok(())
     }
@@ -289,7 +327,7 @@ mod tests {
     #[test]
     fn exceeding_max_growth_run_returns_too_slow() {
         // One block past the limit triggers TooSlow, even in a single jump.
-        assert!(matches!(run(&[0, MAX_RUNNING_GAP + 1]), Err(StateSubscriptionError::TooSlow)));
+        assert!(matches!(run(&[0, MAX_RUNNING_GAP + 1]), Err(())));
     }
 
     #[test]
@@ -298,7 +336,7 @@ mod tests {
         // past MAX_RUNNING_GAP.
         let step = MAX_RUNNING_GAP / 4;
         let gaps: Vec<u32> = (1..=6).map(|i| i * step).collect(); // total growth = 5 * step
-        assert!(matches!(run(&gaps), Err(StateSubscriptionError::TooSlow)));
+        assert!(matches!(run(&gaps), Err(())));
     }
 
     #[test]
@@ -313,6 +351,6 @@ mod tests {
         // A client that grows by a large amount then shrinks by just one block on each cycle
         // accumulates net growth and is eventually disconnected.
         let gaps: Vec<u32> = (0u32..MAX_RUNNING_GAP + 10).flat_map(|i| [50 + i, 49 + i]).collect();
-        assert!(matches!(run(&gaps), Err(StateSubscriptionError::TooSlow)));
+        assert!(matches!(run(&gaps), Err(())));
     }
 }

--- a/docs/external/src/network-operator/recovery.md
+++ b/docs/external/src/network-operator/recovery.md
@@ -48,12 +48,6 @@ must be imported or re-proven separately as part of recovery before the node res
 4. Commission proofs for the recovered blocks.
 5. Restart the node as a sequencer. See [Sequencer](/network-operator/sequencer).
 
-## Data Loss
-
-There is always some risk of data loss during failover because full nodes follow the sequencer asynchronously. Recovery
-narrows this gap by replaying any committed blocks the validator signed but the promotion target never replicated.
-Blocks that were never sent to the validator cannot be recovered.
-
 ## Common Configuration
 
 | Option             | Purpose                                               |

--- a/docs/external/src/network-operator/recovery.md
+++ b/docs/external/src/network-operator/recovery.md
@@ -1,0 +1,64 @@
+---
+title: "Recovery"
+sidebar_position: 10
+---
+
+# Recovery
+
+Recovery restores missing committed block data to a node from the validator's block backup. It is used when promoting a
+full node to sequencer after the active sequencer is lost, and the promotion target is missing committed blocks.
+
+This complements the [Sequencer Failover](/network-operator/sequencer) flow. Full nodes replicate the sequencer
+asynchronously, so a node promoted to sequencer can be behind the committed chain tip. The
+[Validator](/network-operator/validator) retains the raw block data for every block it signed, which lets it serve those
+missing blocks back to the promotion target.
+
+## When to recover
+
+Recover when both of the following hold:
+
+- The active sequencer is lost or being replaced, and a full node is being promoted to take its place.
+- The promotion target is behind the committed chain tip and cannot catch up from another in-sync source.
+
+If the promotion target is already in sync with the committed chain tip, recovery is unnecessary; promote it directly.
+
+## What recovery does
+
+The `miden-node recover` command streams the validator's signed blocks into the node's local storage, starting from the
+node's current committed tip and stopping once it reaches the validator's chain tip. It then exits.
+
+Recovered blocks are signed but **carry no proofs** — the validator backs up block data, not block proofs. These blocks
+must be imported or re-proven separately as part of recovery before the node resumes block production as a sequencer.
+
+## Procedure
+
+1. Stop the sequencer, if it is not down already.
+2. Stop the full node being promoted.
+3. Run recovery against the validator, pointed at the promotion target's data directory:
+
+   ```bash
+   miden-node recover \
+     --data-directory node-data \
+     --validator.url http://validator:50101
+   ```
+
+   The command applies blocks up to the validator's chain tip and exits. If the node is already at the validator's chain
+   tip, it reports that there is nothing to recover and exits successfully.
+
+4. Commission proofs for the recovered blocks.
+5. Restart the node as a sequencer. See [Sequencer](/network-operator/sequencer).
+
+## Data Loss
+
+There is always some risk of data loss during failover because full nodes follow the sequencer asynchronously. Recovery
+narrows this gap by replaying any committed blocks the validator signed but the promotion target never replicated. Blocks
+that were never sent to the validator cannot be recovered.
+
+## Common Configuration
+
+| Option             | Purpose                                                  |
+| ------------------ | -------------------------------------------------------- |
+| `--data-directory` | Local data storage of the node being recovered.         |
+| `--validator.url`  | Internal validator service URL to stream blocks from.   |
+
+Use `miden-node recover --help` for the complete current option list.

--- a/docs/external/src/network-operator/recovery.md
+++ b/docs/external/src/network-operator/recovery.md
@@ -51,14 +51,14 @@ must be imported or re-proven separately as part of recovery before the node res
 ## Data Loss
 
 There is always some risk of data loss during failover because full nodes follow the sequencer asynchronously. Recovery
-narrows this gap by replaying any committed blocks the validator signed but the promotion target never replicated. Blocks
-that were never sent to the validator cannot be recovered.
+narrows this gap by replaying any committed blocks the validator signed but the promotion target never replicated.
+Blocks that were never sent to the validator cannot be recovered.
 
 ## Common Configuration
 
-| Option             | Purpose                                                  |
-| ------------------ | -------------------------------------------------------- |
-| `--data-directory` | Local data storage of the node being recovered.         |
-| `--validator.url`  | Internal validator service URL to stream blocks from.   |
+| Option             | Purpose                                               |
+| ------------------ | ----------------------------------------------------- |
+| `--data-directory` | Local data storage of the node being recovered.       |
+| `--validator.url`  | Internal validator service URL to stream blocks from. |
 
 Use `miden-node recover --help` for the complete current option list.

--- a/docs/external/src/network-operator/recovery.md
+++ b/docs/external/src/network-operator/recovery.md
@@ -9,7 +9,8 @@ Recovery restores missing committed block data to a node from the validator's bl
 full node to sequencer after the active sequencer is lost, and the promotion target is missing committed blocks.
 
 This complements the [Sequencer Failover](/network-operator/sequencer) flow. Full nodes replicate the sequencer state
-asynchronously, so there is no guarantee that the node is fully up to date if the sequencer fails. These missing data can always be recovered from the validator because it has to a sign every block before it can be committed.
+asynchronously, so there is no guarantee that the node is fully up to date if the sequencer fails. These missing data
+can always be recovered from the validator because it has to a sign every block before it can be committed.
 
 ## When to recover
 

--- a/docs/external/src/network-operator/recovery.md
+++ b/docs/external/src/network-operator/recovery.md
@@ -8,10 +8,8 @@ sidebar_position: 10
 Recovery restores missing committed block data to a node from the validator's block backup. It is used when promoting a
 full node to sequencer after the active sequencer is lost, and the promotion target is missing committed blocks.
 
-This complements the [Sequencer Failover](/network-operator/sequencer) flow. Full nodes replicate the sequencer
-asynchronously, so a node promoted to sequencer can be behind the committed chain tip. The
-[Validator](/network-operator/validator) retains the raw block data for every block it signed, which lets it serve those
-missing blocks back to the promotion target.
+This complements the [Sequencer Failover](/network-operator/sequencer) flow. Full nodes replicate the sequencer state
+asynchronously, so there is no guarantee that the node is fully up to date if the sequencer fails. These missing data can always be recovered from the validator because it has to a sign every block before it can be committed.
 
 ## When to recover
 
@@ -19,8 +17,6 @@ Recover when both of the following hold:
 
 - The active sequencer is lost or being replaced, and a full node is being promoted to take its place.
 - The promotion target is behind the committed chain tip and cannot catch up from another in-sync source.
-
-If the promotion target is already in sync with the committed chain tip, recovery is unnecessary; promote it directly.
 
 ## What recovery does
 
@@ -47,12 +43,3 @@ must be imported or re-proven separately as part of recovery before the node res
 
 4. Commission proofs for the recovered blocks.
 5. Restart the node as a sequencer. See [Sequencer](/network-operator/sequencer).
-
-## Common Configuration
-
-| Option             | Purpose                                               |
-| ------------------ | ----------------------------------------------------- |
-| `--data-directory` | Local data storage of the node being recovered.       |
-| `--validator.url`  | Internal validator service URL to stream blocks from. |
-
-Use `miden-node recover --help` for the complete current option list.

--- a/docs/external/src/network-operator/sequencer.md
+++ b/docs/external/src/network-operator/sequencer.md
@@ -44,7 +44,7 @@ valid replacement until it has caught up to the committed chain tip.
 There is always some risk of data loss during failover because full nodes follow the sequencer asynchronously. Blocks
 committed by the sequencer but not yet replicated to the promoted full node may be missing from that node's local state.
 The validator also retains a copy of the blocks it validated and signed, and can be used to recover missing committed
-block data when this occurs.
+block data when this occurs. See [Recovery](/network-operator/recovery) for the procedure.
 
 ## Common Configuration
 

--- a/proto/proto/internal/validator.proto
+++ b/proto/proto/internal/validator.proto
@@ -20,6 +20,32 @@ service Api {
 
    // Validates and signs a proposed block, returning the signature and the signed block commitment.
    rpc SignBlock(blockchain.ProposedBlock) returns (blockchain.SignBlockResponse) {}
+
+   // Streams signed blocks starting from the given block number (inclusive).
+   //
+   // Replays backed-up blocks first, then streams live blocks as they are signed. Unlike the RPC
+   // block subscription, the blocks streamed here carry no proofs; they must be commissioned
+   // separately as part of recovery.
+   rpc BlockSubscription(BlockSubscriptionRequest) returns (stream BlockSubscriptionResponse) {}
+}
+
+// BLOCK SUBSCRIPTION
+// ================================================================================================
+
+// Request to subscribe to the signed block stream.
+message BlockSubscriptionRequest {
+    // The block number to start streaming from (inclusive).
+    fixed32 block_from = 1;
+}
+
+// A signed block streamed to a subscriber.
+message BlockSubscriptionResponse {
+    // The block encoded using [miden_serde_utils::Serializable] implementation for
+    // [miden_protocol::block::SignedBlock].
+    bytes block = 1;
+
+    // The signed chain tip when this item was emitted.
+    fixed32 committed_chain_tip = 2;
 }
 
 // VALIDATOR STATUS


### PR DESCRIPTION
## Summary

Closes #2169.
<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "validator"
impact      = "added"
description = "Block streaming gRPC endpoint for Validator"
```
