### PR TITLE
fix(store): resolve panic sites #1 and #2 from production panic audit

### DIFF
--- a/crates/store/src/db/models/queries/accounts.rs
+++ b/crates/store/src/db/models/queries/accounts.rs
@@ -1244,8 +1244,7 @@ pub(crate) fn upsert_accounts(
 
             // New account is always a full account, but also comes as an update
             AccountUpdateDetails::Delta(delta) if delta.is_full_state() => {
-                let account = Account::try_from(delta)
-                    .expect("Delta to full account always works for full state deltas");
+                let account = Account::try_from(delta)?;
                 debug_assert_eq!(account_id, account.id());
 
                 prepare_full_account_update(update, account)?

--- a/crates/store/src/state/sync_state.rs
+++ b/crates/store/src/state/sync_state.rs
@@ -41,7 +41,11 @@ impl State {
             .db
             .select_block_header_and_signature_by_block_num(block_to)
             .await?
-            .expect("block_to should exist in the database");
+            .ok_or_else(|| {
+                DatabaseError::DataCorrupted(format!(
+                    "block {block_to} should exist in the database but was not found"
+                ))
+            })?;
 
         if block_from == block_to {
             return Ok((


### PR DESCRIPTION
Fixes the two straightforward panic sites from #2266 (items 1 and 2). Items 3-5 require deeper mempool/DAG refactoring and are left for follow-up.

Related to #2266 (partial see issue for remaining items)