### PR TITLE
chore: switch back to miden `next` git dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [BREAKING] Updated `miden-protocol` dependencies to use the `next` branch (v0.16). Block and transaction account updates now use the absolute `AccountPatch` representation instead of the relative `AccountDelta`, and the `miden-tx-batch-prover` crate was renamed to `miden-tx-batch` ([#2258](https://github.com/0xMiden/node/pull/2258)).
+
 ## v0.15.0 (2026-06-10)
 
 - Fixed the store dropping a fungible asset's callback flag when applying partial account deltas ([#2222](https://github.com/0xMiden/node/pull/2222)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,9 +2885,8 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292ded918a0ddd056dc34db471f0bef6ac7991467d513ba505a4fcc0b1ecfac4"
+version = "0.16.0"
+source = "git+https://github.com/0xMiden/protocol.git?branch=next#91d1e88be50a3fa18cfb3b0c99b3cbdd31a68606"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -3196,7 +3195,7 @@ dependencies = [
  "miden-protocol",
  "miden-remote-prover-client",
  "miden-standards",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "pretty_assertions",
  "rand 0.9.4",
  "rand_chacha",
@@ -3295,8 +3294,7 @@ dependencies = [
  "miden-node-utils",
  "miden-protocol",
  "miden-standards",
- "miden-tx",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "reqwest",
  "rstest",
  "semver 1.0.28",
@@ -3495,9 +3493,8 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66340243e37da5936cb278a8dd11037813f1dc6731c2fc866703b76ed465ebc3"
+version = "0.16.0"
+source = "git+https://github.com/0xMiden/protocol.git?branch=next#91d1e88be50a3fa18cfb3b0c99b3cbdd31a68606"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3554,7 +3551,7 @@ dependencies = [
  "miden-protocol",
  "miden-testing",
  "miden-tx",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "opentelemetry",
  "serial_test",
  "tokio",
@@ -3599,9 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c7146b028e637f4079b5bdefeefc54d7d6e47a805451fa0a18859d19efa2ff"
+version = "0.16.0"
+source = "git+https://github.com/0xMiden/protocol.git?branch=next#91d1e88be50a3fa18cfb3b0c99b3cbdd31a68606"
 dependencies = [
  "bon",
  "fs-err",
@@ -3638,9 +3634,8 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4096fc44a4c88f37405be284e25efdce194d6051e9472ae136ab9249659433c"
+version = "0.16.0"
+source = "git+https://github.com/0xMiden/protocol.git?branch=next#91d1e88be50a3fa18cfb3b0c99b3cbdd31a68606"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3651,7 +3646,7 @@ dependencies = [
  "miden-protocol",
  "miden-standards",
  "miden-tx",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "rand 0.9.4",
  "rand_chacha",
  "thiserror 2.0.18",
@@ -3659,26 +3654,26 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94092b45bc0abc656af25473c9807d1e6cee8e682c58d3b1186f0bd0fb6471fb"
+version = "0.16.0"
+source = "git+https://github.com/0xMiden/protocol.git?branch=next#91d1e88be50a3fa18cfb3b0c99b3cbdd31a68606"
 dependencies = [
  "miden-processor",
  "miden-protocol",
  "miden-prover",
  "miden-standards",
- "miden-verifier",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "miden-tx-batch-prover"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60add2b40559352661bc86970541f88ffcf98c528f301295f9dc3bf15481b46"
+name = "miden-tx-batch"
+version = "0.16.0"
+source = "git+https://github.com/0xMiden/protocol.git?branch=next#91d1e88be50a3fa18cfb3b0c99b3cbdd31a68606"
 dependencies = [
+ "miden-processor",
  "miden-protocol",
- "miden-tx",
+ "miden-prover",
+ "miden-verifier",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,12 @@ miden-remote-prover-client      = { path = "crates/remote-prover-client", versio
 miden-node-rocksdb-cxx-linkage-fix = { path = "crates/rocksdb-cxx-linkage-fix", version = "0.15.0" }
 
 # miden-protocol dependencies. These should be updated in sync.
-# Requires the v0.15.2 patch release, which carries the network-account tx-script
-# allowlist (0xMiden/protocol#3028) and the `with_allowed_notes` rename (#3049).
-miden-block-prover    = { version = "0.15.3" }
-miden-protocol        = { default-features = false, version = "0.15.3" }
-miden-standards       = { version = "0.15.3" }
-miden-testing         = { version = "0.15.3" }
-miden-tx              = { default-features = false, version = "0.15.3" }
-miden-tx-batch-prover = { version = "0.15.3" }
+miden-block-prover = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
+miden-protocol     = { branch = "next", default-features = false, git = "https://github.com/0xMiden/protocol.git" }
+miden-standards    = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
+miden-testing      = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
+miden-tx           = { branch = "next", default-features = false, git = "https://github.com/0xMiden/protocol.git" }
+miden-tx-batch     = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
 
 # Other miden dependencies. These should align with those expected by miden-protocol.
 miden-crypto = { version = "0.25" }

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -31,9 +31,9 @@ use miden_protocol::note::{
 use miden_protocol::transaction::{InputNotes, PartialBlockchain, TransactionArgs};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_protocol::{Felt, Word};
-use miden_standards::account::interface::{AccountInterface, AccountInterfaceExt};
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
+use miden_standards::tx_script::SendNotesTransactionScript;
 use miden_tx::auth::BasicAuthenticator;
 use miden_tx::{LocalTransactionProver, TransactionExecutor};
 use rand::{Rng, SeedableRng};
@@ -273,17 +273,16 @@ impl IncrementService {
         err
     )]
     async fn submit_increment(&mut self) -> Result<(String, AccountHeader, BlockNumber)> {
-        let account_interface = AccountInterface::from_account(&self.tx.wallet_account);
-
         let (network_note, note_recipient) = create_network_note(
             &self.tx.wallet_account,
             &self.tx.counter_account,
             self.tx.increment_script.clone(),
             &mut self.tx.rng,
         )?;
-        let script = account_interface.build_send_notes_script(&[network_note.into()], None)?;
+        let interface = self.tx.wallet_account.code().interface(self.tx.wallet_account.id());
+        let script = SendNotesTransactionScript::new(&interface, &[network_note.into()])?;
 
-        let mut tx_args = TransactionArgs::default().with_tx_script(script);
+        let mut tx_args = TransactionArgs::default().with_tx_script(script.into());
         tx_args.add_output_note_recipient(Box::new(note_recipient));
 
         let wallet_account = self.tx.wallet_account.clone();

--- a/bin/network-monitor/src/deploy/mod.rs
+++ b/bin/network-monitor/src/deploy/mod.rs
@@ -331,7 +331,7 @@ impl DataStore for MonitorDataStore {
         }
 
         Result::<Vec<_>, _>::from_iter(vault_keys.into_iter().map(|vault_key| {
-            AssetWitness::new(account.vault().open(vault_key).into()).map_err(|err| {
+            AssetWitness::new(account.vault().open(vault_key).into(), [vault_key]).map_err(|err| {
                 DataStoreError::Other {
                     error_msg: "failed to open vault asset tree".into(),
                     source: Some(Box::new(err)),

--- a/bin/network-monitor/src/deploy/wallet.rs
+++ b/bin/network-monitor/src/deploy/wallet.rs
@@ -5,7 +5,7 @@ use miden_node_utils::crypto::get_random_coin;
 use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::account::{Account, AccountType};
 use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey;
-use miden_standards::AuthMethod;
+use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::wallets::create_basic_wallet;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -20,9 +20,7 @@ use crate::COMPONENT;
 pub fn create_wallet_account() -> Result<(Account, SecretKey)> {
     let mut rng = ChaCha20Rng::from_seed(rand::random());
     let secret_key = SecretKey::with_rng(&mut get_random_coin(&mut rng));
-    let auth = AuthMethod::SingleSig {
-        approver: (secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2),
-    };
+    let auth = AuthSingleSig::new(secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2);
     let init_seed: [u8; 32] = rng.random();
 
     let wallet_account = create_basic_wallet(init_seed, auth, AccountType::Public)?;

--- a/bin/ntx-builder/src/actor/mod.rs
+++ b/bin/ntx-builder/src/actor/mod.rs
@@ -654,7 +654,7 @@ mod tests {
     use std::num::NonZeroU16;
 
     use miden_protocol::ONE;
-    use miden_protocol::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
+    use miden_protocol::account::{Account, AccountDelta, AccountStoragePatch, AccountVaultDelta};
     use tokio::sync::Notify;
 
     use super::*;
@@ -665,7 +665,7 @@ mod tests {
     fn nonce_bump_delta(account_id: AccountId) -> AccountDelta {
         AccountDelta::new(
             account_id,
-            AccountStorageDelta::default(),
+            AccountStoragePatch::default(),
             AccountVaultDelta::default(),
             ONE,
         )

--- a/bin/ntx-builder/src/committed_block.rs
+++ b/bin/ntx-builder/src/committed_block.rs
@@ -1,5 +1,4 @@
-use miden_protocol::account::AccountId;
-use miden_protocol::account::delta::AccountUpdateDetails;
+use miden_protocol::account::{AccountId, AccountUpdateDetails};
 use miden_protocol::block::{BlockHeader, SignedBlock};
 use miden_protocol::note::Nullifier;
 use miden_protocol::transaction::{OutputNote, TransactionId};

--- a/bin/ntx-builder/src/coordinator.rs
+++ b/bin/ntx-builder/src/coordinator.rs
@@ -388,7 +388,7 @@ mod tests {
             nullifiers: vec![],
             network_account_updates: vec![(
                 updated_id,
-                miden_protocol::account::delta::AccountUpdateDetails::Private,
+                miden_protocol::account::AccountUpdateDetails::Private,
             )],
             account_transactions: vec![],
         };

--- a/bin/ntx-builder/src/db/models/account_effect.rs
+++ b/bin/ntx-builder/src/db/models/account_effect.rs
@@ -1,5 +1,4 @@
-use miden_protocol::account::delta::AccountUpdateDetails;
-use miden_protocol::account::{Account, AccountDelta};
+use miden_protocol::account::{Account, AccountPatch, AccountUpdateDetails};
 use miden_standards::account::auth::NetworkAccount;
 
 // NETWORK ACCOUNT EFFECT
@@ -9,23 +8,23 @@ use miden_standards::account::auth::NetworkAccount;
 #[derive(Clone)]
 pub enum NetworkAccountEffect {
     Created(Account),
-    Updated(AccountDelta),
+    Updated(AccountPatch),
 }
 
 impl NetworkAccountEffect {
     pub fn from_protocol(update: &AccountUpdateDetails) -> Option<Self> {
         match update {
             AccountUpdateDetails::Private => None,
-            AccountUpdateDetails::Delta(update) if update.is_full_state() => {
+            AccountUpdateDetails::Public(update) if update.is_full_state() => {
                 // Only treat full-state creations as network if the storage carries the
                 // standardized `NetworkAccountNoteAllowlist` slot.
                 let account = Account::try_from(update)
-                    .expect("Account should be derivable by full state AccountDelta");
+                    .expect("Account should be derivable by full state AccountPatch");
                 NetworkAccount::new(account)
                     .ok()
                     .map(|na| NetworkAccountEffect::Created(na.into_account()))
             },
-            AccountUpdateDetails::Delta(update) => {
+            AccountUpdateDetails::Public(update) => {
                 // Partial updates carry no storage we can inspect here. Forward them as updates and
                 // let the coordinator's actor registry filter to known network accounts.
                 Some(NetworkAccountEffect::Updated(update.clone()))

--- a/bin/ntx-builder/src/db/models/queries/mod.rs
+++ b/bin/ntx-builder/src/db/models/queries/mod.rs
@@ -74,14 +74,14 @@ pub fn apply_committed_block(
             NetworkAccountEffect::Created(account) => {
                 upsert_account(conn, *account_id, &account, last_tx_id)?;
             },
-            NetworkAccountEffect::Updated(delta) => {
+            NetworkAccountEffect::Updated(patch) => {
                 // If the account is not already tracked locally, skip it.
                 let Some(mut current) = get_account(conn, *account_id)? else {
                     continue;
                 };
                 current
-                    .apply_delta(&delta)
-                    .expect("network account delta should apply since the block was committed");
+                    .apply_patch(&patch)
+                    .expect("network account patch should apply since the block was committed");
                 upsert_account(conn, *account_id, &current, last_tx_id)?;
             },
         }

--- a/bin/ntx-builder/src/test_utils.rs
+++ b/bin/ntx-builder/src/test_utils.rs
@@ -119,12 +119,10 @@ pub fn mock_genesis_block() -> miden_protocol::block::SignedBlock {
 
 /// Builds a full-state [`AccountUpdateDetails`] for a network account. The returned account passes
 /// `NetworkAccount::new`, so the ntx-builder treats the update as a network-account creation.
-pub fn mock_network_account_update()
--> (Account, miden_protocol::account::delta::AccountUpdateDetails) {
+pub fn mock_network_account_update() -> (Account, miden_protocol::account::AccountUpdateDetails) {
     use std::collections::BTreeSet;
 
-    use miden_protocol::account::AccountDelta;
-    use miden_protocol::account::delta::AccountUpdateDetails;
+    use miden_protocol::account::{AccountPatch, AccountUpdateDetails};
     use miden_standards::account::auth::AuthNetworkAccount;
 
     // The allowlist content is irrelevant here; any non-empty set yields a valid network account.
@@ -133,8 +131,8 @@ pub fn mock_network_account_update()
         AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([root]))
             .expect("non-empty allowlist should construct"),
     );
-    let details = AccountUpdateDetails::Delta(
-        AccountDelta::try_from(account.clone()).expect("full-state delta should build"),
+    let details = AccountUpdateDetails::Public(
+        AccountPatch::try_from(account.clone()).expect("full-state patch should build"),
     );
     (account, details)
 }

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -25,7 +25,7 @@ miden-node-proto-build = { features = ["internal"], workspace = true }
 miden-node-utils       = { workspace = true }
 miden-protocol         = { features = ["std"], workspace = true }
 miden-tx               = { features = ["concurrent", "std"], workspace = true }
-miden-tx-batch-prover  = { features = ["std"], workspace = true }
+miden-tx-batch         = { features = ["std"], workspace = true }
 opentelemetry          = { workspace = true }
 tokio                  = { features = ["full"], workspace = true }
 tokio-stream           = { features = ["net"], workspace = true }

--- a/bin/remote-prover/src/server/prover.rs
+++ b/bin/remote-prover/src/server/prover.rs
@@ -9,7 +9,7 @@ use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::BlockProof;
 use miden_protocol::transaction::{ProvenTransaction, TransactionInputs};
 use miden_tx::LocalTransactionProver;
-use miden_tx_batch_prover::LocalBatchProver;
+use miden_tx_batch::{BatchExecutor, LocalBatchProver};
 use tracing::{Instrument, instrument};
 
 use crate::COMPONENT;
@@ -27,7 +27,7 @@ impl Prover {
     pub fn new(proof_type: ProofKind) -> Self {
         match proof_type {
             ProofKind::Transaction => Self::Transaction(LocalTransactionProver::default()),
-            ProofKind::Batch => Self::Batch(LocalBatchProver::new(MIN_PROOF_SECURITY_LEVEL)),
+            ProofKind::Batch => Self::Batch(LocalBatchProver::new()),
             ProofKind::Block => Self::Block(LocalBlockProver::new(MIN_PROOF_SECURITY_LEVEL)),
         }
     }
@@ -116,8 +116,11 @@ impl ProveRequest for LocalBatchProver {
         let prover = self.clone();
 
         spawn_blocking_in_current_span(move || {
+            let executed_batch = BatchExecutor::new().execute(input).map_err(|e| {
+                tonic::Status::internal(e.as_report_context("failed to execute batch"))
+            })?;
             prover
-                .prove(input)
+                .prove(executed_batch)
                 .map_err(|e| tonic::Status::internal(e.as_report_context("failed to prove batch")))
         })
         .await

--- a/bin/remote-prover/src/server/tests.rs
+++ b/bin/remote-prover/src/server/tests.rs
@@ -12,11 +12,11 @@ use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::note::NoteType;
 use miden_protocol::testing::account_id::{ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET, ACCOUNT_ID_SENDER};
-use miden_protocol::transaction::{ExecutedTransaction, ProvenTransaction};
+use miden_protocol::transaction::{ExecutedTransaction, ProvenTransaction, TransactionVerifier};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_testing::{Auth, MockChainBuilder};
-use miden_tx::{LocalTransactionProver, TransactionVerifier};
-use miden_tx_batch_prover::LocalBatchProver;
+use miden_tx::LocalTransactionProver;
+use miden_tx_batch::BatchVerifier;
 use serial_test::serial;
 
 use crate::server::Server;
@@ -140,6 +140,7 @@ impl ProofRequestExt for ProofRequest {
             mock_chain.latest_block_header(),
             mock_chain.latest_partial_blockchain(),
             BTreeMap::new(),
+            MIN_PROOF_SECURITY_LEVEL,
         )
         .unwrap()
     }
@@ -367,7 +368,7 @@ async fn transaction_proof_is_correct() {
 
 /// Checks that the a batch request results in a correct proof.
 ///
-/// The proof is replicated locally, which ensures that the gRPC codec and server code do the
+/// The proof is verified locally, which ensures that the gRPC codec and server code do the
 /// correct thing.
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
@@ -384,10 +385,8 @@ async fn batch_proof_is_correct() {
     let response = client.submit_request(request).await.unwrap();
     let response = ProvenBatch::read_from_bytes(&response.payload).unwrap();
 
-    let expected = tokio::task::block_in_place(|| {
-        LocalBatchProver::new(MIN_PROOF_SECURITY_LEVEL).prove(batch).unwrap()
-    });
-    assert_eq!(response, expected);
+    assert_eq!(response.id(), batch.id());
+    BatchVerifier::new(MIN_PROOF_SECURITY_LEVEL).verify(&response).unwrap();
 
     server.abort();
 }

--- a/bin/stress-test/src/seeding/mod.rs
+++ b/bin/stress-test/src/seeding/mod.rs
@@ -8,17 +8,17 @@ use miden_node_proto::domain::batch::BatchInputs;
 use miden_node_store::{DataDirectory, GenesisState, State};
 use miden_node_utils::clap::StorageOptions;
 use miden_protocol::account::auth::AuthScheme;
-use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::account::{
     Account,
     AccountBuilder,
     AccountComponent,
     AccountComponentMetadata,
-    AccountDelta,
     AccountId,
-    AccountStorageDelta,
+    AccountPatch,
+    AccountStoragePatch,
     AccountType,
-    AccountVaultDelta,
+    AccountUpdateDetails,
+    AccountVaultPatch,
     StorageMap,
     StorageMapKey,
     StorageSlot,
@@ -55,12 +55,7 @@ use miden_protocol::vm::ExecutionProof;
 use miden_protocol::{Felt, ONE, Word};
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::faucets::{FungibleFaucet, TokenName};
-use miden_standards::account::policies::{
-    BurnPolicyConfig,
-    MintPolicyConfig,
-    PolicyRegistration,
-    TokenPolicyManager,
-};
+use miden_standards::account::policies::{BurnPolicy, MintPolicy, TokenPolicyManager};
 use miden_standards::account::wallets::BasicWallet;
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::note::P2idNote;
@@ -577,11 +572,10 @@ fn create_faucet_with_seed(index: u64) -> Account {
         .account_type(AccountType::Private)
         .with_component(faucet)
         .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap()
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)
-                .unwrap(),
+            TokenPolicyManager::builder()
+                .active_mint_policy(MintPolicy::allow_all())
+                .active_burn_policy(BurnPolicy::allow_all())
+                .build(),
         )
         .with_auth_component(AuthSingleSig::new(
             key_pair.public_key().into(),
@@ -608,6 +602,7 @@ fn create_batch(txs: &[ProvenTransaction], block_ref: &BlockHeader) -> ProvenBat
         output_notes,
         BlockNumber::MAX,
         OrderedTransactionHeaders::new_unchecked(txs.iter().map(TransactionHeader::from).collect()),
+        ExecutionProof::new_dummy(),
     )
     .unwrap()
 }
@@ -663,14 +658,14 @@ fn create_consume_note_tx(
 
     account.increment_nonce(ONE).unwrap();
 
-    let (details, account_delta_commitment) = if account.is_public() {
-        let account_delta = if is_new_account {
-            AccountDelta::try_from(account.clone()).unwrap()
+    let (details, account_patch_commitment) = if account.is_public() {
+        let account_patch = if is_new_account {
+            AccountPatch::try_from(account.clone()).unwrap()
         } else {
-            create_existing_account_delta(&account, input_note.note().assets(), storage_update)
+            create_existing_account_patch(&account, input_note.note().assets(), storage_update)
         };
-        let commitment = account_delta.clone().to_commitment();
-        (AccountUpdateDetails::Delta(account_delta), commitment)
+        let commitment = account_patch.to_commitment();
+        (AccountUpdateDetails::Public(account_patch), commitment)
     } else {
         (AccountUpdateDetails::Private, Word::empty())
     };
@@ -679,7 +674,7 @@ fn create_consume_note_tx(
         account.id(),
         init_hash,
         account.to_commitment(),
-        account_delta_commitment,
+        account_patch_commitment,
         details,
     )
     .unwrap();
@@ -698,24 +693,28 @@ fn create_consume_note_tx(
     (account, transaction)
 }
 
-fn create_existing_account_delta(
+fn create_existing_account_patch(
     account: &Account,
     note_assets: &NoteAssets,
     storage_update: Option<(BenchmarkStorageUpdate, usize)>,
-) -> AccountDelta {
-    let mut vault_delta = AccountVaultDelta::default();
+) -> AccountPatch {
+    let mut vault_patch = AccountVaultPatch::default();
     for asset in note_assets.iter() {
-        vault_delta.add_asset(*asset).unwrap();
+        let updated_asset = account
+            .vault()
+            .get(asset.vault_key())
+            .expect("note asset should be present in the account vault");
+        vault_patch.insert_asset(updated_asset);
     }
 
-    let mut storage_delta = AccountStorageDelta::new();
+    let mut storage_patch = AccountStoragePatch::new();
     if let Some((storage_update, tx_index)) = storage_update {
         if storage_update.storage_map_entries > 0
             && account.storage().get(&benchmark_storage_map_slot()).is_some()
         {
             let key_index = u32::try_from((tx_index % storage_update.storage_map_entries) + 1)
                 .expect("storage map key fits into u32");
-            storage_delta
+            storage_patch
                 .set_map_item(
                     benchmark_storage_map_slot(),
                     StorageMapKey::from_index(key_index),
@@ -729,7 +728,8 @@ fn create_existing_account_delta(
         }
     }
 
-    AccountDelta::new(account.id(), storage_delta, vault_delta, ONE).unwrap()
+    AccountPatch::new(account.id(), storage_patch, vault_patch, None, Some(account.nonce()))
+        .unwrap()
 }
 
 /// Creates a transaction from the faucet that creates the given output notes. Updates the faucet

--- a/bin/stress-test/src/seeding/tests.rs
+++ b/bin/stress-test/src/seeding/tests.rs
@@ -91,17 +91,11 @@ fn public_account_storage_map_entry_can_be_updated_for_benchmark_blocks() {
     let mut account = create_account(key_pair.public_key(), 42, AccountType::Public, 4);
 
     let key = StorageMapKey::from_index(2);
-    let old_value = account
-        .storage()
-        .get_map_item(&benchmark_storage_map_slot(), key)
-        .unwrap();
+    let old_value = account.storage().get_map_item(&benchmark_storage_map_slot(), key).unwrap();
 
     let updated = update_benchmark_storage_map_entry(&mut account, 3, 9, 4);
 
-    let new_value = account
-        .storage()
-        .get_map_item(&benchmark_storage_map_slot(), key)
-        .unwrap();
+    let new_value = account.storage().get_map_item(&benchmark_storage_map_slot(), key).unwrap();
     assert!(updated);
     assert_ne!(new_value, old_value);
     assert_eq!(new_value, benchmark_storage_map_update_value(3, 9, 2));

--- a/bin/stress-test/src/seeding/tests.rs
+++ b/bin/stress-test/src/seeding/tests.rs
@@ -93,14 +93,14 @@ fn public_account_storage_map_entry_can_be_updated_for_benchmark_blocks() {
     let key = StorageMapKey::from_index(2);
     let old_value = account
         .storage()
-        .get_map_item(&benchmark_storage_map_slot(), key.into())
+        .get_map_item(&benchmark_storage_map_slot(), key)
         .unwrap();
 
     let updated = update_benchmark_storage_map_entry(&mut account, 3, 9, 4);
 
     let new_value = account
         .storage()
-        .get_map_item(&benchmark_storage_map_slot(), key.into())
+        .get_map_item(&benchmark_storage_map_slot(), key)
         .unwrap();
     assert!(updated);
     assert_ne!(new_value, old_value);

--- a/bin/validator/src/server/validator_service/tests.rs
+++ b/bin/validator/src/server/validator_service/tests.rs
@@ -372,6 +372,7 @@ async fn unknown_transactions_rejected() {
         OrderedTransactionHeaders,
         TransactionHeader,
     };
+    use miden_protocol::vm::ExecutionProof;
 
     let tv = TestValidator::new().await;
     let genesis_header = tv.chain_tip.clone();
@@ -401,13 +402,14 @@ async fn unknown_transactions_rejected() {
                 account_id,
                 Word::default(),
                 Word::default(),
-                miden_protocol::account::delta::AccountUpdateDetails::Private,
+                miden_protocol::account::AccountUpdateDetails::Private,
             ),
         )]),
         InputNotes::default(),
         vec![],
         BlockNumber::MAX,
         OrderedTransactionHeaders::new_unchecked(vec![tx_header]),
+        ExecutionProof::new_dummy(),
     )
     .unwrap();
 

--- a/bin/validator/src/tx_validation/mod.rs
+++ b/bin/validator/src/tx_validation/mod.rs
@@ -4,9 +4,14 @@ mod validated_tx;
 pub use data_store::TransactionInputsDataStore;
 use miden_node_utils::spawn::{spawn_blocking_in_current_span, spawn_blocking_in_span};
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
-use miden_protocol::transaction::{ProvenTransaction, TransactionHeader, TransactionInputs};
+use miden_protocol::transaction::{
+    ProvenTransaction,
+    TransactionHeader,
+    TransactionInputs,
+    TransactionVerifier,
+};
 use miden_tx::auth::UnreachableAuth;
-use miden_tx::{TransactionExecutor, TransactionExecutorError, TransactionVerifier};
+use miden_tx::{TransactionExecutor, TransactionExecutorError};
 use tracing::{Instrument, info_span, instrument};
 pub use validated_tx::ValidatedTransaction;
 
@@ -25,7 +30,7 @@ pub enum TransactionValidationError {
         executed_tx_header: Box<TransactionHeader>,
     },
     #[error("transaction proof verification failed")]
-    ProofVerificationFailed(#[from] miden_tx::TransactionVerifierError),
+    ProofVerificationFailed(#[from] miden_protocol::errors::TransactionVerifierError),
 }
 
 // TRANSACTION VALIDATION

--- a/crates/block-producer/Cargo.toml
+++ b/crates/block-producer/Cargo.toml
@@ -31,7 +31,7 @@ miden-node-store           = { workspace = true }
 miden-node-utils           = { features = ["testing"], workspace = true }
 miden-protocol             = { default-features = true, workspace = true }
 miden-remote-prover-client = { features = ["batch-prover", "block-prover"], workspace = true }
-miden-tx-batch-prover      = { workspace = true }
+miden-tx-batch             = { workspace = true }
 rand                       = { workspace = true }
 thiserror                  = { workspace = true }
 tokio                      = { features = ["macros", "net", "rt-multi-thread"], workspace = true }

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -11,7 +11,7 @@ use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{BatchId, ProposedBatch, ProvenBatch};
 use miden_remote_prover_client::RemoteBatchProver;
-use miden_tx_batch_prover::LocalBatchProver;
+use miden_tx_batch::{BatchExecutor, LocalBatchProver};
 use rand::Rng;
 use tokio::task::JoinSet;
 use tokio::time;
@@ -63,8 +63,7 @@ impl BatchBuilder {
         batch_prover_url: Option<Url>,
         batch_interval: Duration,
     ) -> Self {
-        let batch_prover = batch_prover_url
-            .map_or(BatchProver::local(MIN_PROOF_SECURITY_LEVEL), BatchProver::remote);
+        let batch_prover = batch_prover_url.map_or(BatchProver::local(), BatchProver::remote);
 
         // It is important that the worker pool is filled to capacity with ready workers. See
         // `Self::worker_pool` and `Self::wait_for_available_worker` for more context.
@@ -250,6 +249,7 @@ impl BatchJob {
             inputs.batch_reference_block_header,
             inputs.partial_block_chain,
             inputs.note_proofs,
+            MIN_PROOF_SECURITY_LEVEL,
         )
         .map_err(BuildBatchError::ProposeBatchError)
     }
@@ -269,7 +269,10 @@ impl BatchJob {
             BatchProver::Local(prover) => {
                 let prover = prover.clone();
                 spawn_blocking_in_current_span(move || {
-                    prover.prove(proposed_batch).map_err(BuildBatchError::ProveBatchError)
+                    let executed_batch = BatchExecutor::new()
+                        .execute(proposed_batch)
+                        .map_err(BuildBatchError::ProveBatchError)?;
+                    prover.prove(executed_batch).map_err(BuildBatchError::ProveBatchError)
                 })
                 .await
                 .map_err(BuildBatchError::JoinError)?
@@ -337,8 +340,8 @@ impl BatchProver {
         }
     }
 
-    fn local(security_level: u32) -> Self {
-        Self::Local(LocalBatchProver::new(security_level))
+    fn local() -> Self {
+        Self::Local(LocalBatchProver::new())
     }
 
     fn remote(endpoint: impl Into<String>) -> Self {

--- a/crates/block-producer/src/test_utils/batch.rs
+++ b/crates/block-producer/src/test_utils/batch.rs
@@ -9,6 +9,7 @@ use miden_protocol::transaction::{
     ProvenTransaction,
     TransactionHeader,
 };
+use miden_protocol::vm::ExecutionProof;
 
 use crate::test_utils::MockProvenTxBuilder;
 
@@ -70,6 +71,7 @@ impl TransactionBatchConstructor for ProvenBatch {
             OrderedTransactionHeaders::new_unchecked(
                 txs.into_iter().map(TransactionHeader::from).collect(),
             ),
+            ExecutionProof::new_dummy(),
         )
         .unwrap()
     }

--- a/crates/block-producer/src/test_utils/proven_tx.rs
+++ b/crates/block-producer/src/test_utils/proven_tx.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use miden_node_utils::fee::test_fee;
-use miden_protocol::account::AccountId;
-use miden_protocol::account::delta::AccountUpdateDetails;
+use miden_protocol::account::{AccountId, AccountUpdateDetails};
 use miden_protocol::asset::FungibleAsset;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{Note, NoteAttachments, Nullifier};

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -28,8 +28,7 @@ miden-node-proto-build    = { workspace = true }
 miden-node-store          = { workspace = true }
 miden-node-utils          = { workspace = true }
 miden-protocol            = { default-features = true, workspace = true }
-miden-tx                  = { features = ["concurrent"], workspace = true }
-miden-tx-batch-prover     = { workspace = true }
+miden-tx-batch            = { workspace = true }
 semver                    = { version = "1.0" }
 thiserror                 = { workspace = true }
 tokio                     = { features = ["macros", "net", "rt-multi-thread", "time"], workspace = true }

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -7,10 +7,10 @@ use miden_protocol::transaction::{
     OutputNote,
     ProvenTransaction,
     PublicOutputNote,
+    TransactionVerifier,
     TxAccountUpdate,
 };
 use miden_protocol::utils::serde::{Deserializable, Serializable};
-use miden_tx::TransactionVerifier;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::{Request, Status};
 use tracing::{Span, debug};
@@ -84,7 +84,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
             tx.account_id(),
             tx.account_update().initial_state_commitment(),
             tx.account_update().final_state_commitment(),
-            tx.account_update().account_delta_commitment(),
+            tx.account_update().account_patch_commitment(),
             tx.account_update().details().clone(),
         )
         .map_err(|e| Status::invalid_argument(e.to_string()))?;

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -2,10 +2,9 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
-use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
-use miden_tx_batch_prover::LocalBatchProver;
+use miden_tx_batch::{BatchExecutor, LocalBatchProver};
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::{Request, Status};
 use tracing::Span;
@@ -121,13 +120,15 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         let expected_proof = spawn_blocking_in_current_span({
             let proposed_batch = proposed_batch.clone();
             move || {
-                LocalBatchProver::new(MIN_PROOF_SECURITY_LEVEL).prove(proposed_batch).map_err(
-                    |err| {
+                let executed_batch =
+                    BatchExecutor::new().execute(proposed_batch).map_err(|err| {
                         Status::invalid_argument(
                             err.as_report_context("proposed block proof failed"),
                         )
-                    },
-                )
+                    })?;
+                LocalBatchProver::new().prove(executed_batch).map_err(|err| {
+                    Status::invalid_argument(err.as_report_context("proposed block proof failed"))
+                })
             }
         })
         .await

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -31,14 +31,14 @@ use miden_node_utils::limiter::{
     QueryParamNullifierPrefixLimit,
 };
 use miden_protocol::Word;
-use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::account::{
     Account,
     AccountBuilder,
-    AccountDelta,
     AccountId,
     AccountIdVersion,
+    AccountPatch,
     AccountType,
+    AccountUpdateDetails,
 };
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey;
 use miden_protocol::testing::noop_auth_component::NoopAuthComponent;
@@ -125,8 +125,8 @@ async fn load_state(path: &std::path::Path) -> Arc<State> {
 const DELTA_COMMITMENT_BYTE_OFFSET: usize = 15 + 32 + 32;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Creates a minimal account and its delta for testing proven transaction building.
-fn build_test_account(seed: [u8; 32]) -> (Account, AccountDelta) {
+/// Creates a minimal account and its patch for testing proven transaction building.
+fn build_test_account(seed: [u8; 32]) -> (Account, AccountPatch) {
     let account = AccountBuilder::new(seed)
         .account_type(AccountType::Public)
         .with_assets(vec![])
@@ -135,8 +135,8 @@ fn build_test_account(seed: [u8; 32]) -> (Account, AccountDelta) {
         .build_existing()
         .unwrap();
 
-    let delta: AccountDelta = account.clone().try_into().unwrap();
-    (account, delta)
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
+    (account, patch)
 }
 
 /// Creates a minimal proven transaction for testing.
@@ -145,7 +145,7 @@ fn build_test_account(seed: [u8; 32]) -> (Account, AccountDelta) {
 /// need to test validation logic.
 fn build_test_proven_tx(
     account: &Account,
-    delta: &AccountDelta,
+    patch: &AccountPatch,
     genesis: Word,
 ) -> ProvenTransaction {
     let account_id = AccountId::dummy([0; 15], AccountIdVersion::Version1, AccountType::Public);
@@ -154,8 +154,8 @@ fn build_test_proven_tx(
         account_id,
         [8; 32].try_into().unwrap(),
         account.to_commitment(),
-        delta.to_commitment(),
-        AccountUpdateDetails::Delta(delta.clone()),
+        patch.to_commitment(),
+        AccountUpdateDetails::Public(patch.clone()),
     )
     .unwrap();
 
@@ -177,15 +177,15 @@ fn build_test_proven_tx(
 fn build_test_proven_tx_with_id(
     account_id: AccountId,
     account: &Account,
-    delta: &AccountDelta,
     genesis: Word,
 ) -> ProvenTransaction {
+    let patch = AccountPatch::empty(account_id);
     let account_update = TxAccountUpdate::new(
         account_id,
         [8; 32].try_into().unwrap(),
         account.to_commitment(),
-        delta.to_commitment(),
-        AccountUpdateDetails::Delta(delta.clone()),
+        patch.to_commitment(),
+        AccountUpdateDetails::Public(patch),
     )
     .unwrap();
 
@@ -375,15 +375,15 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
             .connect_lazy::<miden_node_proto::clients::RpcClient>();
 
     // Build a valid proven transaction
-    let (account, account_delta) = build_test_account([0; 32]);
-    let tx = build_test_proven_tx(&account, &account_delta, genesis);
+    let (account, account_patch) = build_test_account([0; 32]);
+    let tx = build_test_proven_tx(&account, &account_patch, genesis);
 
-    // Create an incorrect delta commitment from a different account
+    // Create an incorrect patch commitment from a different account
     let (other_account, _) = build_test_account([1; 32]);
-    let incorrect_delta: AccountDelta = other_account.try_into().unwrap();
-    let incorrect_commitment_bytes = incorrect_delta.to_commitment().as_bytes();
+    let incorrect_patch: AccountPatch = AccountPatch::try_from(other_account).unwrap();
+    let incorrect_commitment_bytes = incorrect_patch.to_commitment().as_bytes();
 
-    // Corrupt the transaction bytes with the incorrect delta commitment
+    // Corrupt the transaction bytes with the incorrect patch commitment
     let mut tx_bytes = tx.to_bytes();
     tx_bytes[DELTA_COMMITMENT_BYTE_OFFSET..DELTA_COMMITMENT_BYTE_OFFSET + 32]
         .copy_from_slice(&incorrect_commitment_bytes);
@@ -401,8 +401,8 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
     // Assert that the error is due to the invalid account delta commitment.
     let err = response.as_ref().unwrap_err().message();
     assert!(
-        err.contains("failed to validate account delta in transaction account update"),
-        "expected error message to contain delta commitment error but got: {err}"
+        err.contains("failed to validate account patch in transaction account update"),
+        "expected error message to contain patch commitment error but got: {err}"
     );
 }
 
@@ -424,8 +424,8 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_reference_block() {
 
     // Build a valid proven transaction but with the incorrect hash (empty).
     let invalid = Word::empty();
-    let (account, account_delta) = build_test_account([0; 32]);
-    let tx = build_test_proven_tx(&account, &account_delta, invalid);
+    let (account, account_patch) = build_test_account([0; 32]);
+    let tx = build_test_proven_tx(&account, &account_patch, invalid);
 
     let request = proto::transaction::ProvenTransaction {
         transaction: tx.to_bytes(),
@@ -460,8 +460,8 @@ async fn rpc_rejects_post_deployment_network_account_tx() {
     );
 
     // Build a non-deployment tx for that account.
-    let (account, account_delta) = build_test_account([0; 32]);
-    let tx = build_test_proven_tx_with_id(network_account_id, &account, &account_delta, genesis);
+    let (account, _) = build_test_account([0; 32]);
+    let tx = build_test_proven_tx_with_id(network_account_id, &account, genesis);
     let request = proto::transaction::ProvenTransaction {
         transaction: tx.to_bytes(),
         transaction_inputs: None,
@@ -692,8 +692,8 @@ async fn rpc_server_rejects_tx_submissions_without_genesis() {
             .without_otel_context_injection()
             .connect_lazy::<miden_node_proto::clients::RpcClient>();
 
-    let (account, account_delta) = build_test_account([0; 32]);
-    let tx = build_test_proven_tx(&account, &account_delta, genesis);
+    let (account, account_patch) = build_test_account([0; 32]);
+    let tx = build_test_proven_tx(&account, &account_patch, genesis);
 
     let request = proto::transaction::ProvenTransaction {
         transaction: tx.to_bytes(),

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -20,7 +20,7 @@ use miden_protocol::account::{
     StorageMapKeyHash,
     StorageSlotName,
 };
-use miden_protocol::asset::Asset;
+use miden_protocol::asset::{Asset, AssetVaultKey, AssetVaultKeyHash};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::merkle::smt::{
     ForestOperation,
@@ -46,6 +46,8 @@ pub use crate::db::models::queries::HISTORICAL_BLOCK_RETENTION;
 mod tests;
 
 const HASHED_STORAGE_MAP_KEY_CACHE_CAPACITY: usize = 65_536;
+
+const HASHED_VAULT_KEY_CACHE_CAPACITY: usize = 65_536;
 
 // ERRORS
 // ================================================================================================
@@ -98,6 +100,9 @@ pub(crate) struct AccountStateForest<B: Backend = ForestInMemoryBackend> {
 
     /// Reverse lookup from hashed SMT storage keys to raw storage map keys.
     storage_map_key_cache: LruCache<StorageMapKeyHash, StorageMapKey>,
+
+    /// Reverse lookup from hashed SMT vault keys to raw vault keys.
+    vault_key_cache: LruCache<AssetVaultKeyHash, AssetVaultKey>,
 }
 
 #[cfg(test)]
@@ -108,6 +113,10 @@ impl AccountStateForest<ForestInMemoryBackend> {
             storage_map_key_cache: LruCache::new(
                 NonZeroUsize::new(HASHED_STORAGE_MAP_KEY_CACHE_CAPACITY)
                     .expect("storage map key cache capacity must be non-zero"),
+            ),
+            vault_key_cache: LruCache::new(
+                NonZeroUsize::new(HASHED_VAULT_KEY_CACHE_CAPACITY)
+                    .expect("vault key cache capacity must be non-zero"),
             ),
         }
     }
@@ -130,6 +139,10 @@ impl<B: Backend> AccountStateForest<B> {
             storage_map_key_cache: LruCache::new(
                 NonZeroUsize::new(HASHED_STORAGE_MAP_KEY_CACHE_CAPACITY)
                     .expect("storage map key cache capacity must be non-zero"),
+            ),
+            vault_key_cache: LruCache::new(
+                NonZeroUsize::new(HASHED_VAULT_KEY_CACHE_CAPACITY)
+                    .expect("vault key cache capacity must be non-zero"),
             ),
         })
     }
@@ -200,6 +213,15 @@ impl<B: Backend> AccountStateForest<B> {
 
     pub(crate) fn cache_storage_map_keys(&self, raw_keys: impl IntoIterator<Item = StorageMapKey>) {
         self.storage_map_key_cache
+            .put_many(raw_keys.into_iter().map(|raw_key| (raw_key.hash(), raw_key)));
+    }
+
+    fn cache_vault_keys_from_patch(&mut self, patch: &AccountPatch) {
+        self.cache_vault_keys(patch.vault().iter().map(|(vault_key, _)| *vault_key));
+    }
+
+    pub(crate) fn cache_vault_keys(&self, raw_keys: impl IntoIterator<Item = AssetVaultKey>) {
+        self.vault_key_cache
             .put_many(raw_keys.into_iter().map(|raw_key| (raw_key.hash(), raw_key)));
     }
 
@@ -300,31 +322,52 @@ impl<B: Backend> AccountStateForest<B> {
     // --------------------------------------------------------------------------------------------
 
     /// Enumerates vault contents for the specified account at the requested block.
+    ///
+    /// Vault keys are hashed before insertion into the SMT, so the forest can only reconstruct the
+    /// assets if all hashed keys are known in the reverse-key LRU cache. Returns `Ok(None)` when at
+    /// least one raw key is missing from the cache, so the caller should fall back to database
+    /// reconstruction.
     #[instrument(target = COMPONENT, skip_all)]
     pub(crate) fn get_vault_details(
         &self,
         account_id: AccountId,
         block_num: BlockNumber,
-    ) -> Result<AccountVaultDetails, WitnessError> {
+    ) -> Result<Option<AccountVaultDetails>, WitnessError> {
         let lineage = Self::vault_lineage_id(account_id);
         let tree = self.get_tree_id(lineage, block_num).ok_or(WitnessError::RootNotFound)?;
 
         // Return "limit exceeded" if the number of vault entries is above the limit.
-        let num_input_notes =
+        let num_entries =
             self.forest.entry_count(tree).map_err(Self::map_forest_error_to_witness)?;
-        if num_input_notes > AccountVaultDetails::MAX_RETURN_ENTRIES {
-            return Ok(AccountVaultDetails::LimitExceeded);
+        if num_entries > AccountVaultDetails::MAX_RETURN_ENTRIES {
+            return Ok(Some(AccountVaultDetails::LimitExceeded));
         }
 
         let entries = self.forest.entries(tree).map_err(Self::map_forest_error_to_witness)?;
-        let assets = entries
+        let hashed_entries = entries
             .map(|entry| {
                 let entry = entry.map_err(Self::map_forest_error_to_witness)?;
-                Asset::from_key_value_words(entry.key, entry.value).map_err(WitnessError::from)
+                Ok((AssetVaultKeyHash::from_raw(entry.key), entry.value))
+            })
+            .collect::<Result<Vec<_>, WitnessError>>()?;
+
+        let raw_keys = self
+            .vault_key_cache
+            .get_many(hashed_entries.iter().map(|(hashed_key, _)| hashed_key));
+        if raw_keys.iter().any(Option::is_none) {
+            return Ok(None);
+        }
+
+        let assets = raw_keys
+            .into_iter()
+            .flatten()
+            .zip(hashed_entries)
+            .map(|(raw_key, (_hashed_key, value))| {
+                Asset::from_key_value(raw_key, value).map_err(WitnessError::from)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(AccountVaultDetails::from_assets(assets))
+        Ok(Some(AccountVaultDetails::from_assets(assets)))
     }
 
     /// Opens a storage map and returns storage map details with SMT proofs for the given keys.
@@ -509,6 +552,7 @@ impl<B: Backend> AccountStateForest<B> {
         }
 
         self.cache_storage_map_keys_from_patch(patch);
+        self.cache_vault_keys_from_patch(patch);
 
         Ok(())
     }
@@ -558,7 +602,7 @@ impl<B: Backend> AccountStateForest<B> {
         let mut entries: Vec<(Word, Word)> = Vec::new();
 
         for (vault_key, value) in vault_patch.iter() {
-            entries.push((Word::from(*vault_key), *value));
+            entries.push((vault_key.hash().as_word(), *value));
         }
 
         let num_entries = entries.len();
@@ -649,7 +693,7 @@ impl<B: Backend> AccountStateForest<B> {
         let mut entries: Vec<(Word, Word)> = Vec::new();
 
         for (vault_key, value) in vault_patch.iter() {
-            entries.push((Word::from(*vault_key), *value));
+            entries.push((vault_key.hash().as_word(), *value));
         }
 
         let vault_entries = entries.len();

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -11,15 +11,16 @@ use miden_node_proto::domain::account::{
 };
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
-use miden_protocol::account::delta::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
 use miden_protocol::account::{
     AccountId,
-    NonFungibleDeltaAction,
+    AccountPatch,
+    AccountStoragePatch,
+    AccountVaultPatch,
     StorageMapKey,
     StorageMapKeyHash,
     StorageSlotName,
 };
-use miden_protocol::asset::{Asset, FungibleAsset};
+use miden_protocol::asset::Asset;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::merkle::smt::{
     ForestOperation,
@@ -189,11 +190,11 @@ impl<B: Backend> AccountStateForest<B> {
             .collect()
     }
 
-    fn cache_storage_map_keys_from_delta(&mut self, delta: &AccountDelta) {
-        let raw_keys = delta
+    fn cache_storage_map_keys_from_patch(&mut self, patch: &AccountPatch) {
+        let raw_keys = patch
             .storage()
             .maps()
-            .flat_map(|(_slot_name, map_delta)| map_delta.entries().keys().copied());
+            .flat_map(|(_slot_name, map_patch)| map_patch.entries().keys().copied());
         self.cache_storage_map_keys(raw_keys);
     }
 
@@ -445,34 +446,30 @@ impl<B: Backend> AccountStateForest<B> {
     // PUBLIC INTERFACE
     // --------------------------------------------------------------------------------------------
 
-    /// Updates the forest with account vault and storage changes from a delta.
+    /// Updates the forest with account vault and storage changes from a patch.
     ///
-    /// Iterates through account updates and applies each delta to the forest.
+    /// Iterates through account updates and applies each patch to the forest.
     /// Private accounts should be filtered out before calling this method.
     ///
     /// # Arguments
     ///
     /// * `block_num` - Block number for which these updates apply
-    /// * `account_updates` - Iterator of `AccountDelta` for public accounts
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if applying a vault delta results in a negative balance.
+    /// * `account_updates` - Iterator of `AccountPatch` for public accounts
     #[instrument(target = COMPONENT, skip_all, fields(block.number = %block_num))]
     pub(crate) fn apply_block_updates(
         &mut self,
         block_num: BlockNumber,
-        account_updates: impl IntoIterator<Item = AccountDelta>,
+        account_updates: impl IntoIterator<Item = AccountPatch>,
     ) -> Result<(), AccountStateForestError> {
-        for delta in account_updates {
-            self.update_account(block_num, &delta)?;
+        for patch in account_updates {
+            self.update_account(block_num, &patch)?;
 
             tracing::debug!(
                 target: crate::COMPONENT,
-                account_id = %delta.id(),
+                account_id = %patch.id(),
                 %block_num,
-                is_full_state = delta.is_full_state(),
-                "Updated forest with account delta"
+                is_full_state = patch.is_full_state(),
+                "Updated forest with account patch"
             );
         }
 
@@ -481,41 +478,37 @@ impl<B: Backend> AccountStateForest<B> {
         Ok(())
     }
 
-    /// Updates the forest with account vault and storage changes from a delta.
+    /// Updates the forest with account vault and storage changes from a patch.
     ///
     /// Unified interface for updating all account state in the forest, handling both full-state
-    /// deltas (new accounts or reconstruction from DB) and partial deltas (incremental updates
+    /// patches (new accounts or reconstruction from DB) and partial patches (incremental updates
     /// during block application).
     ///
-    /// Full-state deltas (`delta.is_full_state() == true`) populate the forest from scratch using
-    /// an empty SMT root. Partial deltas apply changes on top of the previous block's state.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if applying a vault delta results in a negative balance.
+    /// Full-state patches (`patch.is_full_state() == true`) populate the forest from scratch using
+    /// an empty SMT root. Partial patches apply changes on top of the previous block's state.
     pub(crate) fn update_account(
         &mut self,
         block_num: BlockNumber,
-        delta: &AccountDelta,
+        patch: &AccountPatch,
     ) -> Result<(), AccountStateForestError> {
-        let account_id = delta.id();
-        let is_full_state = delta.is_full_state();
+        let account_id = patch.id();
+        let is_full_state = patch.is_full_state();
 
         // Apply vault changes.
         if is_full_state {
-            self.insert_account_vault(block_num, account_id, delta.vault())?;
-        } else if !delta.vault().is_empty() {
-            self.update_account_vault(block_num, account_id, delta.vault())?;
+            self.insert_account_vault(block_num, account_id, patch.vault())?;
+        } else if !patch.vault().is_empty() {
+            self.update_account_vault(block_num, account_id, patch.vault())?;
         }
 
         // Apply storage map changes.
         if is_full_state {
-            self.insert_account_storage(block_num, account_id, delta.storage());
-        } else if !delta.storage().is_empty() {
-            self.update_account_storage(block_num, account_id, delta.storage());
+            self.insert_account_storage(block_num, account_id, patch.storage());
+        } else if !patch.storage().is_empty() {
+            self.update_account_storage(block_num, account_id, patch.storage());
         }
 
-        self.cache_storage_map_keys_from_delta(delta);
+        self.cache_storage_map_keys_from_patch(patch);
 
         Ok(())
     }
@@ -532,11 +525,12 @@ impl<B: Backend> AccountStateForest<B> {
 
     /// Inserts asset vault data into the forest for the specified account. Assumes that asset vault
     /// for this account does not yet exist in the forest.
+    #[expect(clippy::unnecessary_wraps)]
     fn insert_account_vault(
         &mut self,
         block_num: BlockNumber,
         account_id: AccountId,
-        vault_delta: &AccountVaultDelta,
+        vault_patch: &AccountVaultPatch,
     ) -> Result<(), AccountStateForestError> {
         let prev_root = self.get_latest_vault_root(account_id);
         let lineage = Self::vault_lineage_id(account_id);
@@ -546,7 +540,7 @@ impl<B: Backend> AccountStateForest<B> {
             "account should not be in the forest"
         );
 
-        if vault_delta.is_empty() {
+        if vault_patch.is_empty() {
             let lineage = Self::vault_lineage_id(account_id);
             let new_root = self.apply_forest_updates(lineage, block_num, Vec::new());
 
@@ -563,23 +557,8 @@ impl<B: Backend> AccountStateForest<B> {
 
         let mut entries: Vec<(Word, Word)> = Vec::new();
 
-        for (vault_key, amount_delta) in vault_delta.fungible().iter() {
-            let amount =
-                (*amount_delta).try_into().expect("full-state amount should be non-negative");
-            let asset = FungibleAsset::new(vault_key.faucet_id(), amount)?
-                .with_callbacks(vault_key.callback_flag());
-            entries.push((asset.to_key_word(), asset.to_value_word()));
-        }
-
-        // process non-fungible assets
-        for (&asset, action) in vault_delta.non_fungible().iter() {
-            let asset_vault_key: Word = asset.vault_key().into();
-            match action {
-                NonFungibleDeltaAction::Add => {
-                    entries.push((asset_vault_key, asset.to_value_word()));
-                },
-                NonFungibleDeltaAction::Remove => entries.push((asset_vault_key, EMPTY_WORD)),
-            }
+        for (vault_key, value) in vault_patch.iter() {
+            entries.push((Word::from(*vault_key), *value));
         }
 
         let num_entries = entries.len();
@@ -599,22 +578,22 @@ impl<B: Backend> AccountStateForest<B> {
         Ok(())
     }
 
-    /// Updates the forest with storage map changes from a delta and returns updated roots.
+    /// Updates the forest with storage map changes from a patch.
     ///
     /// Assumes that storage maps for the provided account are not in the forest already.
     fn insert_account_storage(
         &mut self,
         block_num: BlockNumber,
         account_id: AccountId,
-        storage_delta: &AccountStorageDelta,
+        storage_patch: &AccountStoragePatch,
     ) {
-        for (slot_name, map_delta) in storage_delta.maps() {
+        for (slot_name, map_patch) in storage_patch.maps() {
             // get the latest root for this map, and make sure the root is for an empty tree
             let prev_root = self.get_latest_storage_map_root(account_id, slot_name);
             assert_eq!(prev_root, empty_smt_root(), "account should not be in the forest");
 
             let raw_map_entries: Vec<(StorageMapKey, Word)> =
-                Vec::from_iter(map_delta.entries().iter().filter_map(|(&key, &value)| {
+                Vec::from_iter(map_patch.entries().iter().filter_map(|(&key, &value)| {
                     if value == EMPTY_WORD { None } else { Some((key, value)) }
                 }));
 
@@ -645,82 +624,32 @@ impl<B: Backend> AccountStateForest<B> {
                 %block_num,
                 ?slot_name,
                 %new_root,
-                delta_entries = num_entries,
+                patch_entries = num_entries,
                 "Inserted storage map into forest"
             );
         }
     }
 
-    // ASSET VAULT DELTA PROCESSING
+    // ASSET VAULT PATCH PROCESSING
     // --------------------------------------------------------------------------------------------
 
-    /// Updates the forest with vault changes from a delta and returns the new root.
+    /// Updates the forest with the account's vault changes from the patch.
     ///
-    /// Processes both fungible and non-fungible asset changes, building entries for the vault SMT
-    /// and tracking the new root.
-    ///
-    /// # Returns
-    ///
-    /// The new vault root after applying the delta.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if applying a delta results in a negative balance.
+    /// Writes the patch's absolute vault entries to the vault SMT, where an empty value removes the
+    /// corresponding asset.
+    #[expect(clippy::unnecessary_wraps)]
     fn update_account_vault(
         &mut self,
         block_num: BlockNumber,
         account_id: AccountId,
-        vault_delta: &AccountVaultDelta,
+        vault_patch: &AccountVaultPatch,
     ) -> Result<(), AccountStateForestError> {
-        assert!(!vault_delta.is_empty(), "expected the delta not to be empty");
-
-        // get the previous vault root; the root could be for an empty or non-empty SMT
-        let lineage = Self::vault_lineage_id(account_id);
-        let prev_tree =
-            self.forest.latest_version(lineage).map(|version| TreeId::new(lineage, version));
+        assert!(!vault_patch.is_empty(), "expected the patch not to be empty");
 
         let mut entries: Vec<(Word, Word)> = Vec::new();
 
-        // Process fungible assets
-        for (vault_key, amount_delta) in vault_delta.fungible().iter() {
-            let faucet_id = vault_key.faucet_id();
-            let callback_flag = vault_key.callback_flag();
-            let delta_abs = amount_delta.unsigned_abs();
-            let delta = FungibleAsset::new(faucet_id, delta_abs)?.with_callbacks(callback_flag);
-            let key = Word::from(delta.vault_key());
-
-            let empty = FungibleAsset::new(faucet_id, 0)?.with_callbacks(callback_flag);
-            let asset = if let Some(tree) = prev_tree {
-                self.forest
-                    .get(tree, key)?
-                    .map(|value| FungibleAsset::from_key_value(*vault_key, value))
-                    .transpose()?
-                    .unwrap_or(empty)
-            } else {
-                empty
-            };
-
-            let updated = if *amount_delta < 0 {
-                asset.sub(delta)?
-            } else {
-                asset.add(delta)?
-            };
-
-            let value = if updated.amount().as_u64() == 0 {
-                EMPTY_WORD
-            } else {
-                updated.to_value_word()
-            };
-            entries.push((key, value));
-        }
-
-        // Process non-fungible assets
-        for (asset, action) in vault_delta.non_fungible().iter() {
-            let value = match action {
-                NonFungibleDeltaAction::Add => asset.to_value_word(),
-                NonFungibleDeltaAction::Remove => EMPTY_WORD,
-            };
-            entries.push((asset.vault_key().into(), value));
+        for (vault_key, value) in vault_patch.iter() {
+            entries.push((Word::from(*vault_key), *value));
         }
 
         let vault_entries = entries.len();
@@ -753,7 +682,7 @@ impl<B: Backend> AccountStateForest<B> {
         self.forest.latest_root(lineage).unwrap_or_else(empty_smt_root)
     }
 
-    /// Updates the forest with storage map changes from a delta.
+    /// Updates the forest with storage map changes from a patch.
     ///
     /// # Returns
     ///
@@ -762,21 +691,21 @@ impl<B: Backend> AccountStateForest<B> {
         &mut self,
         block_num: BlockNumber,
         account_id: AccountId,
-        storage_delta: &AccountStorageDelta,
+        storage_patch: &AccountStoragePatch,
     ) {
-        for (slot_name, map_delta) in storage_delta.maps() {
-            // map delta shouldn't be empty, but if it is for some reason, there is nothing to do
-            if map_delta.is_empty() {
+        for (slot_name, map_patch) in storage_patch.maps() {
+            // map patch shouldn't be empty, but if it is for some reason, there is nothing to do
+            if map_patch.is_empty() {
                 continue;
             }
 
             // update the storage map tree in the forest and add an entry to the storage map roots
             let lineage = Self::storage_lineage_id(account_id, slot_name);
-            let delta_entries: Vec<(StorageMapKey, Word)> =
-                Vec::from_iter(map_delta.entries().iter().map(|(key, value)| (*key, *value)));
+            let patch_entries: Vec<(StorageMapKey, Word)> =
+                Vec::from_iter(map_patch.entries().iter().map(|(key, value)| (*key, *value)));
 
             let hashed_entries = Vec::from_iter(
-                delta_entries.iter().map(|(raw_key, value)| (raw_key.hash().into(), *value)),
+                patch_entries.iter().map(|(raw_key, value)| (raw_key.hash().into(), *value)),
             );
 
             let operations = Self::build_forest_operations(hashed_entries);
@@ -788,7 +717,7 @@ impl<B: Backend> AccountStateForest<B> {
                 %block_num,
                 ?slot_name,
                 %new_root,
-                delta_entries = delta_entries.len(),
+                patch_entries = patch_entries.len(),
                 "Updated storage map in forest"
             );
         }

--- a/crates/store/src/account_state_forest/tests.rs
+++ b/crates/store/src/account_state_forest/tests.rs
@@ -184,10 +184,10 @@ fn vault_details_returns_latest_and_historical_assets() {
     let patch_2 = dummy_partial_patch(account_id, vault_patch_2, AccountStoragePatch::default());
     forest.update_account(block_2, &patch_2).unwrap();
 
-    let historical = forest.get_vault_details(account_id, block_1).unwrap();
+    let historical = forest.get_vault_details(account_id, block_1).unwrap().unwrap();
     assert_eq!(historical, AccountVaultDetails::Assets(vec![asset_100]));
 
-    let latest = forest.get_vault_details(account_id, block_2).unwrap();
+    let latest = forest.get_vault_details(account_id, block_2).unwrap().unwrap();
     assert_eq!(latest, AccountVaultDetails::Assets(vec![dummy_fungible_asset(faucet_id, 150)]));
 }
 
@@ -211,7 +211,7 @@ fn vault_details_limit_exceeded_for_large_vault() {
     forest.update_account(block_num, &full_patch).unwrap();
 
     assert_eq!(
-        forest.get_vault_details(account_id, block_num).unwrap(),
+        forest.get_vault_details(account_id, block_num).unwrap().unwrap(),
         AccountVaultDetails::LimitExceeded
     );
 }

--- a/crates/store/src/account_state_forest/tests.rs
+++ b/crates/store/src/account_state_forest/tests.rs
@@ -30,22 +30,22 @@ fn dummy_fungible_asset(faucet_id: AccountId, amount: u64) -> Asset {
     FungibleAsset::new(faucet_id, amount).unwrap().into()
 }
 
-/// Creates a partial `AccountDelta` (without code) for testing incremental updates.
-fn dummy_partial_delta(
+/// Creates a partial `AccountPatch` (without code) for testing incremental updates.
+fn dummy_partial_patch(
     account_id: AccountId,
-    vault_delta: AccountVaultDelta,
-    storage_delta: AccountStorageDelta,
-) -> AccountDelta {
-    let nonce_delta = if vault_delta.is_empty() && storage_delta.is_empty() {
-        Felt::ZERO
+    vault_patch: AccountVaultPatch,
+    storage_patch: AccountStoragePatch,
+) -> AccountPatch {
+    let final_nonce = if vault_patch.is_empty() && storage_patch.is_empty() {
+        None
     } else {
-        Felt::ONE
+        Some(Felt::new_unchecked(2))
     };
-    AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta).unwrap()
+    AccountPatch::new(account_id, storage_patch, vault_patch, None, final_nonce).unwrap()
 }
 
-/// Creates a full-state `AccountDelta` (with code) for testing DB reconstruction.
-fn dummy_full_state_delta(account_id: AccountId, assets: &[Asset]) -> AccountDelta {
+/// Creates a full-state `AccountPatch` (with code) for testing DB reconstruction.
+fn dummy_full_state_patch(account_id: AccountId, assets: &[Asset]) -> AccountPatch {
     use miden_protocol::account::{Account, AccountStorage};
 
     let vault = AssetVault::new(assets).unwrap();
@@ -54,7 +54,7 @@ fn dummy_full_state_delta(account_id: AccountId, assets: &[Asset]) -> AccountDel
     let nonce = Felt::ONE;
 
     let account = Account::new(account_id, vault, storage, code, nonce, None).unwrap();
-    AccountDelta::try_from(account).unwrap()
+    AccountPatch::try_from(account).unwrap()
 }
 
 // INITIALIZATION & BASIC OPERATIONS
@@ -82,13 +82,13 @@ fn update_account_with_empty_deltas() {
     let account_id = dummy_account();
     let block_num = BlockNumber::GENESIS.child();
 
-    let delta = dummy_partial_delta(
+    let patch = dummy_partial_patch(
         account_id,
-        AccountVaultDelta::default(),
-        AccountStorageDelta::default(),
+        AccountVaultPatch::default(),
+        AccountStoragePatch::default(),
     );
 
-    forest.update_account(block_num, &delta).unwrap();
+    forest.update_account(block_num, &patch).unwrap();
 
     assert!(forest.get_vault_root(account_id, block_num).is_none());
     assert_eq!(forest.forest.lineage_count(), 0);
@@ -104,18 +104,18 @@ fn vault_partial_vs_full_state_produces_same_root() {
     let block_num = BlockNumber::GENESIS.child();
     let asset = dummy_fungible_asset(faucet_id, 100);
 
-    // Partial delta (block application)
+    // Partial patch (block application)
     let mut forest_partial = AccountStateForest::new();
-    let mut vault_delta = AccountVaultDelta::default();
-    vault_delta.add_asset(asset).unwrap();
-    let partial_delta =
-        dummy_partial_delta(account_id, vault_delta, AccountStorageDelta::default());
-    forest_partial.update_account(block_num, &partial_delta).unwrap();
+    let mut vault_patch = AccountVaultPatch::default();
+    vault_patch.insert_asset(asset);
+    let partial_patch =
+        dummy_partial_patch(account_id, vault_patch, AccountStoragePatch::default());
+    forest_partial.update_account(block_num, &partial_patch).unwrap();
 
-    // Full-state delta (DB reconstruction)
+    // Full-state patch (DB reconstruction)
     let mut forest_full = AccountStateForest::new();
-    let full_delta = dummy_full_state_delta(account_id, &[asset]);
-    forest_full.update_account(block_num, &full_delta).unwrap();
+    let full_patch = dummy_full_state_patch(account_id, &[asset]);
+    forest_full.update_account(block_num, &full_patch).unwrap();
 
     let root_partial = forest_partial.get_vault_root(account_id, block_num).unwrap();
     let root_full = forest_full.get_vault_root(account_id, block_num).unwrap();
@@ -130,38 +130,38 @@ fn vault_incremental_updates_with_add_and_remove() {
     let account_id = dummy_account();
     let faucet_id = dummy_faucet();
 
-    // Block 1: Add 100 tokens
+    // Block 1: Set balance to 100 tokens
     let block_1 = BlockNumber::GENESIS.child();
-    let mut vault_delta_1 = AccountVaultDelta::default();
-    vault_delta_1.add_asset(dummy_fungible_asset(faucet_id, 100)).unwrap();
-    let delta_1 = dummy_partial_delta(account_id, vault_delta_1, AccountStorageDelta::default());
-    forest.update_account(block_1, &delta_1).unwrap();
+    let mut vault_patch_1 = AccountVaultPatch::default();
+    vault_patch_1.insert_asset(dummy_fungible_asset(faucet_id, 100));
+    let patch_1 = dummy_partial_patch(account_id, vault_patch_1, AccountStoragePatch::default());
+    forest.update_account(block_1, &patch_1).unwrap();
     let root_after_100 = forest.get_vault_root(account_id, block_1).unwrap();
 
-    // Block 2: Add 50 more tokens (result: 150 tokens)
+    // Block 2: Set balance to 150 tokens
     let block_2 = block_1.child();
-    let mut vault_delta_2 = AccountVaultDelta::default();
-    vault_delta_2.add_asset(dummy_fungible_asset(faucet_id, 50)).unwrap();
-    let delta_2 = dummy_partial_delta(account_id, vault_delta_2, AccountStorageDelta::default());
-    forest.update_account(block_2, &delta_2).unwrap();
+    let mut vault_patch_2 = AccountVaultPatch::default();
+    vault_patch_2.insert_asset(dummy_fungible_asset(faucet_id, 150));
+    let patch_2 = dummy_partial_patch(account_id, vault_patch_2, AccountStoragePatch::default());
+    forest.update_account(block_2, &patch_2).unwrap();
     let root_after_150 = forest.get_vault_root(account_id, block_2).unwrap();
 
     assert_ne!(root_after_100, root_after_150);
 
-    // Block 3: Remove 30 tokens (result: 120 tokens)
+    // Block 3: Set balance to 120 tokens
     let block_3 = block_2.child();
-    let mut vault_delta_3 = AccountVaultDelta::default();
-    vault_delta_3.remove_asset(dummy_fungible_asset(faucet_id, 30)).unwrap();
-    let delta_3 = dummy_partial_delta(account_id, vault_delta_3, AccountStorageDelta::default());
-    forest.update_account(block_3, &delta_3).unwrap();
+    let mut vault_patch_3 = AccountVaultPatch::default();
+    vault_patch_3.insert_asset(dummy_fungible_asset(faucet_id, 120));
+    let patch_3 = dummy_partial_patch(account_id, vault_patch_3, AccountStoragePatch::default());
+    forest.update_account(block_3, &patch_3).unwrap();
     let root_after_120 = forest.get_vault_root(account_id, block_3).unwrap();
 
     assert_ne!(root_after_150, root_after_120);
 
-    // Verify by comparing to full-state delta
+    // Verify by comparing to full-state patch
     let mut fresh_forest = AccountStateForest::new();
-    let full_delta = dummy_full_state_delta(account_id, &[dummy_fungible_asset(faucet_id, 120)]);
-    fresh_forest.update_account(block_3, &full_delta).unwrap();
+    let full_patch = dummy_full_state_patch(account_id, &[dummy_fungible_asset(faucet_id, 120)]);
+    fresh_forest.update_account(block_3, &full_patch).unwrap();
     let root_full_state_120 = fresh_forest.get_vault_root(account_id, block_3).unwrap();
 
     assert_eq!(root_after_120, root_full_state_120);
@@ -175,14 +175,14 @@ fn vault_details_returns_latest_and_historical_assets() {
 
     let block_1 = BlockNumber::GENESIS.child();
     let asset_100 = dummy_fungible_asset(faucet_id, 100);
-    let full_delta = dummy_full_state_delta(account_id, &[asset_100]);
-    forest.update_account(block_1, &full_delta).unwrap();
+    let full_patch = dummy_full_state_patch(account_id, &[asset_100]);
+    forest.update_account(block_1, &full_patch).unwrap();
 
     let block_2 = block_1.child();
-    let mut vault_delta_2 = AccountVaultDelta::default();
-    vault_delta_2.add_asset(dummy_fungible_asset(faucet_id, 50)).unwrap();
-    let delta_2 = dummy_partial_delta(account_id, vault_delta_2, AccountStorageDelta::default());
-    forest.update_account(block_2, &delta_2).unwrap();
+    let mut vault_patch_2 = AccountVaultPatch::default();
+    vault_patch_2.insert_asset(dummy_fungible_asset(faucet_id, 150));
+    let patch_2 = dummy_partial_patch(account_id, vault_patch_2, AccountStoragePatch::default());
+    forest.update_account(block_2, &patch_2).unwrap();
 
     let historical = forest.get_vault_details(account_id, block_1).unwrap();
     assert_eq!(historical, AccountVaultDetails::Assets(vec![asset_100]));
@@ -207,8 +207,8 @@ fn vault_details_limit_exceeded_for_large_vault() {
         })
         .collect::<Vec<_>>();
 
-    let full_delta = dummy_full_state_delta(account_id, &assets);
-    forest.update_account(block_num, &full_delta).unwrap();
+    let full_patch = dummy_full_state_patch(account_id, &assets);
+    forest.update_account(block_num, &full_patch).unwrap();
 
     assert_eq!(
         forest.get_vault_details(account_id, block_num).unwrap(),
@@ -221,7 +221,7 @@ fn forest_versions_are_continuous_for_sequential_updates() {
     use std::collections::BTreeMap;
 
     use assert_matches::assert_matches;
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -233,18 +233,16 @@ fn forest_versions_are_continuous_for_sequential_updates() {
 
     for i in 1..=3u32 {
         let block_num = BlockNumber::from(i);
-        let mut vault_delta = AccountVaultDelta::default();
-        vault_delta
-            .add_asset(dummy_fungible_asset(faucet_id, u64::from(i) * 10))
-            .unwrap();
+        let mut vault_patch = AccountVaultPatch::default();
+        vault_patch.insert_asset(dummy_fungible_asset(faucet_id, u64::from(i) * 10));
 
-        let mut map_delta = StorageMapDelta::default();
-        map_delta.insert(raw_key, Word::from([i, 0, 0, 0]));
-        let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta))]);
-        let storage_delta = AccountStorageDelta::from_raw(raw);
+        let mut map_patch = StorageMapPatch::default();
+        map_patch.insert(raw_key, Word::from([i, 0, 0, 0]));
+        let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch))]);
+        let storage_patch = AccountStoragePatch::from_raw(raw);
 
-        let delta = dummy_partial_delta(account_id, vault_delta, storage_delta);
-        forest.update_account(block_num, &delta).unwrap();
+        let patch = dummy_partial_patch(account_id, vault_patch, storage_patch);
+        forest.update_account(block_num, &patch).unwrap();
 
         let vault_tree = forest.tree_id_for_vault_root(account_id, block_num);
         let storage_tree = forest.tree_id_for_root(account_id, &slot_name, block_num);
@@ -261,16 +259,16 @@ fn vault_state_is_not_available_for_block_gaps() {
     let faucet_id = dummy_faucet();
 
     let block_1 = BlockNumber::GENESIS.child();
-    let mut vault_delta_1 = AccountVaultDelta::default();
-    vault_delta_1.add_asset(dummy_fungible_asset(faucet_id, 100)).unwrap();
-    let delta_1 = dummy_partial_delta(account_id, vault_delta_1, AccountStorageDelta::default());
-    forest.update_account(block_1, &delta_1).unwrap();
+    let mut vault_patch_1 = AccountVaultPatch::default();
+    vault_patch_1.insert_asset(dummy_fungible_asset(faucet_id, 100));
+    let patch_1 = dummy_partial_patch(account_id, vault_patch_1, AccountStoragePatch::default());
+    forest.update_account(block_1, &patch_1).unwrap();
 
     let block_6 = BlockNumber::from(6);
-    let mut vault_delta_6 = AccountVaultDelta::default();
-    vault_delta_6.add_asset(dummy_fungible_asset(faucet_id, 150)).unwrap();
-    let delta_6 = dummy_partial_delta(account_id, vault_delta_6, AccountStorageDelta::default());
-    forest.update_account(block_6, &delta_6).unwrap();
+    let mut vault_patch_6 = AccountVaultPatch::default();
+    vault_patch_6.insert_asset(dummy_fungible_asset(faucet_id, 150));
+    let patch_6 = dummy_partial_patch(account_id, vault_patch_6, AccountStoragePatch::default());
+    forest.update_account(block_6, &patch_6).unwrap();
 
     assert!(forest.get_vault_root(account_id, BlockNumber::from(3)).is_some());
     assert!(forest.get_vault_root(account_id, BlockNumber::from(5)).is_some());
@@ -290,12 +288,12 @@ fn vault_full_state_with_empty_vault_records_root() {
     let code = AccountCode::mock();
     let nonce = Felt::ONE;
     let account = Account::new(account_id, vault, storage, code, nonce, None).unwrap();
-    let full_delta = AccountDelta::try_from(account).unwrap();
+    let full_patch = AccountPatch::try_from(account).unwrap();
 
-    assert!(full_delta.vault().is_empty());
-    assert!(full_delta.is_full_state());
+    assert!(full_patch.vault().is_empty());
+    assert!(full_patch.is_full_state());
 
-    forest.update_account(block_num, &full_delta).unwrap();
+    forest.update_account(block_num, &full_patch).unwrap();
 
     let recorded_root = forest.get_vault_root(account_id, block_num);
     assert_eq!(recorded_root, Some(AccountStateForest::empty_smt_root()));
@@ -312,28 +310,27 @@ fn vault_shared_root_retained_when_one_entry_pruned() {
     let amount_increment = asset_amount / u64::from(HISTORICAL_BLOCK_RETENTION);
     let asset = dummy_fungible_asset(faucet_id, asset_amount);
 
-    let mut vault_delta_1 = AccountVaultDelta::default();
-    vault_delta_1.add_asset(asset).unwrap();
-    let delta_1 = dummy_partial_delta(account1, vault_delta_1, AccountStorageDelta::default());
-    forest.update_account(block_1, &delta_1).unwrap();
+    let mut vault_patch_1 = AccountVaultPatch::default();
+    vault_patch_1.insert_asset(asset);
+    let patch_1 = dummy_partial_patch(account1, vault_patch_1, AccountStoragePatch::default());
+    forest.update_account(block_1, &patch_1).unwrap();
 
-    let mut vault_delta_2 = AccountVaultDelta::default();
-    vault_delta_2.add_asset(dummy_fungible_asset(faucet_id, asset_amount)).unwrap();
-    let delta_2 = dummy_partial_delta(account2, vault_delta_2, AccountStorageDelta::default());
-    forest.update_account(block_1, &delta_2).unwrap();
+    let mut vault_patch_2 = AccountVaultPatch::default();
+    vault_patch_2.insert_asset(dummy_fungible_asset(faucet_id, asset_amount));
+    let patch_2 = dummy_partial_patch(account2, vault_patch_2, AccountStoragePatch::default());
+    forest.update_account(block_1, &patch_2).unwrap();
 
     let root1 = forest.get_vault_root(account1, block_1).unwrap();
     let root2 = forest.get_vault_root(account2, block_1).unwrap();
     assert_eq!(root1, root2);
 
     let block_at_51 = BlockNumber::from(HISTORICAL_BLOCK_RETENTION + 1);
-    let mut vault_delta_2_update = AccountVaultDelta::default();
-    vault_delta_2_update
-        .add_asset(dummy_fungible_asset(faucet_id, amount_increment))
-        .unwrap();
-    let delta_2_update =
-        dummy_partial_delta(account2, vault_delta_2_update, AccountStorageDelta::default());
-    forest.update_account(block_at_51, &delta_2_update).unwrap();
+    let mut vault_patch_2_update = AccountVaultPatch::default();
+    vault_patch_2_update
+        .insert_asset(dummy_fungible_asset(faucet_id, asset_amount + amount_increment));
+    let patch_2_update =
+        dummy_partial_patch(account2, vault_patch_2_update, AccountStoragePatch::default());
+    forest.update_account(block_at_51, &patch_2_update).unwrap();
 
     let block_at_52 = BlockNumber::from(HISTORICAL_BLOCK_RETENTION + 2);
     let total_roots_removed = forest.prune(block_at_52);
@@ -353,7 +350,7 @@ fn vault_shared_root_retained_when_one_entry_pruned() {
 fn storage_map_incremental_updates() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -367,32 +364,32 @@ fn storage_map_incremental_updates() {
 
     // Block 1: Insert key1 -> value1
     let block_1 = BlockNumber::GENESIS.child();
-    let mut map_delta_1 = StorageMapDelta::default();
-    map_delta_1.insert(key1, value1);
-    let raw_1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_1))]);
-    let storage_delta_1 = AccountStorageDelta::from_raw(raw_1);
-    let delta_1 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_1);
-    forest.update_account(block_1, &delta_1).unwrap();
+    let mut map_patch_1 = StorageMapPatch::default();
+    map_patch_1.insert(key1, value1);
+    let raw_1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_1))]);
+    let storage_patch_1 = AccountStoragePatch::from_raw(raw_1);
+    let patch_1 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_1);
+    forest.update_account(block_1, &patch_1).unwrap();
     let root_1 = forest.get_storage_map_root(account_id, &slot_name, block_1).unwrap();
 
     // Block 2: Insert key2 -> value2
     let block_2 = block_1.child();
-    let mut map_delta_2 = StorageMapDelta::default();
-    map_delta_2.insert(key2, value2);
-    let raw_2 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_2))]);
-    let storage_delta_2 = AccountStorageDelta::from_raw(raw_2);
-    let delta_2 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_2);
-    forest.update_account(block_2, &delta_2).unwrap();
+    let mut map_patch_2 = StorageMapPatch::default();
+    map_patch_2.insert(key2, value2);
+    let raw_2 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_2))]);
+    let storage_patch_2 = AccountStoragePatch::from_raw(raw_2);
+    let patch_2 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_2);
+    forest.update_account(block_2, &patch_2).unwrap();
     let root_2 = forest.get_storage_map_root(account_id, &slot_name, block_2).unwrap();
 
     // Block 3: Update key1 -> value3
     let block_3 = block_2.child();
-    let mut map_delta_3 = StorageMapDelta::default();
-    map_delta_3.insert(key1, value3);
-    let raw_3 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_3))]);
-    let storage_delta_3 = AccountStorageDelta::from_raw(raw_3);
-    let delta_3 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_3);
-    forest.update_account(block_3, &delta_3).unwrap();
+    let mut map_patch_3 = StorageMapPatch::default();
+    map_patch_3.insert(key1, value3);
+    let raw_3 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_3))]);
+    let storage_patch_3 = AccountStoragePatch::from_raw(raw_3);
+    let patch_3 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_3);
+    forest.update_account(block_3, &patch_3).unwrap();
     let root_3 = forest.get_storage_map_root(account_id, &slot_name, block_3).unwrap();
 
     assert_ne!(root_1, root_2);
@@ -404,7 +401,7 @@ fn storage_map_incremental_updates() {
 fn test_storage_map_removals() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     const SLOT_INDEX: usize = 3;
     const VALUE_1: [u32; 4] = [10, 0, 0, 0];
@@ -419,20 +416,20 @@ fn test_storage_map_removals() {
     let value_2 = Word::from(VALUE_2);
 
     let block_1 = BlockNumber::GENESIS.child();
-    let mut map_delta_1 = StorageMapDelta::default();
-    map_delta_1.insert(key_1, value_1);
-    map_delta_1.insert(key_2, value_2);
-    let raw_1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_1))]);
-    let storage_delta_1 = AccountStorageDelta::from_raw(raw_1);
-    let delta_1 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_1);
-    forest.update_account(block_1, &delta_1).unwrap();
+    let mut map_patch_1 = StorageMapPatch::default();
+    map_patch_1.insert(key_1, value_1);
+    map_patch_1.insert(key_2, value_2);
+    let raw_1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_1))]);
+    let storage_patch_1 = AccountStoragePatch::from_raw(raw_1);
+    let patch_1 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_1);
+    forest.update_account(block_1, &patch_1).unwrap();
 
     let block_2 = block_1.child();
-    let map_delta_2 = StorageMapDelta::from_iters([key_1], []);
-    let raw_2 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_2))]);
-    let storage_delta_2 = AccountStorageDelta::from_raw(raw_2);
-    let delta_2 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_2);
-    forest.update_account(block_2, &delta_2).unwrap();
+    let map_patch_2 = StorageMapPatch::from_iters([key_1], []);
+    let raw_2 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_2))]);
+    let storage_patch_2 = AccountStoragePatch::from_raw(raw_2);
+    let patch_2 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_2);
+    forest.update_account(block_2, &patch_2).unwrap();
 
     let tree = forest.tree_id_for_root(account_id, &slot_name, block_2);
 
@@ -450,7 +447,7 @@ fn test_storage_map_removals() {
 fn storage_map_state_is_not_available_for_block_gaps() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     const BLOCK_FIRST: u32 = 1;
     const BLOCK_SECOND: u32 = 4;
@@ -466,22 +463,22 @@ fn storage_map_state_is_not_available_for_block_gaps() {
     let raw_key = StorageMapKey::from_index(KEY_VALUE);
 
     let block_1 = BlockNumber::from(BLOCK_FIRST);
-    let mut map_delta_1 = StorageMapDelta::default();
+    let mut map_patch_1 = StorageMapPatch::default();
     let value_1 = Word::from([VALUE_FIRST, 0, 0, 0]);
-    map_delta_1.insert(raw_key, value_1);
-    let raw_1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_1))]);
-    let storage_delta_1 = AccountStorageDelta::from_raw(raw_1);
-    let delta_1 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_1);
-    forest.update_account(block_1, &delta_1).unwrap();
+    map_patch_1.insert(raw_key, value_1);
+    let raw_1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_1))]);
+    let storage_patch_1 = AccountStoragePatch::from_raw(raw_1);
+    let patch_1 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_1);
+    forest.update_account(block_1, &patch_1).unwrap();
 
     let block_4 = BlockNumber::from(BLOCK_SECOND);
-    let mut map_delta_4 = StorageMapDelta::default();
+    let mut map_patch_4 = StorageMapPatch::default();
     let value_2 = Word::from([VALUE_SECOND, 0, 0, 0]);
-    map_delta_4.insert(raw_key, value_2);
-    let raw_4 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_4))]);
-    let storage_delta_4 = AccountStorageDelta::from_raw(raw_4);
-    let delta_4 = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_4);
-    forest.update_account(block_4, &delta_4).unwrap();
+    map_patch_4.insert(raw_key, value_2);
+    let raw_4 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_4))]);
+    let storage_patch_4 = AccountStoragePatch::from_raw(raw_4);
+    let patch_4 = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_4);
+    forest.update_account(block_4, &patch_4).unwrap();
 
     assert!(
         forest
@@ -538,10 +535,10 @@ fn storage_map_empty_entries_query() {
         .unwrap();
 
     let account_id = account.id();
-    let full_delta = AccountDelta::try_from(account).unwrap();
-    assert!(full_delta.is_full_state());
+    let full_patch = AccountPatch::try_from(account).unwrap();
+    assert!(full_patch.is_full_state());
 
-    forest.update_account(block_num, &full_delta).unwrap();
+    forest.update_account(block_num, &full_patch).unwrap();
 
     let root = forest.get_storage_map_root(account_id, &slot_name, block_num);
     assert_eq!(root, Some(AccountStateForest::empty_smt_root()));
@@ -552,23 +549,23 @@ fn storage_map_open_returns_proofs() {
     use std::collections::BTreeMap;
 
     use assert_matches::assert_matches;
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
     let slot_name = StorageSlotName::mock(3);
     let block_num = BlockNumber::GENESIS.child();
 
-    let mut map_delta = StorageMapDelta::default();
+    let mut map_patch = StorageMapPatch::default();
     for i in 0..20u32 {
         let key = StorageMapKey::from_index(i);
         let value = Word::from([0, 0, 0, i]);
-        map_delta.insert(key, value);
+        map_patch.insert(key, value);
     }
-    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta))]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
-    let delta = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta);
-    forest.update_account(block_num, &delta).unwrap();
+    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch))]);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
+    let patch = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch);
+    forest.update_account(block_num, &patch).unwrap();
 
     let keys: Vec<StorageMapKey> = (0..20u32).map(StorageMapKey::from_index).collect();
     let result =
@@ -584,7 +581,7 @@ fn storage_map_open_returns_proofs() {
 fn storage_map_all_entries_returns_raw_keys_after_update() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -593,12 +590,12 @@ fn storage_map_all_entries_returns_raw_keys_after_update() {
     let raw_key = StorageMapKey::from_index(42);
     let value = Word::from([42u32, 0, 0, 0]);
 
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(raw_key, value);
-    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta))]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
-    let delta = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta);
-    forest.update_account(block_num, &delta).unwrap();
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(raw_key, value);
+    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch))]);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
+    let patch = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch);
+    forest.update_account(block_num, &patch).unwrap();
 
     let result = forest
         .get_storage_map_details_for_all_entries(account_id, slot_name.clone(), block_num)
@@ -617,7 +614,7 @@ fn storage_map_all_entries_returns_raw_keys_after_update() {
 fn storage_map_all_entries_returns_cache_miss_when_raw_key_is_not_cached() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -626,12 +623,12 @@ fn storage_map_all_entries_returns_cache_miss_when_raw_key_is_not_cached() {
     let raw_key = StorageMapKey::from_index(43);
     let value = Word::from([43u32, 0, 0, 0]);
 
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(raw_key, value);
-    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta))]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
-    let delta = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta);
-    forest.update_account(block_num, &delta).unwrap();
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(raw_key, value);
+    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch))]);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
+    let patch = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch);
+    forest.update_account(block_num, &patch).unwrap();
 
     forest.clear_storage_map_key_cache();
 
@@ -674,7 +671,7 @@ fn prune_handles_empty_forest() {
 
 #[test]
 fn prune_removes_smt_roots_from_forest() {
-    use miden_protocol::account::delta::StorageMapDelta;
+    use miden_protocol::account::StorageMapPatch;
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -684,24 +681,23 @@ fn prune_removes_smt_roots_from_forest() {
     for i in 1..=TEST_PRUNE_CHAIN_TIP {
         let block_num = BlockNumber::from(i);
 
-        let mut vault_delta = AccountVaultDelta::default();
-        vault_delta
-            .add_asset(dummy_fungible_asset(faucet_id, (i * TEST_AMOUNT_MULTIPLIER).into()))
-            .unwrap();
-        let storage_delta = if i.is_multiple_of(3) {
-            let mut map_delta = StorageMapDelta::default();
-            map_delta.insert(
+        let mut vault_patch = AccountVaultPatch::default();
+        vault_patch
+            .insert_asset(dummy_fungible_asset(faucet_id, (i * TEST_AMOUNT_MULTIPLIER).into()));
+        let storage_patch = if i.is_multiple_of(3) {
+            let mut map_patch = StorageMapPatch::default();
+            map_patch.insert(
                 StorageMapKey::new(Word::from([1u32, 0, 0, 0])),
                 Word::from([99u32, i, i * i, i * i * i]),
             );
-            let asd = AccountStorageDelta::new();
-            asd.add_updated_maps([(slot_name.clone(), map_delta)])
+            let asd = AccountStoragePatch::new();
+            asd.add_updated_maps([(slot_name.clone(), map_patch)])
         } else {
-            AccountStorageDelta::default()
+            AccountStoragePatch::default()
         };
 
-        let delta = dummy_partial_delta(account_id, vault_delta, storage_delta);
-        forest.update_account(block_num, &delta).unwrap();
+        let patch = dummy_partial_patch(account_id, vault_patch, storage_patch);
+        forest.update_account(block_num, &patch).unwrap();
     }
 
     let retained_block = BlockNumber::from(TEST_PRUNE_CHAIN_TIP);
@@ -733,12 +729,11 @@ fn prune_respects_retention_boundary() {
 
     for i in 1..=HISTORICAL_BLOCK_RETENTION {
         let block_num = BlockNumber::from(i);
-        let mut vault_delta = AccountVaultDelta::default();
-        vault_delta
-            .add_asset(dummy_fungible_asset(faucet_id, (i * TEST_AMOUNT_MULTIPLIER).into()))
-            .unwrap();
-        let delta = dummy_partial_delta(account_id, vault_delta, AccountStorageDelta::default());
-        forest.update_account(block_num, &delta).unwrap();
+        let mut vault_patch = AccountVaultPatch::default();
+        vault_patch
+            .insert_asset(dummy_fungible_asset(faucet_id, (i * TEST_AMOUNT_MULTIPLIER).into()));
+        let patch = dummy_partial_patch(account_id, vault_patch, AccountStoragePatch::default());
+        forest.update_account(block_num, &patch).unwrap();
     }
 
     let total_roots_removed = forest.prune(BlockNumber::from(HISTORICAL_BLOCK_RETENTION));
@@ -749,7 +744,7 @@ fn prune_respects_retention_boundary() {
 
 #[test]
 fn prune_roots_removes_old_entries() {
-    use miden_protocol::account::delta::StorageMapDelta;
+    use miden_protocol::account::StorageMapPatch;
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -760,18 +755,18 @@ fn prune_roots_removes_old_entries() {
     for i in 1..=TEST_CHAIN_LENGTH {
         let block_num = BlockNumber::from(i);
         let amount = (i * TEST_AMOUNT_MULTIPLIER).into();
-        let mut vault_delta = AccountVaultDelta::default();
-        vault_delta.add_asset(dummy_fungible_asset(faucet_id, amount)).unwrap();
+        let mut vault_patch = AccountVaultPatch::default();
+        vault_patch.insert_asset(dummy_fungible_asset(faucet_id, amount));
 
         let key = StorageMapKey::new(Word::from([i, i * i, 5, 4]));
         let value = Word::from([0, 0, i * i * i, 77]);
-        let mut map_delta = StorageMapDelta::default();
-        map_delta.insert(key, value);
-        let storage_delta =
-            AccountStorageDelta::new().add_updated_maps([(slot_name.clone(), map_delta)]);
+        let mut map_patch = StorageMapPatch::default();
+        map_patch.insert(key, value);
+        let storage_patch =
+            AccountStoragePatch::new().add_updated_maps([(slot_name.clone(), map_patch)]);
 
-        let delta = dummy_partial_delta(account_id, vault_delta, storage_delta);
-        forest.update_account(block_num, &delta).unwrap();
+        let patch = dummy_partial_patch(account_id, vault_patch, storage_patch);
+        forest.update_account(block_num, &patch).unwrap();
     }
 
     assert_eq!(forest.forest.tree_count(), 22);
@@ -794,15 +789,15 @@ fn prune_handles_multiple_accounts() {
         let block_num = BlockNumber::from(i);
         let amount = (i * TEST_AMOUNT_MULTIPLIER).into();
 
-        let mut vault_delta1 = AccountVaultDelta::default();
-        vault_delta1.add_asset(dummy_fungible_asset(faucet_id, amount)).unwrap();
-        let delta1 = dummy_partial_delta(account1, vault_delta1, AccountStorageDelta::default());
-        forest.update_account(block_num, &delta1).unwrap();
+        let mut vault_patch1 = AccountVaultPatch::default();
+        vault_patch1.insert_asset(dummy_fungible_asset(faucet_id, amount));
+        let patch1 = dummy_partial_patch(account1, vault_patch1, AccountStoragePatch::default());
+        forest.update_account(block_num, &patch1).unwrap();
 
-        let mut vault_delta2 = AccountVaultDelta::default();
-        vault_delta2.add_asset(dummy_fungible_asset(account2, amount * 2)).unwrap();
-        let delta2 = dummy_partial_delta(account2, vault_delta2, AccountStorageDelta::default());
-        forest.update_account(block_num, &delta2).unwrap();
+        let mut vault_patch2 = AccountVaultPatch::default();
+        vault_patch2.insert_asset(dummy_fungible_asset(account2, amount * 2));
+        let patch2 = dummy_partial_patch(account2, vault_patch2, AccountStoragePatch::default());
+        forest.update_account(block_num, &patch2).unwrap();
     }
 
     assert_eq!(forest.forest.tree_count(), 22);
@@ -820,7 +815,7 @@ fn prune_handles_multiple_accounts() {
 fn prune_handles_multiple_slots() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -829,17 +824,17 @@ fn prune_handles_multiple_slots() {
 
     for i in 1..=TEST_CHAIN_LENGTH {
         let block_num = BlockNumber::from(i);
-        let mut map_delta_a = StorageMapDelta::default();
-        map_delta_a.insert(StorageMapKey::new(Word::from([i, 0, 0, 0])), Word::from([i, 0, 0, 1]));
-        let mut map_delta_b = StorageMapDelta::default();
-        map_delta_b.insert(StorageMapKey::new(Word::from([i, 0, 0, 2])), Word::from([i, 0, 0, 3]));
+        let mut map_patch_a = StorageMapPatch::default();
+        map_patch_a.insert(StorageMapKey::new(Word::from([i, 0, 0, 0])), Word::from([i, 0, 0, 1]));
+        let mut map_patch_b = StorageMapPatch::default();
+        map_patch_b.insert(StorageMapKey::new(Word::from([i, 0, 0, 2])), Word::from([i, 0, 0, 3]));
         let raw = BTreeMap::from_iter([
-            (slot_a.clone(), StorageSlotDelta::Map(map_delta_a)),
-            (slot_b.clone(), StorageSlotDelta::Map(map_delta_b)),
+            (slot_a.clone(), StorageSlotPatch::Map(map_patch_a)),
+            (slot_b.clone(), StorageSlotPatch::Map(map_patch_b)),
         ]);
-        let storage_delta = AccountStorageDelta::from_raw(raw);
-        let delta = dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta);
-        forest.update_account(block_num, &delta).unwrap();
+        let storage_patch = AccountStoragePatch::from_raw(raw);
+        let patch = dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch);
+        forest.update_account(block_num, &patch).unwrap();
     }
 
     assert_eq!(forest.forest.tree_count(), 22);
@@ -856,7 +851,7 @@ fn prune_handles_multiple_slots() {
 fn prune_preserves_most_recent_state_per_entity() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -866,37 +861,37 @@ fn prune_preserves_most_recent_state_per_entity() {
 
     // Block 1: Create vault + map_a + map_b
     let block_1 = BlockNumber::from(1);
-    let mut vault_delta_1 = AccountVaultDelta::default();
-    vault_delta_1.add_asset(dummy_fungible_asset(faucet_id, 1000)).unwrap();
+    let mut vault_patch_1 = AccountVaultPatch::default();
+    vault_patch_1.insert_asset(dummy_fungible_asset(faucet_id, 1000));
 
-    let mut map_delta_a = StorageMapDelta::default();
-    map_delta_a
+    let mut map_patch_a = StorageMapPatch::default();
+    map_patch_a
         .insert(StorageMapKey::new(Word::from([1u32, 0, 0, 0])), Word::from([100u32, 0, 0, 0]));
 
-    let mut map_delta_b = StorageMapDelta::default();
-    map_delta_b
+    let mut map_patch_b = StorageMapPatch::default();
+    map_patch_b
         .insert(StorageMapKey::new(Word::from([2u32, 0, 0, 0])), Word::from([200u32, 0, 0, 0]));
 
     let raw = BTreeMap::from_iter([
-        (slot_map_a.clone(), StorageSlotDelta::Map(map_delta_a)),
-        (slot_map_b.clone(), StorageSlotDelta::Map(map_delta_b)),
+        (slot_map_a.clone(), StorageSlotPatch::Map(map_patch_a)),
+        (slot_map_b.clone(), StorageSlotPatch::Map(map_patch_b)),
     ]);
-    let storage_delta_1 = AccountStorageDelta::from_raw(raw);
-    let delta_1 = dummy_partial_delta(account_id, vault_delta_1, storage_delta_1);
-    forest.update_account(block_1, &delta_1).unwrap();
+    let storage_patch_1 = AccountStoragePatch::from_raw(raw);
+    let patch_1 = dummy_partial_patch(account_id, vault_patch_1, storage_patch_1);
+    forest.update_account(block_1, &patch_1).unwrap();
 
     // Block 51: Update only map_a
     let block_at_51 = BlockNumber::from(51);
-    let mut map_delta_a_new = StorageMapDelta::default();
-    map_delta_a_new
+    let mut map_patch_a_new = StorageMapPatch::default();
+    map_patch_a_new
         .insert(StorageMapKey::new(Word::from([1u32, 0, 0, 0])), Word::from([999u32, 0, 0, 0]));
 
     let raw_at_51 =
-        BTreeMap::from_iter([(slot_map_a.clone(), StorageSlotDelta::Map(map_delta_a_new))]);
-    let storage_delta_at_51 = AccountStorageDelta::from_raw(raw_at_51);
-    let delta_at_51 =
-        dummy_partial_delta(account_id, AccountVaultDelta::default(), storage_delta_at_51);
-    forest.update_account(block_at_51, &delta_at_51).unwrap();
+        BTreeMap::from_iter([(slot_map_a.clone(), StorageSlotPatch::Map(map_patch_a_new))]);
+    let storage_patch_at_51 = AccountStoragePatch::from_raw(raw_at_51);
+    let patch_at_51 =
+        dummy_partial_patch(account_id, AccountVaultPatch::default(), storage_patch_at_51);
+    forest.update_account(block_at_51, &patch_at_51).unwrap();
 
     // Block 100: Prune
     let block_100 = BlockNumber::from(100);
@@ -913,7 +908,7 @@ fn prune_preserves_most_recent_state_per_entity() {
 fn prune_preserves_entries_within_retention_window() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     let mut forest = AccountStateForest::new();
     let account_id = dummy_account();
@@ -925,19 +920,17 @@ fn prune_preserves_entries_within_retention_window() {
     for &block_num in &blocks {
         let block = BlockNumber::from(block_num);
 
-        let mut vault_delta = AccountVaultDelta::default();
-        vault_delta
-            .add_asset(dummy_fungible_asset(faucet_id, u64::from(block_num) * 100))
-            .unwrap();
+        let mut vault_patch = AccountVaultPatch::default();
+        vault_patch.insert_asset(dummy_fungible_asset(faucet_id, u64::from(block_num) * 100));
 
-        let mut map_delta = StorageMapDelta::default();
-        map_delta
+        let mut map_patch = StorageMapPatch::default();
+        map_patch
             .insert(StorageMapKey::from_index(block_num), Word::from([block_num * 10, 0, 0, 0]));
 
-        let raw = BTreeMap::from_iter([(slot_map.clone(), StorageSlotDelta::Map(map_delta))]);
-        let storage_delta = AccountStorageDelta::from_raw(raw);
-        let delta = dummy_partial_delta(account_id, vault_delta, storage_delta);
-        forest.update_account(block, &delta).unwrap();
+        let raw = BTreeMap::from_iter([(slot_map.clone(), StorageSlotPatch::Map(map_patch))]);
+        let storage_patch = AccountStoragePatch::from_raw(raw);
+        let patch = dummy_partial_patch(account_id, vault_patch, storage_patch);
+        forest.update_account(block, &patch).unwrap();
     }
 
     // Block 100: Prune (retention window = 50 blocks, cutoff = 50)
@@ -969,17 +962,15 @@ fn shared_vault_root_retained_when_one_account_changes() {
     let initial_amount = 1000u64;
     let asset = dummy_fungible_asset(faucet_id, initial_amount);
 
-    let mut vault_delta_1 = AccountVaultDelta::default();
-    vault_delta_1.add_asset(asset).unwrap();
-    let delta_1 = dummy_partial_delta(account1, vault_delta_1, AccountStorageDelta::default());
-    forest.update_account(block_1, &delta_1).unwrap();
+    let mut vault_patch_1 = AccountVaultPatch::default();
+    vault_patch_1.insert_asset(asset);
+    let patch_1 = dummy_partial_patch(account1, vault_patch_1, AccountStoragePatch::default());
+    forest.update_account(block_1, &patch_1).unwrap();
 
-    let mut vault_delta_2 = AccountVaultDelta::default();
-    vault_delta_2
-        .add_asset(dummy_fungible_asset(faucet_id, initial_amount))
-        .unwrap();
-    let delta_2 = dummy_partial_delta(account2, vault_delta_2, AccountStorageDelta::default());
-    forest.update_account(block_1, &delta_2).unwrap();
+    let mut vault_patch_2 = AccountVaultPatch::default();
+    vault_patch_2.insert_asset(dummy_fungible_asset(faucet_id, initial_amount));
+    let patch_2 = dummy_partial_patch(account2, vault_patch_2, AccountStoragePatch::default());
+    forest.update_account(block_1, &patch_2).unwrap();
 
     // Both accounts should have the same vault root (structural sharing in SmtForest)
     let root1_at_block1 = forest.get_vault_root(account1, block_1).unwrap();
@@ -988,11 +979,11 @@ fn shared_vault_root_retained_when_one_account_changes() {
 
     // Block 2: Only account2 changes (adds more assets)
     let block_2 = block_1.child();
-    let mut vault_delta_2_update = AccountVaultDelta::default();
-    vault_delta_2_update.add_asset(dummy_fungible_asset(faucet_id, 500)).unwrap();
-    let delta_2_update =
-        dummy_partial_delta(account2, vault_delta_2_update, AccountStorageDelta::default());
-    forest.update_account(block_2, &delta_2_update).unwrap();
+    let mut vault_patch_2_update = AccountVaultPatch::default();
+    vault_patch_2_update.insert_asset(dummy_fungible_asset(faucet_id, initial_amount + 500));
+    let patch_2_update =
+        dummy_partial_patch(account2, vault_patch_2_update, AccountStoragePatch::default());
+    forest.update_account(block_2, &patch_2_update).unwrap();
 
     // Account2 now has a different root
     let root2_at_block2 = forest.get_vault_root(account2, block_2).unwrap();

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -625,6 +625,22 @@ impl Db {
         })
     }
 
+    /// Reconstructs the account vault from the database for a specific account at a block.
+    ///
+    /// Used as fallback when the `AccountStateForest` vault-key cache misses (historical or evicted
+    /// queries). Returns the latest asset for each vault key at or before `block_num`.
+    #[instrument(target = COMPONENT, skip_all)]
+    pub async fn select_account_vault_at_block(
+        &self,
+        account_id: AccountId,
+        block_num: BlockNumber,
+    ) -> Result<Vec<Asset>, DatabaseError> {
+        self.transact("select account vault at block", move |conn| {
+            queries::select_account_vault_at_block(conn, account_id, block_num)
+        })
+        .await
+    }
+
     pub async fn get_account_vault_sync(
         &self,
         account_id: AccountId,

--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -554,6 +554,65 @@ pub(crate) fn select_account_vault_assets(
     Ok((last_block_included, values))
 }
 
+/// Query vault assets at a specific block by finding the most recent update for each `vault_key`.
+///
+/// Uses a single raw SQL query with a subquery join:
+/// ```sql
+/// SELECT a.asset FROM account_vault_assets a
+/// INNER JOIN (
+///     SELECT vault_key, MAX(block_num) as max_block
+///     FROM account_vault_assets
+///     WHERE account_id = ? AND block_num <= ?
+///     GROUP BY vault_key
+/// ) latest ON a.vault_key = latest.vault_key AND a.block_num = latest.max_block
+/// WHERE a.account_id = ?
+/// ```
+pub(crate) fn select_account_vault_at_block(
+    conn: &mut SqliteConnection,
+    account_id: AccountId,
+    block_num: BlockNumber,
+) -> Result<Vec<Asset>, DatabaseError> {
+    use diesel::sql_types::{BigInt, Binary};
+
+    let account_id_bytes = account_id.to_bytes();
+    let block_num_sql = block_num.to_raw_sql();
+
+    let entries: Vec<Option<Vec<u8>>> = diesel::sql_query(
+        r"
+        SELECT a.asset FROM account_vault_assets a
+        INNER JOIN (
+            SELECT vault_key, MAX(block_num) as max_block
+            FROM account_vault_assets
+            WHERE account_id = ? AND block_num <= ?
+            GROUP BY vault_key
+        ) latest ON a.vault_key = latest.vault_key AND a.block_num = latest.max_block
+        WHERE a.account_id = ?
+        ",
+    )
+    .bind::<Binary, _>(&account_id_bytes)
+    .bind::<BigInt, _>(block_num_sql)
+    .bind::<Binary, _>(&account_id_bytes)
+    .load::<AssetRow>(conn)?
+    .into_iter()
+    .map(|row| row.asset)
+    .collect();
+
+    // Convert to assets, filtering out deletions (None values)
+    let mut assets = Vec::new();
+    for asset_bytes in entries.into_iter().flatten() {
+        let asset = Asset::read_from_bytes(&asset_bytes)?;
+        assets.push(asset);
+    }
+
+    Ok(assets)
+}
+
+#[derive(QueryableByName)]
+struct AssetRow {
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Binary>)]
+    asset: Option<Vec<u8>>,
+}
+
 /// Select all accounts from the DB using the given [`SqliteConnection`].
 ///
 /// # Returns

--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -25,14 +25,15 @@ use miden_node_utils::limiter::{
     QueryParamAccountIdLimit,
     QueryParamLimiter,
 };
-use miden_protocol::account::delta::AccountUpdateDetails;
+use miden_protocol::Word;
 use miden_protocol::account::{
     Account,
     AccountCode,
     AccountId,
+    AccountPatch,
     AccountStorage,
     AccountStorageHeader,
-    NonFungibleDeltaAction,
+    AccountUpdateDetails,
     StorageMap,
     StorageMapKey,
     StorageSlot,
@@ -40,10 +41,9 @@ use miden_protocol::account::{
     StorageSlotName,
     StorageSlotType,
 };
-use miden_protocol::asset::{Asset, AssetVault, AssetVaultKey, FungibleAsset};
+use miden_protocol::asset::{Asset, AssetVault, AssetVaultKey};
 use miden_protocol::block::{BlockAccountUpdate, BlockNumber};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
-use miden_protocol::{Felt, Word};
 use miden_standards::account::auth::NetworkAccount;
 
 use crate::COMPONENT;
@@ -60,10 +60,9 @@ mod delta;
 use delta::{
     AccountStateForInsert,
     PartialAccountState,
-    apply_storage_delta,
+    apply_storage_patch,
     select_latest_vault_assets,
     select_minimal_account_state_headers,
-    select_vault_balances_by_vault_keys,
 };
 
 #[cfg(test)]
@@ -1047,69 +1046,42 @@ fn prepare_full_account_update(
     Ok((AccountStateForInsert::FullAccount(account), storage, assets))
 }
 
-/// Prepare partial delta data for account upserts and follow-up storage and vault inserts.
+/// Prepare partial patch data for account upserts and follow-up storage and vault inserts.
 fn prepare_partial_account_update(
     conn: &mut SqliteConnection,
     update: &BlockAccountUpdate,
     account_id: AccountId,
-    delta: &miden_protocol::account::delta::AccountDelta,
+    patch: &AccountPatch,
 ) -> Result<(AccountStateForInsert, PendingStorageInserts, PendingAssetInserts), DatabaseError> {
-    // Build the minimal account state needed for partial delta application. Only load the storage
-    // map entries and vault balances that will receive updates. The next line fetches the header,
-    // which will always change unless the delta is empty.
+    // Build the minimal account state needed for partial patch application. Only load the storage
+    // map entries that will receive updates. The next line fetches the header, which will always
+    // change unless the patch is empty.
     let state_headers = select_minimal_account_state_headers(conn, account_id)?;
 
-    // --- Process asset updates. --------------------------------- Look up balances by vault key
-    // (which includes the callback flag), not by faucet id.
-    let vault_keys =
-        Vec::from_iter(delta.vault().fungible().iter().map(|(vault_key, _)| *vault_key));
-    let prev_balances = select_vault_balances_by_vault_keys(conn, account_id, &vault_keys)?;
-
-    // Encode `Some` as update and `None` as removal.
+    // --- Process asset updates. --------------------------------- The patch carries absolute final
+    // values, so encode `Some` as update and `None` (an empty value word) as removal.
     let mut assets = Vec::new();
-
-    // Update fungible assets.
-    for (vault_key, amount_delta) in delta.vault().fungible().iter() {
-        let faucet_id = vault_key.faucet_id();
-        let callback_flag = vault_key.callback_flag();
-        let prev_amount = prev_balances.get(&vault_key.to_word()).copied().unwrap_or(0);
-        let prev_asset = FungibleAsset::new(faucet_id, prev_amount)?.with_callbacks(callback_flag);
-        let amount_abs = amount_delta.unsigned_abs();
-        let delta = FungibleAsset::new(faucet_id, amount_abs)?.with_callbacks(callback_flag);
-        let new_balance = if *amount_delta < 0 {
-            prev_asset.sub(delta)?
-        } else {
-            prev_asset.add(delta)?
-        };
-        let update_or_remove = if new_balance.amount().as_u64() == 0 {
+    for (vault_key, value) in patch.vault().iter() {
+        let update_or_remove = if *value == Word::empty() {
             None
         } else {
-            Some(Asset::from(new_balance))
+            Some(Asset::from_key_value(*vault_key, *value)?)
         };
-        assets.push((account_id, new_balance.vault_key(), update_or_remove));
-    }
-
-    // Update non-fungible assets.
-    for (asset, delta_action) in delta.vault().non_fungible().iter() {
-        let asset_update = match delta_action {
-            NonFungibleDeltaAction::Add => Some(Asset::NonFungible(*asset)),
-            NonFungibleDeltaAction::Remove => None,
-        };
-        assets.push((account_id, asset.vault_key(), asset_update));
+        assets.push((account_id, *vault_key, update_or_remove));
     }
 
     // --- Collect storage map updates. ---------------------------
 
     let mut storage = Vec::new();
-    for (slot_name, map_delta) in delta.storage().maps() {
-        for (key, value) in map_delta.entries() {
+    for (slot_name, map_patch) in patch.storage().maps() {
+        for (key, value) in map_patch.entries() {
             storage.push((account_id, slot_name.clone(), *key, *value));
         }
     }
 
     // First collect entries that have associated changes.
-    let slot_names = Vec::from_iter(delta.storage().maps().filter_map(|(slot_name, map_delta)| {
-        if map_delta.is_empty() {
+    let slot_names = Vec::from_iter(patch.storage().maps().filter_map(|(slot_name, map_patch)| {
+        if map_patch.is_empty() {
             None
         } else {
             Some(slot_name.clone())
@@ -1118,27 +1090,20 @@ fn prepare_partial_account_update(
 
     let map_entries = select_latest_storage_map_entries_for_slots(conn, &account_id, &slot_names)?;
 
-    // Apply the delta storage to the given storage header.
+    // Apply the patch storage to the given storage header.
     let new_storage_header =
-        apply_storage_delta(&state_headers.storage_header, delta.storage(), &map_entries)?;
+        apply_storage_patch(&state_headers.storage_header, patch.storage(), &map_entries)?;
 
     // --- Update the vault root by constructing the asset vault from DB.
     let new_vault_root = {
         let assets = select_latest_vault_assets(conn, account_id)?;
         let mut vault = AssetVault::new(&assets)?;
-        vault.apply_delta(delta.vault())?;
+        vault.apply_patch(patch.vault())?;
         vault.root()
     };
 
-    // --- Compute updated account state for the accounts row. --- Apply nonce delta.
-    let new_nonce_value = state_headers
-        .nonce
-        .as_canonical_u64()
-        .checked_add(delta.nonce_delta().as_canonical_u64())
-        .ok_or_else(|| {
-            DatabaseError::DataCorrupted(format!("Nonce overflow for account {account_id}"))
-        })?;
-    let new_nonce = Felt::new_unchecked(new_nonce_value);
+    // --- Compute updated account state for the accounts row. --- Use the absolute final nonce.
+    let new_nonce = patch.final_nonce().unwrap_or(state_headers.nonce);
 
     // Create minimal account state data for the row insert.
     let account_state = PartialAccountState {
@@ -1243,17 +1208,17 @@ pub(crate) fn upsert_accounts(
             AccountUpdateDetails::Private => (AccountStateForInsert::Private, vec![], vec![]),
 
             // New account is always a full account, but also comes as an update
-            AccountUpdateDetails::Delta(delta) if delta.is_full_state() => {
-                let account = Account::try_from(delta)
-                    .expect("Delta to full account always works for full state deltas");
+            AccountUpdateDetails::Public(patch) if patch.is_full_state() => {
+                let account = Account::try_from(patch)
+                    .expect("Patch to full account always works for full state patches");
                 debug_assert_eq!(account_id, account.id());
 
                 prepare_full_account_update(update, account)?
             },
 
             // Update of an existing account
-            AccountUpdateDetails::Delta(delta) => {
-                prepare_partial_account_update(conn, update, account_id, delta)?
+            AccountUpdateDetails::Public(patch) => {
+                prepare_partial_account_update(conn, update, account_id, patch)?
             },
         };
 
@@ -1411,7 +1376,7 @@ impl AccountRowInsert {
         }
     }
 
-    /// Creates an insert row from a partial account state (delta update).
+    /// Creates an insert row from a partial account state (patch update).
     fn new_from_partial(
         account_id: AccountId,
         network_account_type: NetworkAccountType,

--- a/crates/store/src/db/models/queries/accounts/delta.rs
+++ b/crates/store/src/db/models/queries/accounts/delta.rs
@@ -12,17 +12,17 @@ use std::collections::{BTreeMap, HashMap};
 
 use diesel::query_dsl::methods::SelectDsl;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl, SqliteConnection};
-use miden_protocol::account::delta::AccountStorageDelta;
 use miden_protocol::account::{
     Account,
     AccountId,
     AccountStorageHeader,
+    AccountStoragePatch,
     StorageMap,
     StorageMapKey,
     StorageSlotHeader,
     StorageSlotName,
 };
-use miden_protocol::asset::{Asset, AssetVaultKey};
+use miden_protocol::asset::Asset;
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_protocol::{EMPTY_WORD, Felt, Word};
 
@@ -67,6 +67,10 @@ pub(super) struct PartialAccountState {
 
 /// Represents the account state to be inserted, either from a full account or from a partial delta
 /// update.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "built per account update and consumed immediately"
+)]
 pub(super) enum AccountStateForInsert {
     /// Private account - no public state stored
     Private,
@@ -133,58 +137,6 @@ pub(super) fn select_minimal_account_state_headers(
     Ok(AccountStateHeadersForDelta { nonce, code_commitment, storage_header })
 }
 
-/// Selects vault balances for specific vault keys.
-///
-/// Optimized query that only fetches balances for the vault keys
-/// that are being updated by a delta, rather than loading all vault assets.
-///
-/// Returns a map from the vault key word to the current balance (absent if not found). Keyed by
-/// vault key rather than faucet id because the callback flag is part of the key.
-///
-/// # Raw SQL
-///
-/// ```sql
-/// SELECT vault_key, asset
-/// FROM account_vault_assets
-/// WHERE account_id = ?1 AND is_latest = 1 AND vault_key IN (?2, ?3, ...)
-/// ```
-pub(super) fn select_vault_balances_by_vault_keys(
-    conn: &mut SqliteConnection,
-    account_id: AccountId,
-    vault_keys: &[AssetVaultKey],
-) -> Result<HashMap<Word, u64>, DatabaseError> {
-    use schema::account_vault_assets as vault;
-
-    if vault_keys.is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    let account_id_bytes = account_id.to_bytes();
-
-    let vault_key_bytes: Vec<Vec<u8>> =
-        vault_keys.iter().map(|vault_key| vault_key.to_word().to_bytes()).collect();
-
-    let entries: Vec<(Vec<u8>, Option<Vec<u8>>)> =
-        SelectDsl::select(vault::table, (vault::vault_key, vault::asset))
-            .filter(vault::account_id.eq(&account_id_bytes))
-            .filter(vault::is_latest.eq(true))
-            .filter(vault::vault_key.eq_any(&vault_key_bytes))
-            .load(conn)?;
-
-    let mut balances = HashMap::new();
-
-    for (_vault_key_bytes, maybe_asset_bytes) in entries {
-        if let Some(asset_bytes) = maybe_asset_bytes {
-            let asset = Asset::read_from_bytes(&asset_bytes)?;
-            if let Asset::Fungible(fungible) = asset {
-                balances.insert(fungible.vault_key().to_word(), fungible.amount().as_u64());
-            }
-        }
-    }
-
-    Ok(balances)
-}
-
 /// Selects the latest vault assets for an account.
 ///
 /// # Raw SQL
@@ -218,29 +170,29 @@ pub(super) fn select_latest_vault_assets(
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Applies storage delta to an existing storage header using precomputed map roots.
+/// Applies a storage patch to an existing storage header using precomputed map roots.
 ///
 /// For value slots, updates the slot value directly.
 /// For map slots, uses the precomputed roots for updated maps.
-pub(super) fn apply_storage_delta(
+pub(super) fn apply_storage_patch(
     header: &AccountStorageHeader,
-    delta: &AccountStorageDelta,
+    patch: &AccountStoragePatch,
     map_entries: &HashMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>,
 ) -> Result<AccountStorageHeader, DatabaseError> {
     let mut value_updates: HashMap<&StorageSlotName, Word> = HashMap::new();
     let mut map_updates: HashMap<&StorageSlotName, Word> = HashMap::new();
 
-    for (slot_name, new_value) in delta.values() {
+    for (slot_name, new_value) in patch.values() {
         value_updates.insert(slot_name, *new_value);
     }
 
-    for (slot_name, map_delta) in delta.maps() {
-        if map_delta.is_empty() {
+    for (slot_name, map_patch) in patch.maps() {
+        if map_patch.is_empty() {
             continue;
         }
 
         let mut entries = map_entries.get(slot_name).cloned().unwrap_or_default();
-        for (key, value) in map_delta.entries() {
+        for (key, value) in map_patch.entries() {
             if *value == EMPTY_WORD {
                 entries.remove(key);
             } else {

--- a/crates/store/src/db/models/queries/accounts/delta/tests.rs
+++ b/crates/store/src/db/models/queries/accounts/delta/tests.rs
@@ -8,23 +8,21 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, SqliteConnection};
 use miden_node_utils::fee::test_fee_params;
 use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
 use miden_protocol::account::component::AccountComponentMetadata;
-use miden_protocol::account::delta::{
-    AccountStorageDelta,
-    AccountUpdateDetails,
-    AccountVaultDelta,
-    StorageMapDelta,
-    StorageSlotDelta,
-};
 use miden_protocol::account::{
     AccountBuilder,
     AccountComponent,
-    AccountDelta,
     AccountId,
+    AccountPatch,
+    AccountStoragePatch,
     AccountType,
+    AccountUpdateDetails,
+    AccountVaultPatch,
     StorageMap,
     StorageMapKey,
+    StorageMapPatch,
     StorageSlot,
     StorageSlotName,
+    StorageSlotPatch,
 };
 use miden_protocol::asset::{Asset, AssetCallbackFlag, FungibleAsset};
 use miden_protocol::block::{BlockAccountUpdate, BlockHeader, BlockNumber};
@@ -154,11 +152,11 @@ fn optimized_delta_matches_full_account_method() {
     insert_block_header(&mut conn, block_2);
 
     // Insert the initial account at block 1 (full state) - no vault assets
-    let delta_initial = AccountDelta::try_from(account.clone()).unwrap();
+    let patch_initial = AccountPatch::try_from(account.clone()).unwrap();
     let account_update_initial = BlockAccountUpdate::new(
         account.id(),
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta_initial),
+        AccountUpdateDetails::Public(patch_initial),
     );
     upsert_accounts(&mut conn, &[account_update_initial], block_1).expect("Initial upsert failed");
 
@@ -189,52 +187,51 @@ fn optimized_delta_matches_full_account_method() {
         full_account_before.storage().slots().iter().next().unwrap().name().clone();
 
     // Build the storage delta (value slot update only)
-    let storage_delta = {
+    let storage_patch = {
         let deltas = BTreeMap::from_iter([(
             value_slot_name.clone(),
-            StorageSlotDelta::Value(new_slot_value),
+            StorageSlotPatch::Value(new_slot_value),
         )]);
-        AccountStorageDelta::from_raw(deltas)
+        AccountStoragePatch::from_raw(deltas)
     };
 
-    // Build the vault delta (add 500 tokens to empty vault)
-    let vault_delta = {
-        let mut delta = AccountVaultDelta::default();
+    // Build the vault patch (the absolute end-state is 500 tokens, starting from an empty vault)
+    let vault_patch = {
         let asset = Asset::Fungible(FungibleAsset::new(faucet_id, VAULT_AMOUNT).unwrap());
-        delta.add_asset(asset).unwrap();
-        delta
+        AccountVaultPatch::with_assets([asset])
     };
 
-    // Create a partial delta
+    // Create a partial patch
     let nonce_delta = Felt::new_unchecked(NONCE_DELTA);
-    let partial_delta = AccountDelta::new(
-        full_account_before.id(),
-        storage_delta.clone(),
-        vault_delta.clone(),
-        nonce_delta,
-    )
-    .unwrap();
-    assert!(!partial_delta.is_full_state(), "Delta should be partial, not full state");
-
-    // Construct the expected final account by applying the delta
     let expected_nonce = Felt::new_unchecked(
         full_account_before.nonce().as_canonical_u64() + nonce_delta.as_canonical_u64(),
     );
+    let partial_patch = AccountPatch::new(
+        full_account_before.id(),
+        storage_patch,
+        vault_patch,
+        None,
+        Some(expected_nonce),
+    )
+    .unwrap();
+    assert!(!partial_patch.is_full_state(), "Patch should be partial, not full state");
+
+    // Construct the expected final account by applying the patch
     let expected_code_commitment = full_account_before.code().commitment();
 
     let mut expected_account = full_account_before.clone();
-    expected_account.apply_delta(&partial_delta).unwrap();
+    expected_account.apply_patch(&partial_patch).unwrap();
     let final_account_for_commitment = expected_account;
 
     let final_commitment = final_account_for_commitment.to_commitment();
     let expected_storage_commitment = final_account_for_commitment.storage().to_commitment();
     let expected_vault_root = final_account_for_commitment.vault().root();
 
-    // ----- Apply the partial delta via upsert_accounts (optimized path) -----
+    // ----- Apply the partial patch via upsert_accounts (optimized path) -----
     let account_update = BlockAccountUpdate::new(
         account.id(),
         final_commitment,
-        AccountUpdateDetails::Delta(partial_delta),
+        AccountUpdateDetails::Public(partial_patch),
     );
     upsert_accounts(&mut conn, &[account_update], block_2).expect("Partial delta upsert failed");
 
@@ -356,44 +353,46 @@ fn optimized_delta_updates_non_empty_vault() {
     insert_block_header(&mut conn, block_2);
     insert_block_header(&mut conn, block_3);
 
-    // Block 1: insert full-state delta (initial account with 700 tokens of faucet_id)
-    let delta_initial = AccountDelta::try_from(account.clone()).unwrap();
+    // Block 1: insert full-state patch (initial account with 700 tokens of faucet_id)
+    let patch_initial = AccountPatch::try_from(account.clone()).unwrap();
     let account_update_initial = BlockAccountUpdate::new(
         account.id(),
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta_initial),
+        AccountUpdateDetails::Public(patch_initial),
     );
     upsert_accounts(&mut conn, &[account_update_initial], block_1).expect("Initial upsert failed");
 
     let full_account_before =
         select_full_account(&mut conn, account.id()).expect("Failed to load full account");
 
-    // Block 2: partial delta — remove faucet_id (700), add faucet_id_1 (250)
-    let mut vault_delta = AccountVaultDelta::default();
-    vault_delta
-        .add_asset(Asset::Fungible(FungibleAsset::new(faucet_id_1, ADDED_AMOUNT_BLOCK_2).unwrap()))
-        .unwrap();
-    vault_delta
-        .remove_asset(Asset::Fungible(FungibleAsset::new(faucet_id, INITIAL_AMOUNT).unwrap()))
-        .unwrap();
+    // Block 2: partial patch — remove faucet_id (700), add faucet_id_1 (250)
+    let removed_asset = Asset::Fungible(FungibleAsset::new(faucet_id, INITIAL_AMOUNT).unwrap());
+    let added_asset =
+        Asset::Fungible(FungibleAsset::new(faucet_id_1, ADDED_AMOUNT_BLOCK_2).unwrap());
+    let mut vault_patch = AccountVaultPatch::default();
+    vault_patch.insert_asset(added_asset);
+    vault_patch.remove_asset(removed_asset.vault_key());
 
-    let partial_delta = AccountDelta::new(
+    let final_nonce =
+        Felt::new_unchecked(full_account_before.nonce().as_canonical_u64() + NONCE_DELTA);
+    let partial_patch = AccountPatch::new(
         account.id(),
-        AccountStorageDelta::new(),
-        vault_delta,
-        Felt::new_unchecked(NONCE_DELTA),
+        AccountStoragePatch::new(),
+        vault_patch,
+        None,
+        Some(final_nonce),
     )
     .unwrap();
 
     let mut expected_account = full_account_before.clone();
-    expected_account.apply_delta(&partial_delta).unwrap();
+    expected_account.apply_patch(&partial_patch).unwrap();
     let expected_commitment = expected_account.to_commitment();
     let expected_vault_root = expected_account.vault().root();
 
     let account_update = BlockAccountUpdate::new(
         account.id(),
         expected_commitment,
-        AccountUpdateDetails::Delta(partial_delta),
+        AccountUpdateDetails::Public(partial_patch),
     );
     upsert_accounts(&mut conn, &[account_update], block_2).expect("Partial delta upsert failed");
 
@@ -412,29 +411,32 @@ fn optimized_delta_updates_non_empty_vault() {
     assert_eq!(full_account_after.vault().root(), expected_vault_root);
     assert_eq!(full_account_after.to_commitment(), expected_commitment);
 
-    // Block 3: partial delta — add more of faucet_id_1 (150 more, total = 400)
-    let mut vault_delta_3 = AccountVaultDelta::default();
-    vault_delta_3
-        .add_asset(Asset::Fungible(FungibleAsset::new(faucet_id_1, ADDED_AMOUNT_BLOCK_3).unwrap()))
-        .unwrap();
+    // Block 3: partial patch — add more of faucet_id_1 (150 more, total = 400)
+    let mut vault_patch_3 = AccountVaultPatch::default();
+    vault_patch_3.insert_asset(Asset::Fungible(
+        FungibleAsset::new(faucet_id_1, ADDED_AMOUNT_BLOCK_2 + ADDED_AMOUNT_BLOCK_3).unwrap(),
+    ));
 
-    let partial_delta_3 = AccountDelta::new(
+    let final_nonce_3 =
+        Felt::new_unchecked(full_account_after.nonce().as_canonical_u64() + NONCE_DELTA);
+    let partial_patch_3 = AccountPatch::new(
         account.id(),
-        AccountStorageDelta::new(),
-        vault_delta_3,
-        Felt::new_unchecked(NONCE_DELTA),
+        AccountStoragePatch::new(),
+        vault_patch_3,
+        None,
+        Some(final_nonce_3),
     )
     .unwrap();
 
     let mut expected_after_3 = full_account_after.clone();
-    expected_after_3.apply_delta(&partial_delta_3).unwrap();
+    expected_after_3.apply_patch(&partial_patch_3).unwrap();
     let commitment_3 = expected_after_3.to_commitment();
     let expected_vault_root_3 = expected_after_3.vault().root();
 
     let account_update_3 = BlockAccountUpdate::new(
         account.id(),
         commitment_3,
-        AccountUpdateDetails::Delta(partial_delta_3),
+        AccountUpdateDetails::Public(partial_patch_3),
     );
     upsert_accounts(&mut conn, &[account_update_3], block_3).expect("Block 3 upsert failed");
 
@@ -496,13 +498,13 @@ fn optimized_delta_updates_preserve_callback_flag() {
     insert_block_header(&mut conn, block_3);
 
     // Block 1: full-state insert of the (asset-less) account.
-    let delta_initial = AccountDelta::try_from(account.clone()).unwrap();
+    let patch_initial = AccountPatch::try_from(account.clone()).unwrap();
     upsert_accounts(
         &mut conn,
         &[BlockAccountUpdate::new(
             account.id(),
             account.to_commitment(),
-            AccountUpdateDetails::Delta(delta_initial),
+            AccountUpdateDetails::Public(patch_initial),
         )],
         block_1,
     )
@@ -513,30 +515,43 @@ fn optimized_delta_updates_preserve_callback_flag() {
     let apply_callback_delta = |conn: &mut SqliteConnection, block, amount| {
         let prev = select_full_account(conn, account.id()).expect("load account");
 
-        let asset = Asset::Fungible(
-            FungibleAsset::new(faucet_id, amount)
+        let callback_template = FungibleAsset::new(faucet_id, amount)
+            .unwrap()
+            .with_callbacks(AssetCallbackFlag::Enabled);
+        let vault_key = callback_template.vault_key();
+
+        // The patch carries the absolute end-state, so accumulate the previous balance for this
+        // asset and add the new amount on top.
+        let prev_amount = match prev.vault().get(vault_key) {
+            Some(Asset::Fungible(f)) => f.amount().as_u64(),
+            _ => 0,
+        };
+        let absolute_asset = Asset::Fungible(
+            FungibleAsset::new(faucet_id, prev_amount + amount)
                 .unwrap()
                 .with_callbacks(AssetCallbackFlag::Enabled),
         );
-        let mut vault_delta = AccountVaultDelta::default();
-        vault_delta.add_asset(asset).unwrap();
-        let delta = AccountDelta::new(
+        let mut vault_patch = AccountVaultPatch::default();
+        vault_patch.insert_asset(absolute_asset);
+        let final_nonce = Felt::new_unchecked(prev.nonce().as_canonical_u64() + NONCE_DELTA);
+        let patch = AccountPatch::new(
             account.id(),
-            AccountStorageDelta::new(),
-            vault_delta,
-            Felt::new_unchecked(NONCE_DELTA),
+            AccountStoragePatch::new(),
+            vault_patch,
+            None,
+            Some(final_nonce),
         )
         .unwrap();
 
         let mut expected = prev.clone();
-        expected.apply_delta(&delta).unwrap();
+        expected.apply_patch(&patch).unwrap();
 
         upsert_accounts(
             conn,
             &[BlockAccountUpdate::new(
                 account.id(),
                 expected.to_commitment(),
-                AccountUpdateDetails::Delta(delta),
+                AccountUpdateDetails::Public(patch),
             )],
             block,
         )
@@ -565,6 +580,7 @@ fn optimized_delta_updates_preserve_callback_flag() {
 }
 
 #[test]
+#[expect(clippy::too_many_lines)]
 fn optimized_delta_updates_storage_map_header() {
     // Use deterministic account seed to keep account IDs stable.
     const ACCOUNT_SEED: [u8; 32] = [30u8; 32];
@@ -631,41 +647,44 @@ fn optimized_delta_updates_storage_map_header() {
     insert_block_header(&mut conn, block_1);
     insert_block_header(&mut conn, block_2);
 
-    let delta_initial = AccountDelta::try_from(account.clone()).unwrap();
+    let patch_initial = AccountPatch::try_from(account.clone()).unwrap();
     let account_update_initial = BlockAccountUpdate::new(
         account.id(),
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta_initial),
+        AccountUpdateDetails::Public(patch_initial),
     );
     upsert_accounts(&mut conn, &[account_update_initial], block_1).expect("Initial upsert failed");
 
     let full_account_before =
         select_full_account(&mut conn, account.id()).expect("Failed to load full account");
 
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(map_key, map_value_updated);
-    let storage_delta = AccountStorageDelta::from_raw(BTreeMap::from_iter([(
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(map_key, map_value_updated);
+    let storage_patch = AccountStoragePatch::from_raw(BTreeMap::from_iter([(
         StorageSlotName::mock(SLOT_INDEX_MAP),
-        StorageSlotDelta::Map(map_delta),
+        StorageSlotPatch::Map(map_patch),
     )]));
 
-    let partial_delta = AccountDelta::new(
+    let final_nonce =
+        Felt::new_unchecked(full_account_before.nonce().as_canonical_u64() + NONCE_DELTA);
+    let partial_patch = AccountPatch::new(
         account.id(),
-        storage_delta,
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(NONCE_DELTA),
+        storage_patch,
+        AccountVaultPatch::default(),
+        None,
+        Some(final_nonce),
     )
     .unwrap();
 
     let mut expected_account = full_account_before.clone();
-    expected_account.apply_delta(&partial_delta).unwrap();
+    expected_account.apply_patch(&partial_patch).unwrap();
     let expected_commitment = expected_account.to_commitment();
     let expected_storage_commitment = expected_account.storage().to_commitment();
 
     let account_update = BlockAccountUpdate::new(
         account.id(),
         expected_commitment,
-        AccountUpdateDetails::Delta(partial_delta),
+        AccountUpdateDetails::Public(partial_patch),
     );
     upsert_accounts(&mut conn, &[account_update], block_2).expect("Partial delta upsert failed");
 
@@ -794,14 +813,14 @@ fn upsert_full_state_delta() {
         .build_existing()
         .unwrap();
 
-    // Create a full-state delta from the account
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
-    assert!(delta.is_full_state(), "Delta should be full state");
+    // Create a full-state patch from the account
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
+    assert!(patch.is_full_state(), "Patch should be full state");
 
     let account_update = BlockAccountUpdate::new(
         account.id(),
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     );
 
     upsert_accounts(&mut conn, &[account_update], block_num)

--- a/crates/store/src/db/models/queries/accounts/delta/tests.rs
+++ b/crates/store/src/db/models/queries/accounts/delta/tests.rs
@@ -36,9 +36,9 @@ use miden_protocol::{EMPTY_WORD, Felt, Word};
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::code_builder::CodeBuilder;
 
-use crate::db::models::queries::accounts::tests::select_account_vault_at_block;
 use crate::db::models::queries::accounts::{
     select_account_header_with_storage_header_at_block,
+    select_account_vault_at_block,
     select_full_account,
     upsert_accounts,
 };

--- a/crates/store/src/db/models/queries/accounts/tests.rs
+++ b/crates/store/src/db/models/queries/accounts/tests.rs
@@ -235,66 +235,6 @@ fn assert_storage_map_slot_entries(
     assert_eq!(&entries, expected, "map entries mismatch");
 }
 
-/// Test helper: query vault assets at a specific block by finding the most recent
-/// update for each `vault_key`.
-///
-/// Uses a single raw SQL query with a subquery join:
-/// ```sql
-/// SELECT a.asset FROM account_vault_assets a
-/// INNER JOIN (
-///     SELECT vault_key, MAX(block_num) as max_block
-///     FROM account_vault_assets
-///     WHERE account_id = ? AND block_num <= ?
-///     GROUP BY vault_key
-/// ) latest ON a.vault_key = latest.vault_key AND a.block_num = latest.max_block
-/// WHERE a.account_id = ?
-/// ```
-pub(super) fn select_account_vault_at_block(
-    conn: &mut SqliteConnection,
-    account_id: AccountId,
-    block_num: BlockNumber,
-) -> Result<Vec<Asset>, DatabaseError> {
-    use diesel::sql_types::{BigInt, Binary};
-
-    let account_id_bytes = account_id.to_bytes();
-    let block_num_sql = block_num.to_raw_sql();
-
-    let entries: Vec<Option<Vec<u8>>> = diesel::sql_query(
-        r"
-        SELECT a.asset FROM account_vault_assets a
-        INNER JOIN (
-            SELECT vault_key, MAX(block_num) as max_block
-            FROM account_vault_assets
-            WHERE account_id = ? AND block_num <= ?
-            GROUP BY vault_key
-        ) latest ON a.vault_key = latest.vault_key AND a.block_num = latest.max_block
-        WHERE a.account_id = ?
-        ",
-    )
-    .bind::<Binary, _>(&account_id_bytes)
-    .bind::<BigInt, _>(block_num_sql)
-    .bind::<Binary, _>(&account_id_bytes)
-    .load::<AssetRow>(conn)?
-    .into_iter()
-    .map(|row| row.asset)
-    .collect();
-
-    // Convert to assets, filtering out deletions (None values)
-    let mut assets = Vec::new();
-    for asset_bytes in entries.into_iter().flatten() {
-        let asset = Asset::read_from_bytes(&asset_bytes)?;
-        assets.push(asset);
-    }
-
-    Ok(assets)
-}
-
-#[derive(QueryableByName)]
-struct AssetRow {
-    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Binary>)]
-    asset: Option<Vec<u8>>,
-}
-
 // ACCOUNT HEADER AT BLOCK TESTS
 // ================================================================================================
 

--- a/crates/store/src/db/models/queries/accounts/tests.rs
+++ b/crates/store/src/db/models/queries/accounts/tests.rs
@@ -7,26 +7,26 @@ use diesel::{BoolExpressionMethods, ExpressionMethods, OptionalExtension, QueryD
 use miden_node_utils::fee::test_fee_params;
 use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
 use miden_protocol::account::component::AccountComponentMetadata;
-use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::account::{
     Account,
     AccountBuilder,
     AccountComponent,
-    AccountDelta,
     AccountId,
     AccountIdVersion,
+    AccountPatch,
     AccountStorage,
-    AccountStorageDelta,
     AccountStorageHeader,
+    AccountStoragePatch,
     AccountType,
-    AccountVaultDelta,
+    AccountUpdateDetails,
+    AccountVaultPatch,
     StorageMap,
-    StorageMapDelta,
     StorageMapKey,
+    StorageMapPatch,
     StorageSlot,
     StorageSlotContent,
-    StorageSlotDelta,
     StorageSlotName,
+    StorageSlotPatch,
     StorageSlotType,
 };
 use miden_protocol::block::{BlockAccountUpdate, BlockHeader, BlockNumber};
@@ -324,11 +324,11 @@ fn test_select_account_header_at_block_returns_correct_header() {
     insert_block_header(&mut conn, block_num);
 
     // Insert the account
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
     let account_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     );
 
     upsert_accounts(&mut conn, &[account_update], block_num).expect("upsert_accounts failed");
@@ -361,11 +361,11 @@ fn test_select_account_header_at_block_historical_query() {
 
     // Insert the account at block 1
     let nonce_1 = account.nonce();
-    let delta_1 = AccountDelta::try_from(account.clone()).unwrap();
+    let patch_1 = AccountPatch::try_from(account.clone()).unwrap();
     let account_update_1 = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta_1),
+        AccountUpdateDetails::Public(patch_1),
     );
 
     upsert_accounts(&mut conn, &[account_update_1], block_num_1).expect("First upsert failed");
@@ -400,11 +400,11 @@ fn test_select_account_vault_at_block_empty() {
     insert_block_header(&mut conn, block_num);
 
     // Insert account without vault assets
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
     let account_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     );
 
     upsert_accounts(&mut conn, &[account_update], block_num).expect("upsert_accounts failed");
@@ -432,12 +432,15 @@ fn test_upsert_accounts_inserts_storage_header() {
     let storage_slots_len = account.storage().slots().len();
     let account_commitment = account.to_commitment();
 
-    // Create full state delta from the account
-    let delta = AccountDelta::try_from(account).unwrap();
-    assert!(delta.is_full_state(), "Delta should be full state");
+    // Create full state patch from the account
+    let patch = AccountPatch::try_from(account).unwrap();
+    assert!(patch.is_full_state(), "Patch should be full state");
 
-    let account_update =
-        BlockAccountUpdate::new(account_id, account_commitment, AccountUpdateDetails::Delta(delta));
+    let account_update = BlockAccountUpdate::new(
+        account_id,
+        account_commitment,
+        AccountUpdateDetails::Public(patch),
+    );
 
     // Upsert account
     let result = upsert_accounts(&mut conn, &[account_update], block_num);
@@ -486,13 +489,13 @@ fn test_upsert_accounts_updates_is_latest_flag() {
     let storage_commitment_1 = account.storage().to_commitment();
     let account_commitment_1 = account.to_commitment();
 
-    // First update with original account - full state delta
-    let delta_1 = AccountDelta::try_from(account).unwrap();
+    // First update with original account - full state patch
+    let patch_1 = AccountPatch::try_from(account).unwrap();
 
     let account_update_1 = BlockAccountUpdate::new(
         account_id,
         account_commitment_1,
-        AccountUpdateDetails::Delta(delta_1),
+        AccountUpdateDetails::Public(patch_1),
     );
 
     upsert_accounts(&mut conn, &[account_update_1], block_num_1).expect("First upsert failed");
@@ -531,13 +534,13 @@ fn test_upsert_accounts_updates_is_latest_flag() {
     let storage_commitment_2 = account_2.storage().to_commitment();
     let account_commitment_2 = account_2.to_commitment();
 
-    // Second update with modified account - full state delta
-    let delta_2 = AccountDelta::try_from(account_2).unwrap();
+    // Second update with modified account - full state patch
+    let patch_2 = AccountPatch::try_from(account_2).unwrap();
 
     let account_update_2 = BlockAccountUpdate::new(
         account_id,
         account_commitment_2,
-        AccountUpdateDetails::Delta(delta_2),
+        AccountUpdateDetails::Public(patch_2),
     );
 
     upsert_accounts(&mut conn, &[account_update_2], block_num_2).expect("Second upsert failed");
@@ -626,10 +629,13 @@ fn test_upsert_accounts_with_multiple_storage_slots() {
 
     let storage_commitment = account.storage().to_commitment();
     let account_commitment = account.to_commitment();
-    let delta = AccountDelta::try_from(account).unwrap();
+    let patch = AccountPatch::try_from(account).unwrap();
 
-    let account_update =
-        BlockAccountUpdate::new(account_id, account_commitment, AccountUpdateDetails::Delta(delta));
+    let account_update = BlockAccountUpdate::new(
+        account_id,
+        account_commitment,
+        AccountUpdateDetails::Public(patch),
+    );
 
     upsert_accounts(&mut conn, &[account_update], block_num)
         .expect("Upsert with multiple storage slots failed");
@@ -689,10 +695,13 @@ fn test_upsert_accounts_with_empty_storage() {
 
     let storage_commitment = account.storage().to_commitment();
     let account_commitment = account.to_commitment();
-    let delta = AccountDelta::try_from(account).unwrap();
+    let patch = AccountPatch::try_from(account).unwrap();
 
-    let account_update =
-        BlockAccountUpdate::new(account_id, account_commitment, AccountUpdateDetails::Delta(delta));
+    let account_update = BlockAccountUpdate::new(
+        account_id,
+        account_commitment,
+        AccountUpdateDetails::Public(patch),
+    );
 
     upsert_accounts(&mut conn, &[account_update], block_num)
         .expect("Upsert with empty storage failed");
@@ -762,9 +771,12 @@ fn test_select_latest_account_storage_ordering_semantics() {
         "storage commitments should be order-independent"
     );
 
-    let delta = AccountDelta::try_from(account).unwrap();
-    let account_update =
-        BlockAccountUpdate::new(account_id, account_commitment, AccountUpdateDetails::Delta(delta));
+    let patch = AccountPatch::try_from(account).unwrap();
+    let account_update = BlockAccountUpdate::new(
+        account_id,
+        account_commitment,
+        AccountUpdateDetails::Public(patch),
+    );
 
     upsert_accounts(&mut conn, &[account_update], block_num).expect("upsert_accounts failed");
 
@@ -821,9 +833,12 @@ fn test_select_latest_account_storage_multiple_slots() {
 
     let account_id = account.id();
     let account_commitment = account.to_commitment();
-    let delta = AccountDelta::try_from(account).unwrap();
-    let account_update =
-        BlockAccountUpdate::new(account_id, account_commitment, AccountUpdateDetails::Delta(delta));
+    let patch = AccountPatch::try_from(account).unwrap();
+    let account_update = BlockAccountUpdate::new(
+        account_id,
+        account_commitment,
+        AccountUpdateDetails::Public(patch),
+    );
 
     upsert_accounts(&mut conn, &[account_update], block_num).expect("upsert_accounts failed");
 
@@ -857,36 +872,41 @@ fn test_select_latest_account_storage_slot_updates() {
     let account_id = account.id();
     let account_commitment = account.to_commitment();
 
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
-    let account_update =
-        BlockAccountUpdate::new(account_id, account_commitment, AccountUpdateDetails::Delta(delta));
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
+    let account_update = BlockAccountUpdate::new(
+        account_id,
+        account_commitment,
+        AccountUpdateDetails::Public(patch),
+    );
 
     upsert_accounts(&mut conn, &[account_update], block_1).expect("upsert_accounts failed");
 
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(key_1, value_2);
-    map_delta.insert(key_2, value_3);
-    let storage_delta = AccountStorageDelta::from_raw(BTreeMap::from_iter([(
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(key_1, value_2);
+    map_patch.insert(key_2, value_3);
+    let storage_patch = AccountStoragePatch::from_raw(BTreeMap::from_iter([(
         slot_name.clone(),
-        StorageSlotDelta::Map(map_delta),
+        StorageSlotPatch::Map(map_patch),
     )]));
 
-    let partial_delta = AccountDelta::new(
+    let final_nonce = Felt::new_unchecked(account.nonce().as_canonical_u64() + 1);
+    let partial_patch = AccountPatch::new(
         account_id,
-        storage_delta,
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(1),
+        storage_patch,
+        AccountVaultPatch::default(),
+        None,
+        Some(final_nonce),
     )
     .unwrap();
 
     let mut expected_account = account.clone();
-    expected_account.apply_delta(&partial_delta).unwrap();
+    expected_account.apply_patch(&partial_patch).unwrap();
     let expected_commitment = expected_account.to_commitment();
 
     let account_update = BlockAccountUpdate::new(
         account_id,
         expected_commitment,
-        AccountUpdateDetails::Delta(partial_delta),
+        AccountUpdateDetails::Public(partial_patch),
     );
 
     upsert_accounts(&mut conn, &[account_update], block_2).expect("upsert_accounts failed");
@@ -931,11 +951,11 @@ fn test_select_account_vault_at_block_historical_with_updates() {
     insert_block_header(&mut conn, block_3);
 
     // Insert account at block 1
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
     let account_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     );
 
     for block in [block_1, block_2, block_3] {
@@ -1025,11 +1045,11 @@ fn test_select_account_vault_at_block_exponential_updates() {
         insert_block_header(&mut conn, *block);
     }
 
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
     let account_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     );
 
     for block in &blocks {
@@ -1083,11 +1103,11 @@ fn test_select_account_vault_at_block_with_deletion() {
     insert_block_header(&mut conn, block_3);
 
     // Insert account at block 1
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
     let account_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     );
 
     for block in [block_1, block_2, block_3] {
@@ -1157,12 +1177,12 @@ fn account_code_exists(conn: &mut SqliteConnection, code_commitment: Word) -> bo
 
 /// Creates a full-state [`BlockAccountUpdate`] for the given account.
 fn make_full_state_update(account: &Account) -> BlockAccountUpdate {
-    let delta = AccountDelta::try_from(account.clone()).unwrap();
-    assert!(delta.is_full_state(), "expected full-state delta");
+    let patch = AccountPatch::try_from(account.clone()).unwrap();
+    assert!(patch.is_full_state(), "expected full-state patch");
     BlockAccountUpdate::new(
         account.id(),
         account.to_commitment(),
-        AccountUpdateDetails::Delta(delta),
+        AccountUpdateDetails::Public(patch),
     )
 }
 

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -6,23 +6,23 @@ use miden_node_proto::domain::account::{AccountSummary, StorageMapEntries};
 use miden_node_utils::fee::{test_fee, test_fee_params};
 use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
 use miden_protocol::account::component::AccountComponentMetadata;
-use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::account::{
     Account,
     AccountBuilder,
     AccountCode,
     AccountComponent,
-    AccountDelta,
     AccountId,
     AccountIdVersion,
-    AccountStorageDelta,
+    AccountPatch,
+    AccountStoragePatch,
     AccountType,
-    AccountVaultDelta,
+    AccountUpdateDetails,
+    AccountVaultPatch,
     StorageMapKey,
     StorageSlot,
     StorageSlotContent,
-    StorageSlotDelta,
     StorageSlotName,
+    StorageSlotPatch,
 };
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::block::{
@@ -266,7 +266,7 @@ fn make_account_and_note(
             &[BlockAccountUpdate::new(
                 account_id,
                 account.to_commitment(),
-                AccountUpdateDetails::Delta(AccountDelta::try_from(account).unwrap()),
+                AccountUpdateDetails::Public(AccountPatch::try_from(account).unwrap()),
             )],
             block_num,
         )
@@ -952,14 +952,14 @@ fn note_sync_no_matching_tags() {
     assert!(result.is_empty());
 }
 
-fn insert_account_delta(
+fn insert_account_patch(
     conn: &mut SqliteConnection,
     account_id: AccountId,
     block_number: BlockNumber,
-    delta: &AccountDelta,
+    patch: &AccountPatch,
 ) {
-    for (slot_name, slot_delta) in delta.storage().maps() {
-        for (k, v) in slot_delta.entries() {
+    for (slot_name, slot_patch) in patch.storage().maps() {
+        for (k, v) in slot_patch.entries() {
             insert_account_storage_map_value(
                 conn,
                 account_id,
@@ -978,7 +978,7 @@ fn insert_account_delta(
 fn sql_account_storage_map_values_insertion() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::StorageMapDelta;
+    use miden_protocol::account::StorageMapPatch;
 
     let mut conn = create_db();
     let conn = &mut conn;
@@ -1002,14 +1002,20 @@ fn sql_account_storage_map_values_insertion() {
     let value3 = Word::from([30u32, 31, 32, 33]);
 
     // Insert at block 1
-    let mut map1 = StorageMapDelta::default();
+    let mut map1 = StorageMapPatch::default();
     map1.insert(key1, value1);
     map1.insert(key2, value2);
-    let delta1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map1))]);
-    let storage1 = AccountStorageDelta::from_raw(delta1);
-    let delta1 =
-        AccountDelta::new(account_id, storage1, AccountVaultDelta::default(), Felt::ONE).unwrap();
-    insert_account_delta(conn, account_id, block1, &delta1);
+    let delta1 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map1))]);
+    let storage1 = AccountStoragePatch::from_raw(delta1);
+    let patch1 = AccountPatch::new(
+        account_id,
+        storage1,
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
+    insert_account_patch(conn, account_id, block1, &patch1);
 
     let storage_map_page = queries::select_account_storage_map_values_paged(
         conn,
@@ -1021,18 +1027,19 @@ fn sql_account_storage_map_values_insertion() {
     assert_eq!(storage_map_page.values.len(), 2, "expect 2 initial rows");
 
     // Update key1 at block 2
-    let mut map2 = StorageMapDelta::default();
+    let mut map2 = StorageMapPatch::default();
     map2.insert(key1, value3);
-    let delta2 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map2))]);
-    let storage2 = AccountStorageDelta::from_raw(delta2);
-    let delta2 = AccountDelta::new(
+    let delta2 = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map2))]);
+    let storage2 = AccountStoragePatch::from_raw(delta2);
+    let patch2 = AccountPatch::new(
         account_id,
         storage2,
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(2),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(3)),
     )
     .unwrap();
-    insert_account_delta(conn, account_id, block2, &delta2);
+    insert_account_patch(conn, account_id, block2, &patch2);
 
     let storage_map_values = queries::select_account_storage_map_values_paged(
         conn,
@@ -1707,7 +1714,7 @@ fn test_select_account_code_by_commitment() {
         &[BlockAccountUpdate::new(
             account.id(),
             account.to_commitment(),
-            AccountUpdateDetails::Delta(AccountDelta::try_from(account).unwrap()),
+            AccountUpdateDetails::Public(AccountPatch::try_from(account).unwrap()),
         )],
         block_num_1,
     )
@@ -1755,7 +1762,7 @@ fn test_select_account_code_by_commitment_multiple_codes() {
         &[BlockAccountUpdate::new(
             account_v1.id(),
             account_v1.to_commitment(),
-            AccountUpdateDetails::Delta(AccountDelta::try_from(account_v1).unwrap()),
+            AccountUpdateDetails::Public(AccountPatch::try_from(account_v1).unwrap()),
         )],
         block_num_1,
     )
@@ -1788,7 +1795,7 @@ fn test_select_account_code_by_commitment_multiple_codes() {
         &[BlockAccountUpdate::new(
             account_v2.id(),
             account_v2.to_commitment(),
-            AccountUpdateDetails::Delta(AccountDelta::try_from(account_v2).unwrap()),
+            AccountUpdateDetails::Public(AccountPatch::try_from(account_v2).unwrap()),
         )],
         block_num_2,
     )
@@ -2097,14 +2104,14 @@ fn regression_1461_full_state_delta_inserts_vault_assets() {
     );
     let account_id = account.id();
 
-    // Convert to full state delta, same as genesis
-    let account_delta = AccountDelta::try_from(account.clone()).unwrap();
-    assert!(account_delta.is_full_state());
+    // Convert to full state patch, same as genesis
+    let account_patch = AccountPatch::try_from(account.clone()).unwrap();
+    assert!(account_patch.is_full_state());
 
     let block_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(account_delta),
+        AccountUpdateDetails::Public(account_patch),
     );
 
     queries::upsert_accounts(&mut conn, &[block_update], block_num).unwrap();
@@ -2320,12 +2327,12 @@ fn db_roundtrip_account() {
     let account_id = account.id();
     let account_commitment = account.to_commitment();
 
-    // Insert with full delta (like genesis)
-    let account_delta = AccountDelta::try_from(account.clone()).unwrap();
+    // Insert with full patch (like genesis)
+    let account_patch = AccountPatch::try_from(account.clone()).unwrap();
     let block_update = BlockAccountUpdate::new(
         account_id,
         account_commitment,
-        AccountUpdateDetails::Delta(account_delta),
+        AccountUpdateDetails::Public(account_patch),
     );
     queries::upsert_accounts(&mut conn, &[block_update], block_num).unwrap();
 
@@ -2543,11 +2550,11 @@ fn db_roundtrip_account_storage_with_maps() {
     let original_commitment = original_storage.to_commitment();
 
     // Insert the account (this should store header + map values separately)
-    let account_delta = AccountDelta::try_from(account.clone()).unwrap();
+    let account_patch = AccountPatch::try_from(account.clone()).unwrap();
     let block_update = BlockAccountUpdate::new(
         account_id,
         account.to_commitment(),
-        AccountUpdateDetails::Delta(account_delta),
+        AccountUpdateDetails::Public(account_patch),
     );
     queries::upsert_accounts(&mut conn, &[block_update], block_num).unwrap();
 
@@ -2915,7 +2922,7 @@ fn test_prune_history() {
 fn account_state_forest_matches_db_storage_map_roots_across_updates() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
     use miden_protocol::crypto::merkle::smt::Smt;
 
     use crate::account_state_forest::AccountStateForest;
@@ -3003,21 +3010,26 @@ fn account_state_forest_matches_db_storage_map_roots_across_updates() {
     let value3 = num_to_word(3000);
 
     // Block 1: Add storage map entries and a storage value
-    let mut map_delta_1 = StorageMapDelta::default();
-    map_delta_1.insert(key1, value1);
-    map_delta_1.insert(key2, value2);
+    let mut map_patch_1 = StorageMapPatch::default();
+    map_patch_1.insert(key1, value1);
+    map_patch_1.insert(key2, value2);
 
     let raw_1 = BTreeMap::from_iter([
-        (slot_map.clone(), StorageSlotDelta::Map(map_delta_1)),
-        (slot_value.clone(), StorageSlotDelta::Value(value1)),
+        (slot_map.clone(), StorageSlotPatch::Map(map_patch_1)),
+        (slot_value.clone(), StorageSlotPatch::Value(value1)),
     ]);
-    let storage_1 = AccountStorageDelta::from_raw(raw_1);
-    let delta_1 =
-        AccountDelta::new(account_id, storage_1.clone(), AccountVaultDelta::default(), Felt::ONE)
-            .unwrap();
+    let storage_1 = AccountStoragePatch::from_raw(raw_1);
+    let patch_1 = AccountPatch::new(
+        account_id,
+        storage_1.clone(),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
 
-    insert_account_delta(&mut conn, account_id, block1, &delta_1);
-    forest.update_account(block1, &delta_1).unwrap();
+    insert_account_patch(&mut conn, account_id, block1, &patch_1);
+    forest.update_account(block1, &patch_1).unwrap();
 
     // Verify forest matches DB for block 1
     let forest_root_1 = forest.get_storage_map_root(account_id, &slot_map, block1).unwrap();
@@ -3030,24 +3042,25 @@ fn account_state_forest_matches_db_storage_map_roots_across_updates() {
     );
 
     // Block 2: Delete storage map entry (set to EMPTY_WORD) and delete storage value
-    let mut map_delta_2 = StorageMapDelta::default();
-    map_delta_2.insert(key1, EMPTY_WORD);
+    let mut map_patch_2 = StorageMapPatch::default();
+    map_patch_2.insert(key1, EMPTY_WORD);
 
     let raw_2 = BTreeMap::from_iter([
-        (slot_map.clone(), StorageSlotDelta::Map(map_delta_2)),
-        (slot_value.clone(), StorageSlotDelta::Value(EMPTY_WORD)),
+        (slot_map.clone(), StorageSlotPatch::Map(map_patch_2)),
+        (slot_value.clone(), StorageSlotPatch::Value(EMPTY_WORD)),
     ]);
-    let storage_2 = AccountStorageDelta::from_raw(raw_2);
-    let delta_2 = AccountDelta::new(
+    let storage_2 = AccountStoragePatch::from_raw(raw_2);
+    let patch_2 = AccountPatch::new(
         account_id,
         storage_2.clone(),
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(2),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(3)),
     )
     .unwrap();
 
-    insert_account_delta(&mut conn, account_id, block2, &delta_2);
-    forest.update_account(block2, &delta_2).unwrap();
+    insert_account_patch(&mut conn, account_id, block2, &patch_2);
+    forest.update_account(block2, &patch_2).unwrap();
 
     // Verify forest matches DB for block 2
     let forest_root_2 = forest.get_storage_map_root(account_id, &slot_map, block2).unwrap();
@@ -3060,24 +3073,25 @@ fn account_state_forest_matches_db_storage_map_roots_across_updates() {
     );
 
     // Block 3: Re-add same value as block 1 and add different map entry
-    let mut map_delta_3 = StorageMapDelta::default();
-    map_delta_3.insert(key2, value3); // Update existing key
+    let mut map_patch_3 = StorageMapPatch::default();
+    map_patch_3.insert(key2, value3); // Update existing key
 
     let raw_3 = BTreeMap::from_iter([
-        (slot_map.clone(), StorageSlotDelta::Map(map_delta_3)),
-        (slot_value.clone(), StorageSlotDelta::Value(value1)), // Same as block 1
+        (slot_map.clone(), StorageSlotPatch::Map(map_patch_3)),
+        (slot_value.clone(), StorageSlotPatch::Value(value1)), // Same as block 1
     ]);
-    let storage_3 = AccountStorageDelta::from_raw(raw_3);
-    let delta_3 = AccountDelta::new(
+    let storage_3 = AccountStoragePatch::from_raw(raw_3);
+    let patch_3 = AccountPatch::new(
         account_id,
         storage_3.clone(),
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(3),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(4)),
     )
     .unwrap();
 
-    insert_account_delta(&mut conn, account_id, block3, &delta_3);
-    forest.update_account(block3, &delta_3).unwrap();
+    insert_account_patch(&mut conn, account_id, block3, &patch_3);
+    forest.update_account(block3, &patch_3).unwrap();
 
     // Verify forest matches DB for block 3
     let forest_root_3 = forest.get_storage_map_root(account_id, &slot_map, block3).unwrap();
@@ -3109,7 +3123,7 @@ fn account_state_forest_matches_db_storage_map_roots_across_updates() {
 fn account_state_forest_shared_roots_not_deleted_prematurely() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
     use miden_protocol::testing::account_id::{
         ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
         ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE_2,
@@ -3136,31 +3150,46 @@ fn account_state_forest_shared_roots_not_deleted_prematurely() {
     let value2 = num_to_word(2000);
 
     // All three accounts add identical storage maps at block 1
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(key1, value1);
-    map_delta.insert(key2, value2);
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(key1, value1);
+    map_patch.insert(key2, value2);
 
     // Setups a single slot with a map and two key-value-pairs
-    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta.clone()))]);
-    let storage = AccountStorageDelta::from_raw(raw);
+    let raw = BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch.clone()))]);
+    let storage = AccountStoragePatch::from_raw(raw);
 
     // Account 1
-    let delta1 =
-        AccountDelta::new(account1, storage.clone(), AccountVaultDelta::default(), Felt::ONE)
-            .unwrap();
-    forest.update_account(block01, &delta1).unwrap();
+    let patch1 = AccountPatch::new(
+        account1,
+        storage.clone(),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
+    forest.update_account(block01, &patch1).unwrap();
 
     // Account 2 (same storage)
-    let delta2 =
-        AccountDelta::new(account2, storage.clone(), AccountVaultDelta::default(), Felt::ONE)
-            .unwrap();
-    forest.update_account(block02, &delta2).unwrap();
+    let patch2 = AccountPatch::new(
+        account2,
+        storage.clone(),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
+    forest.update_account(block02, &patch2).unwrap();
 
     // Account 3 (same storage)
-    let delta3 =
-        AccountDelta::new(account3, storage.clone(), AccountVaultDelta::default(), Felt::ONE)
-            .unwrap();
-    forest.update_account(block02, &delta3).unwrap();
+    let patch3 = AccountPatch::new(
+        account3,
+        storage.clone(),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
+    forest.update_account(block02, &patch3).unwrap();
 
     // All three accounts should have the same root (structural sharing in SmtForest)
     let root1 = forest.get_storage_map_root(account1, &slot_name, block01).unwrap();
@@ -3175,28 +3204,30 @@ fn account_state_forest_shared_roots_not_deleted_prematurely() {
     assert_eq!(total_roots_removed, 0);
 
     // Update accounts 1,2,3
-    let mut map_delta_update = StorageMapDelta::default();
-    map_delta_update.insert(key1, num_to_word(1001)); // Slight change
+    let mut map_patch_update = StorageMapPatch::default();
+    map_patch_update.insert(key1, num_to_word(1001)); // Slight change
     let raw_update =
-        BTreeMap::from_iter([(slot_name.clone(), StorageSlotDelta::Map(map_delta_update))]);
-    let storage_update = AccountStorageDelta::from_raw(raw_update);
-    let delta2_update = AccountDelta::new(
+        BTreeMap::from_iter([(slot_name.clone(), StorageSlotPatch::Map(map_patch_update))]);
+    let storage_update = AccountStoragePatch::from_raw(raw_update);
+    let patch2_update = AccountPatch::new(
         account2,
         storage_update.clone(),
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(2),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(3)),
     )
     .unwrap();
-    forest.update_account(block51, &delta2_update).unwrap();
+    forest.update_account(block51, &patch2_update).unwrap();
 
-    let delta3_update = AccountDelta::new(
+    let patch3_update = AccountPatch::new(
         account3,
         storage_update.clone(),
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(2),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(3)),
     )
     .unwrap();
-    forest.update_account(block52, &delta3_update).unwrap();
+    forest.update_account(block52, &patch3_update).unwrap();
 
     // Prune at block 52
     let total_roots_removed = forest.prune(block52);
@@ -3206,14 +3237,15 @@ fn account_state_forest_shared_roots_not_deleted_prematurely() {
     let account1_root_after_prune = forest.get_storage_map_root(account1, &slot_name, block01);
     assert!(account1_root_after_prune.is_some());
 
-    let delta1_update = AccountDelta::new(
+    let patch1_update = AccountPatch::new(
         account1,
         storage_update,
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(2),
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(3)),
     )
     .unwrap();
-    forest.update_account(block53, &delta1_update).unwrap();
+    forest.update_account(block53, &patch1_update).unwrap();
 
     // Prune at block 53
     let total_roots_removed = forest.prune(block53);
@@ -3230,7 +3262,7 @@ fn account_state_forest_shared_roots_not_deleted_prematurely() {
 fn account_state_forest_retains_latest_after_100_blocks_and_pruning() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     use crate::account_state_forest::{AccountStateForest, HISTORICAL_BLOCK_RETENTION};
 
@@ -3249,19 +3281,25 @@ fn account_state_forest_retains_latest_after_100_blocks_and_pruning() {
     let block_1 = BlockNumber::from(1);
 
     // Create storage map with two entries
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(key1, value1);
-    map_delta.insert(key2, value2);
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(key1, value1);
+    map_patch.insert(key2, value2);
 
-    let raw = BTreeMap::from_iter([(slot_map.clone(), StorageSlotDelta::Map(map_delta))]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
+    let raw = BTreeMap::from_iter([(slot_map.clone(), StorageSlotPatch::Map(map_patch))]);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
 
     // Create vault with one asset
     let asset = FungibleAsset::new(faucet_id, 100).unwrap();
-    let mut vault_delta = AccountVaultDelta::default();
-    vault_delta.add_asset(asset.into()).unwrap();
+    let vault_patch = AccountVaultPatch::with_assets([asset.into()]);
 
-    let delta_1 = AccountDelta::new(account_id, storage_delta, vault_delta, Felt::ONE).unwrap();
+    let delta_1 = AccountPatch::new(
+        account_id,
+        storage_patch,
+        vault_patch,
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
 
     forest.update_account(block_1, &delta_1).unwrap();
 
@@ -3299,19 +3337,23 @@ fn account_state_forest_retains_latest_after_100_blocks_and_pruning() {
 
     // Update with new values
     let value1_new = num_to_word(3000);
-    let mut map_delta_51 = StorageMapDelta::default();
-    map_delta_51.insert(key1, value1_new);
+    let mut map_patch_51 = StorageMapPatch::default();
+    map_patch_51.insert(key1, value1_new);
 
-    let raw_51 = BTreeMap::from_iter([(slot_map.clone(), StorageSlotDelta::Map(map_delta_51))]);
-    let storage_delta_51 = AccountStorageDelta::from_raw(raw_51);
+    let raw_51 = BTreeMap::from_iter([(slot_map.clone(), StorageSlotPatch::Map(map_patch_51))]);
+    let storage_patch_51 = AccountStoragePatch::from_raw(raw_51);
 
     let asset_51 = FungibleAsset::new(faucet_id, 200).unwrap();
-    let mut vault_delta_51 = AccountVaultDelta::default();
-    vault_delta_51.add_asset(asset_51.into()).unwrap();
+    let vault_patch_51 = AccountVaultPatch::with_assets([asset_51.into()]);
 
-    let delta_51 =
-        AccountDelta::new(account_id, storage_delta_51, vault_delta_51, Felt::new_unchecked(51))
-            .unwrap();
+    let delta_51 = AccountPatch::new(
+        account_id,
+        storage_patch_51,
+        vault_patch_51,
+        None,
+        Some(Felt::new_unchecked(51)),
+    )
+    .unwrap();
 
     forest.update_account(block_51, &delta_51).unwrap();
 
@@ -3345,12 +3387,16 @@ fn account_state_forest_preserves_most_recent_vault_only() {
     // Block 1: Create vault with asset
     let block_1 = BlockNumber::from(1);
     let asset = FungibleAsset::new(faucet_id, 500).unwrap();
-    let mut vault_delta = AccountVaultDelta::default();
-    vault_delta.add_asset(asset.into()).unwrap();
+    let vault_patch = AccountVaultPatch::with_assets([asset.into()]);
 
-    let delta_1 =
-        AccountDelta::new(account_id, AccountStorageDelta::default(), vault_delta, Felt::ONE)
-            .unwrap();
+    let delta_1 = AccountPatch::new(
+        account_id,
+        AccountStoragePatch::default(),
+        vault_patch,
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
 
     forest.update_account(block_1, &delta_1).unwrap();
 
@@ -3473,7 +3519,7 @@ fn db_roundtrip_transactions_filters_missing_output_note_sync_records() {
 fn account_state_forest_preserves_most_recent_storage_map_only() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     use crate::account_state_forest::AccountStateForest;
 
@@ -3486,15 +3532,20 @@ fn account_state_forest_preserves_most_recent_storage_map_only() {
 
     // Block 1: Create storage map
     let block_1 = BlockNumber::from(1);
-    let mut map_delta = StorageMapDelta::default();
-    map_delta.insert(key1, value1);
+    let mut map_patch = StorageMapPatch::default();
+    map_patch.insert(key1, value1);
 
-    let raw = BTreeMap::from_iter([(slot_map.clone(), StorageSlotDelta::Map(map_delta))]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
+    let raw = BTreeMap::from_iter([(slot_map.clone(), StorageSlotPatch::Map(map_patch))]);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
 
-    let delta_1 =
-        AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), Felt::ONE)
-            .unwrap();
+    let delta_1 = AccountPatch::new(
+        account_id,
+        storage_patch,
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
 
     forest.update_account(block_1, &delta_1).unwrap();
 
@@ -3527,7 +3578,7 @@ fn account_state_forest_preserves_most_recent_storage_map_only() {
 fn account_state_forest_preserves_most_recent_storage_value_slot() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::StorageSlotDelta;
+    use miden_protocol::account::StorageSlotPatch;
 
     use crate::account_state_forest::AccountStateForest;
 
@@ -3540,12 +3591,17 @@ fn account_state_forest_preserves_most_recent_storage_value_slot() {
     // Block 1: Create storage value slot
     let block_1 = BlockNumber::from(1);
 
-    let raw = BTreeMap::from_iter([(slot_value.clone(), StorageSlotDelta::Value(value1))]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
+    let raw = BTreeMap::from_iter([(slot_value.clone(), StorageSlotPatch::Value(value1))]);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
 
-    let delta_1 =
-        AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), Felt::ONE)
-            .unwrap();
+    let delta_1 = AccountPatch::new(
+        account_id,
+        storage_patch,
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
 
     forest.update_account(block_1, &delta_1).unwrap();
 
@@ -3578,7 +3634,7 @@ fn account_state_forest_preserves_most_recent_storage_value_slot() {
 fn account_state_forest_preserves_mixed_slots_independently() {
     use std::collections::BTreeMap;
 
-    use miden_protocol::account::delta::{StorageMapDelta, StorageSlotDelta};
+    use miden_protocol::account::{StorageMapPatch, StorageSlotPatch};
 
     use crate::account_state_forest::AccountStateForest;
 
@@ -3598,23 +3654,29 @@ fn account_state_forest_preserves_mixed_slots_independently() {
     let block_1 = BlockNumber::from(1);
 
     let asset = FungibleAsset::new(faucet_id, 100).unwrap();
-    let mut vault_delta = AccountVaultDelta::default();
-    vault_delta.add_asset(asset.into()).unwrap();
+    let vault_patch = AccountVaultPatch::with_assets([asset.into()]);
 
-    let mut map_delta_a = StorageMapDelta::default();
-    map_delta_a.insert(key1, value1);
+    let mut map_patch_a = StorageMapPatch::default();
+    map_patch_a.insert(key1, value1);
 
-    let mut map_delta_b = StorageMapDelta::default();
-    map_delta_b.insert(key1, value1);
+    let mut map_patch_b = StorageMapPatch::default();
+    map_patch_b.insert(key1, value1);
 
     let raw = BTreeMap::from_iter([
-        (slot_map_a.clone(), StorageSlotDelta::Map(map_delta_a)),
-        (slot_map_b.clone(), StorageSlotDelta::Map(map_delta_b)),
-        (slot_value.clone(), StorageSlotDelta::Value(value_slot_data)),
+        (slot_map_a.clone(), StorageSlotPatch::Map(map_patch_a)),
+        (slot_map_b.clone(), StorageSlotPatch::Map(map_patch_b)),
+        (slot_value.clone(), StorageSlotPatch::Value(value_slot_data)),
     ]);
-    let storage_delta = AccountStorageDelta::from_raw(raw);
+    let storage_patch = AccountStoragePatch::from_raw(raw);
 
-    let delta_1 = AccountDelta::new(account_id, storage_delta, vault_delta, Felt::ONE).unwrap();
+    let delta_1 = AccountPatch::new(
+        account_id,
+        storage_patch,
+        vault_patch,
+        None,
+        Some(Felt::new_unchecked(2)),
+    )
+    .unwrap();
 
     forest.update_account(block_1, &delta_1).unwrap();
 
@@ -3626,18 +3688,19 @@ fn account_state_forest_preserves_mixed_slots_independently() {
     let block_51 = BlockNumber::from(51);
     let value2 = num_to_word(2000);
 
-    let mut map_delta_a_update = StorageMapDelta::default();
-    map_delta_a_update.insert(key1, value2);
+    let mut map_patch_a_update = StorageMapPatch::default();
+    map_patch_a_update.insert(key1, value2);
 
     let raw_51 =
-        BTreeMap::from_iter([(slot_map_a.clone(), StorageSlotDelta::Map(map_delta_a_update))]);
-    let storage_delta_51 = AccountStorageDelta::from_raw(raw_51);
+        BTreeMap::from_iter([(slot_map_a.clone(), StorageSlotPatch::Map(map_patch_a_update))]);
+    let storage_patch_51 = AccountStoragePatch::from_raw(raw_51);
 
-    let delta_51 = AccountDelta::new(
+    let delta_51 = AccountPatch::new(
         account_id,
-        storage_delta_51,
-        AccountVaultDelta::default(),
-        Felt::new_unchecked(51),
+        storage_patch_51,
+        AccountVaultPatch::default(),
+        None,
+        Some(Felt::new_unchecked(51)),
     )
     .unwrap();
 

--- a/crates/store/src/genesis/config/errors.rs
+++ b/crates/store/src/genesis/config/errors.rs
@@ -4,8 +4,6 @@ use miden_protocol::account::AccountId;
 use miden_protocol::errors::{AccountDeltaError, AccountError, AssetError, TokenSymbolError};
 use miden_protocol::utils::serde::DeserializationError;
 use miden_standards::account::faucets::FungibleFaucetError;
-use miden_standards::account::policies::TokenPolicyManagerError;
-use miden_standards::account::wallets::BasicWalletError;
 
 use crate::genesis::config::TokenSymbolStr;
 
@@ -41,8 +39,6 @@ pub enum GenesisConfigError {
     },
     #[error("failed to create fungible faucet account")]
     FungibleFaucet(#[from] FungibleFaucetError),
-    #[error("failed to create basic wallet account")]
-    BasicWallet(#[from] BasicWalletError),
     #[error(r#"incompatible combination of `max_supply` ({max_supply})" and `decimals` ({decimals}) exceeding the allowed value range of an `u64`"#)]
     OutOfRange { max_supply: u64, decimals: u8 },
     #[error("Found duplicate faucet definition for token symbol '{symbol}'")]
@@ -67,6 +63,4 @@ pub enum GenesisConfigError {
     InvalidSecretKey(#[from] DeserializationError),
     #[error("provided signer config is not supported")]
     UnsupportedSignerConfig,
-    #[error("token policy manager error")]
-    TokenPolicyManager(#[from] TokenPolicyManagerError),
 }

--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -13,7 +13,7 @@ use miden_protocol::account::{
     AccountDelta,
     AccountFile,
     AccountId,
-    AccountStorageDelta,
+    AccountStoragePatch,
     AccountType,
     AccountVaultDelta,
     FungibleAssetDelta,
@@ -25,15 +25,9 @@ use miden_protocol::crypto::dsa::ecdsa_k256_keccak::PublicKey;
 use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey as RpoSecretKey;
 use miden_protocol::errors::TokenSymbolError;
 use miden_protocol::{Felt, ONE};
-use miden_standards::AuthMethod;
 use miden_standards::account::auth::AuthSingleSig;
 use miden_standards::account::faucets::{FungibleFaucet, TokenName};
-use miden_standards::account::policies::{
-    BurnPolicyConfig,
-    MintPolicyConfig,
-    PolicyRegistration,
-    TokenPolicyManager,
-};
+use miden_standards::account::policies::{BurnPolicy, MintPolicy, TokenPolicyManager};
 use miden_standards::account::wallets::create_basic_wallet;
 use rand::distr::weighted::Weight;
 use rand::{Rng, SeedableRng};
@@ -225,9 +219,8 @@ impl GenesisConfig {
 
             let mut rng = ChaCha20Rng::from_seed(rand::random());
             let secret_key = RpoSecretKey::with_rng(&mut get_random_coin(&mut rng));
-            let auth = AuthMethod::SingleSig {
-                approver: (secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2),
-            };
+            let auth =
+                AuthSingleSig::new(secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2);
             let init_seed: [u8; 32] = rng.random();
 
             let mut wallet_account = create_basic_wallet(init_seed, auth, account_type.into())?;
@@ -246,7 +239,7 @@ impl GenesisConfig {
             // therefore we need bump the nonce manually to uphold this invariant.
             let wallet_delta = AccountDelta::new(
                 wallet_account.id(),
-                AccountStorageDelta::default(),
+                AccountStoragePatch::default(),
                 AccountVaultDelta::new(
                     wallet_fungible_asset_update,
                     NonFungibleAssetDelta::default(),
@@ -275,7 +268,7 @@ impl GenesisConfig {
             // `ONE`.
             let total_issuance = faucet_issuance.get(&faucet_id).copied().unwrap_or_default();
 
-            let mut storage_delta = AccountStorageDelta::default();
+            let mut storage_delta = AccountStoragePatch::default();
 
             if total_issuance != 0 {
                 let current_faucet = FungibleFaucet::try_from(faucet_account.storage())?;
@@ -453,9 +446,10 @@ impl FungibleFaucetConfig {
             .with_auth_component(auth)
             .with_component(faucet)
             .with_components(
-                TokenPolicyManager::new()
-                    .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)?
-                    .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)?,
+                TokenPolicyManager::builder()
+                    .active_mint_policy(MintPolicy::allow_all())
+                    .active_burn_policy(BurnPolicy::allow_all())
+                    .build(),
             )
             .build()?;
 

--- a/crates/store/src/genesis/config/tests.rs
+++ b/crates/store/src/genesis/config/tests.rs
@@ -90,7 +90,7 @@ async fn genesis_accounts_have_nonce_one() -> TestResult {
 fn parsing_account_from_file() -> TestResult {
     use miden_protocol::account::auth::AuthScheme;
     use miden_protocol::account::{AccountFile, AccountType};
-    use miden_standards::AuthMethod;
+    use miden_standards::account::auth::AuthSingleSig;
     use miden_standards::account::wallets::create_basic_wallet;
     use tempfile::tempdir;
 
@@ -104,9 +104,7 @@ fn parsing_account_from_file() -> TestResult {
     let secret_key = miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey::with_rng(
         &mut miden_node_utils::crypto::get_random_coin(&mut rng),
     );
-    let auth = AuthMethod::SingleSig {
-        approver: (secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2),
-    };
+    let auth = AuthSingleSig::new(secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2);
 
     let test_account = create_basic_wallet(init_seed, auth, AccountType::Public)?;
 
@@ -147,12 +145,7 @@ fn parsing_native_faucet_from_file() -> TestResult {
     use miden_protocol::account::{AccountBuilder, AccountFile, AccountType};
     use miden_protocol::asset::AssetAmount;
     use miden_standards::account::auth::AuthSingleSig;
-    use miden_standards::account::policies::{
-        BurnPolicyConfig,
-        MintPolicyConfig,
-        PolicyRegistration,
-        TokenPolicyManager,
-    };
+    use miden_standards::account::policies::{BurnPolicy, MintPolicy, TokenPolicyManager};
     use tempfile::tempdir;
 
     // Create a temporary directory for our test files
@@ -179,9 +172,10 @@ fn parsing_native_faucet_from_file() -> TestResult {
         .with_auth_component(auth)
         .with_component(faucet)
         .with_components(
-            TokenPolicyManager::new()
-                .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)?
-                .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)?,
+            TokenPolicyManager::builder()
+                .active_mint_policy(MintPolicy::allow_all())
+                .active_burn_policy(BurnPolicy::allow_all())
+                .build(),
         )
         .build()?;
 
@@ -222,7 +216,7 @@ verification_base_fee = 0
 fn native_faucet_from_file_must_be_faucet_type() -> TestResult {
     use miden_protocol::account::auth::AuthScheme;
     use miden_protocol::account::{AccountFile, AccountType};
-    use miden_standards::AuthMethod;
+    use miden_standards::account::auth::AuthSingleSig;
     use miden_standards::account::wallets::create_basic_wallet;
     use tempfile::tempdir;
 
@@ -236,9 +230,7 @@ fn native_faucet_from_file_must_be_faucet_type() -> TestResult {
     let secret_key = miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey::with_rng(
         &mut miden_node_utils::crypto::get_random_coin(&mut rng),
     );
-    let auth = AuthMethod::SingleSig {
-        approver: (secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2),
-    };
+    let auth = AuthSingleSig::new(secret_key.public_key().into(), AuthScheme::Falcon512Poseidon2);
 
     let regular_account = create_basic_wallet(init_seed, auth, AccountType::Public)?;
 

--- a/crates/store/src/genesis/mod.rs
+++ b/crates/store/src/genesis/mod.rs
@@ -1,6 +1,5 @@
 use miden_protocol::Word;
-use miden_protocol::account::delta::AccountUpdateDetails;
-use miden_protocol::account::{Account, AccountDelta};
+use miden_protocol::account::{Account, AccountPatch, AccountUpdateDetails};
 use miden_protocol::block::account_tree::{AccountIdKey, AccountTree};
 use miden_protocol::block::{
     BlockAccountUpdate,
@@ -115,7 +114,7 @@ impl GenesisState {
                 let account_update_details = if account.id().is_private() {
                     AccountUpdateDetails::Private
                 } else {
-                    AccountUpdateDetails::Delta(AccountDelta::try_from(account.clone())?)
+                    AccountUpdateDetails::Public(AccountPatch::try_from(account.clone())?)
                 };
 
                 Ok(BlockAccountUpdate::new(

--- a/crates/store/src/state/account.rs
+++ b/crates/store/src/state/account.rs
@@ -132,6 +132,22 @@ impl State {
         })
     }
 
+    /// Returns vault details by reconstructing the vault from the database.
+    async fn reconstruct_vault_details_from_db(
+        &self,
+        account_id: AccountId,
+        block_num: BlockNumber,
+    ) -> Result<AccountVaultDetails, DatabaseError> {
+        let assets = self.db.select_account_vault_at_block(account_id, block_num).await?;
+
+        self.forest
+            .write()
+            .await
+            .cache_vault_keys(assets.iter().map(miden_protocol::asset::Asset::vault_key));
+
+        Ok(AccountVaultDetails::from_assets(assets))
+    }
+
     /// Returns storage map details by reconstructing the storage map from the database.
     async fn reconstruct_storage_map_details_from_db(
         &self,
@@ -219,18 +235,29 @@ impl State {
             None => None,
         };
 
-        // Query account state forest for vault details on commitment mismatch
+        // Query account state forest for vault details on commitment mismatch.
+        //
+        // The forest can only reconstruct the vault if all hashed vault keys are known in the
+        // reverse-key LRU cache. If any hashed key is unknown, the forest returns `None` and we
+        // fall back to reconstructing the vault details from the database.
         let vault_details = match asset_vault_commitment {
             Some(commitment) if commitment == account_header.vault_root() => {
                 AccountVaultDetails::empty()
             },
-            Some(_) => self.with_forest_read_blocking(|forest| {
-                forest.get_vault_details(account_id, block_num).map_err(|err| {
-                    DatabaseError::DataCorrupted(format!(
-                        "failed to reconstruct vault for account {account_id} at block {block_num}: {err}"
-                    ))
-                })
-            })?,
+            Some(_) => {
+                let forest_details = self.with_forest_read_blocking(|forest| {
+                    forest.get_vault_details(account_id, block_num).map_err(|err| {
+                        DatabaseError::DataCorrupted(format!(
+                            "failed to reconstruct vault for account {account_id} at block {block_num}: {err}"
+                        ))
+                    })
+                })?;
+
+                match forest_details {
+                    Some(details) => details,
+                    None => self.reconstruct_vault_details_from_db(account_id, block_num).await?,
+                }
+            },
             None => AccountVaultDetails::empty(),
         };
 

--- a/crates/store/src/state/apply_block.rs
+++ b/crates/store/src/state/apply_block.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use miden_node_proto::domain::proof_request::BlockProofRequest;
 use miden_node_utils::ErrorReport;
 use miden_protocol::Word;
-use miden_protocol::account::delta::AccountUpdateDetails;
+use miden_protocol::account::AccountUpdateDetails;
 use miden_protocol::batch::OrderedBatches;
 use miden_protocol::block::account_tree::AccountMutationSet;
 use miden_protocol::block::nullifier_tree::NullifierMutationSet;
@@ -109,12 +109,12 @@ impl State {
         // Signals the write lock has been acquired, and the transaction can be committed.
         let (inform_acquire_done, acquire_done) = oneshot::channel::<()>();
 
-        // Extract public account updates with deltas before block is moved into async task. Private
-        // accounts are filtered out since they don't expose their state changes.
-        let account_deltas =
+        // Extract public account updates with patches before block is moved into async task.
+        // Private accounts are filtered out since they don't expose their state changes.
+        let account_patches =
             Vec::from_iter(body.updated_accounts().iter().filter_map(
                 |update| match update.details() {
-                    AccountUpdateDetails::Delta(delta) => Some(delta.clone()),
+                    AccountUpdateDetails::Public(patch) => Some(patch.clone()),
                     AccountUpdateDetails::Private => None,
                 },
             ));
@@ -177,7 +177,7 @@ impl State {
         })?;
 
         self.with_forest_write_blocking(|forest| {
-            forest.apply_block_updates(block_num, account_deltas)
+            forest.apply_block_updates(block_num, account_patches)
         })?;
 
         // Push to cache and notify replica subscribers.

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -508,7 +508,7 @@ pub async fn rebuild_account_state_forest(
     db: &mut Db,
     block_num: BlockNumber,
 ) -> Result<(), StateInitializationError> {
-    use miden_protocol::account::delta::AccountDelta;
+    use miden_protocol::account::AccountPatch;
 
     let mut cursor = None;
 
@@ -528,12 +528,12 @@ pub async fn rebuild_account_state_forest(
                 .details
                 .ok_or(StateInitializationError::PublicAccountMissingDetails(account_id))?;
 
-            // Convert the full account to a full-state delta
-            let delta = AccountDelta::try_from(account).map_err(|e| {
+            // Convert the full account to a full-state patch
+            let patch = AccountPatch::try_from(account).map_err(|e| {
                 StateInitializationError::AccountToDeltaConversionFailed(e.to_string())
             })?;
 
-            forest.update_account(block_num, &delta)?;
+            forest.update_account(block_num, &patch)?;
         }
 
         cursor = page.next_cursor;


### PR DESCRIPTION
## Summary

Switch back miden protocol dependency from crates.io to github's `next` branch. Unsure if this is something to have addressed now, the main goal of the PR is to apply most recent changes of protocol as soon as possible on the miden-client.

## Changelog

Most notable change is `Delta` storages being replaced by `Patch`.

```toml
[[entry]]
scope       = "protocol"
impact      = "breaking"
description = "Updated `miden-protocol` dependencies to use the `next` branch (v0.16). Block and transaction account updates now use the absolute `AccountPatch` representation instead of the relative `AccountDelta`, and the `miden-tx-batch-prover` crate was renamed to `miden-tx-batch`."
```
