### PR TITLE
feat: Validator standby

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "tonic-reflection",
  "tower-http",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/bin/validator/Cargo.toml
+++ b/bin/validator/Cargo.toml
@@ -39,6 +39,7 @@ tonic                  = { default-features = true, features = ["transport"], wo
 tonic-reflection       = { workspace = true }
 tower-http             = { features = ["util"], workspace = true }
 tracing                = { workspace = true }
+url                       = { workspace = true }
 
 [build-dependencies]
 build-rs      = { workspace = true }

--- a/bin/validator/Cargo.toml
+++ b/bin/validator/Cargo.toml
@@ -39,7 +39,7 @@ tonic                  = { default-features = true, features = ["transport"], wo
 tonic-reflection       = { workspace = true }
 tower-http             = { features = ["util"], workspace = true }
 tracing                = { workspace = true }
-url                       = { workspace = true }
+url                    = { workspace = true }
 
 [build-dependencies]
 build-rs      = { workspace = true }

--- a/bin/validator/src/commands/mod.rs
+++ b/bin/validator/src/commands/mod.rs
@@ -166,8 +166,9 @@ impl ValidatorCommand {
 
                 let signer = if let Some(kms_key_id) = kms_key_id {
                     ValidatorSigner::new_kms(kms_key_id).await?
-                }else{
-                    let signing_key = SigningKey::read_from_bytes(hex::decode(validator_key)?.as_ref())?;
+                } else {
+                    let signing_key =
+                        SigningKey::read_from_bytes(hex::decode(validator_key)?.as_ref())?;
                     ValidatorSigner::new_local(signing_key)
                 };
                 start::start(

--- a/bin/validator/src/commands/mod.rs
+++ b/bin/validator/src/commands/mod.rs
@@ -11,9 +11,11 @@ use miden_node_utils::logging::OpenTelemetry;
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey;
 use miden_protocol::utils::serde::Deserializable;
 use miden_validator::{DataDirectory, ValidatorSigner};
+use url::Url;
 
 const ENV_DATA_DIRECTORY: &str = "MIDEN_VALIDATOR_DATA_DIRECTORY";
 const ENV_LISTEN: &str = "MIDEN_VALIDATOR_LISTEN";
+const ENV_STANDBY_URL: &str = "MIDEN_VALIDATOR_STANDBY_URL";
 const ENV_KEY: &str = "MIDEN_VALIDATOR_KEY";
 const ENV_KMS_KEY_ID: &str = "MIDEN_VALIDATOR_KMS_KEY_ID";
 const ENV_GENESIS_CONFIG_FILE: &str = "MIDEN_VALIDATOR_GENESIS_CONFIG_FILE";
@@ -74,6 +76,10 @@ pub enum ValidatorCommand {
         /// Socket address at which to serve the gRPC API.
         #[arg(long = "listen", env = ENV_LISTEN, value_name = "LISTEN")]
         listen: std::net::SocketAddr,
+
+        /// URL to the standby Validator instance that all requests are forwarded to.
+        #[arg(long, env = ENV_STANDBY_URL, value_name = "URL")]
+        standby_url: Option<Url>,
 
         #[command(flatten)]
         grpc_options: GrpcOptionsInternal,
@@ -148,6 +154,7 @@ impl ValidatorCommand {
             },
             Self::Start {
                 listen,
+                standby_url,
                 grpc_options,
                 validator_key,
                 data_directory,
@@ -157,28 +164,21 @@ impl ValidatorCommand {
             } => {
                 let address = listen;
 
-                if let Some(kms_key_id) = kms_key_id {
-                    let signer = ValidatorSigner::new_kms(kms_key_id).await?;
-                    start::start(
-                        address,
-                        grpc_options,
-                        signer,
-                        data_directory,
-                        sqlite_connection_pool_size,
-                    )
-                    .await
-                } else {
-                    let signer = SigningKey::read_from_bytes(hex::decode(validator_key)?.as_ref())?;
-                    let signer = ValidatorSigner::new_local(signer);
-                    start::start(
-                        address,
-                        grpc_options,
-                        signer,
-                        data_directory,
-                        sqlite_connection_pool_size,
-                    )
-                    .await
-                }
+                let signer = if let Some(kms_key_id) = kms_key_id {
+                    ValidatorSigner::new_kms(kms_key_id).await?
+                }else{
+                    let signing_key = SigningKey::read_from_bytes(hex::decode(validator_key)?.as_ref())?;
+                    ValidatorSigner::new_local(signing_key)
+                };
+                start::start(
+                    address,
+                    standby_url,
+                    grpc_options,
+                    signer,
+                    data_directory,
+                    sqlite_connection_pool_size,
+                )
+                .await
             },
         }
     }

--- a/bin/validator/src/commands/start.rs
+++ b/bin/validator/src/commands/start.rs
@@ -5,10 +5,12 @@ use std::path::PathBuf;
 use anyhow::Context;
 use miden_node_utils::clap::GrpcOptionsInternal;
 use miden_validator::{DataDirectory, ValidatorServer, ValidatorSigner};
+use url::Url;
 
 // Starts the validator component.
 pub async fn start(
     address: SocketAddr,
+    standby_validator_url: Option<Url>,
     grpc_options: GrpcOptionsInternal,
     signer: ValidatorSigner,
     data_directory: PathBuf,
@@ -18,6 +20,7 @@ pub async fn start(
         .context("failed to load validator data directory")?;
     ValidatorServer {
         address,
+        standby_validator_url,
         grpc_options,
         signer,
         data_directory,

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -1,7 +1,9 @@
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use std::time::Duration;
 
 use anyhow::Context;
+use miden_node_proto::clients::{Builder, ValidatorClient};
 use miden_node_proto::server::validator_api;
 use miden_node_proto_build::validator_api_descriptor;
 use miden_node_store::BlockStore;
@@ -12,6 +14,7 @@ use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::trace::TraceLayer;
+use url::Url;
 
 use crate::db::{
     count_signed_blocks,
@@ -34,6 +37,10 @@ use validator_service::ValidatorService;
 pub struct ValidatorServer {
     /// The address of the validator component.
     pub address: SocketAddr,
+
+    /// The URL of the standby validator.
+    pub standby_validator_url: Option<Url>,
+
     /// gRPC server options for internal services (timeouts, connection caps).
     ///
     /// If the handler takes longer than this duration, the server cancels the call.
@@ -84,6 +91,17 @@ impl ValidatorServer {
             .await
             .context("failed to bind to block producer address")?;
 
+        let standby = self.standby_validator_url.map(|url| {
+            Builder::new(url)
+                    .with_tls()
+                    .expect("trusted certs should be available")
+                    .with_timeout(Duration::from_secs(5))
+                    .without_metadata_version()
+                    .without_metadata_genesis()
+                    .with_otel_context_injection()
+                    .connect_lazy::<ValidatorClient>()
+        });
+
         let reflection_service = tonic_reflection::server::Builder::configure()
             .register_file_descriptor_set(validator_api_descriptor())
             .build_v1()
@@ -102,6 +120,7 @@ impl ValidatorServer {
                     initial_chain_tip,
                     initial_tx_count,
                     initial_block_count,
+                    standby,
                 )
                 .await
                 .context("failed to initialize validator server")?,

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -93,13 +93,13 @@ impl ValidatorServer {
 
         let standby = self.standby_validator_url.map(|url| {
             Builder::new(url)
-                    .with_tls()
-                    .expect("trusted certs should be available")
-                    .with_timeout(Duration::from_secs(5))
-                    .without_metadata_version()
-                    .without_metadata_genesis()
-                    .with_otel_context_injection()
-                    .connect_lazy::<ValidatorClient>()
+                .with_tls()
+                .expect("trusted certs should be available")
+                .with_timeout(Duration::from_secs(5))
+                .without_metadata_version()
+                .without_metadata_genesis()
+                .with_otel_context_injection()
+                .connect_lazy::<ValidatorClient>()
         });
 
         let reflection_service = tonic_reflection::server::Builder::configure()

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
 use miden_node_db::{DatabaseError, Db};
+use miden_node_proto::clients::ValidatorClient;
 use miden_node_store::BlockStore;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::{BlockHeader, BlockNumber, ProposedBlock, SignedBlock};
@@ -65,6 +66,7 @@ pub(crate) struct ValidatorService {
     signer: ValidatorSigner,
     db: Arc<Db>,
     block_store: BlockStore,
+    standby: Option<ValidatorClient>,
     /// Serializes `sign_block` requests so that concurrent calls are processed sequentially,
     /// ensuring consistent chain tip reads and preventing race conditions.
     sign_block_semaphore: Semaphore,
@@ -85,6 +87,7 @@ impl ValidatorService {
         initial_chain_tip: u32,
         initial_tx_count: u64,
         initial_block_count: u64,
+        standby: Option<ValidatorClient>,
     ) -> Result<Self, ValidatorError> {
         // The validator key is fixed at genesis and carried forward unchanged by every block, so
         // the signing key must match the chain's validator key for this validator's lifetime.
@@ -104,6 +107,7 @@ impl ValidatorService {
 
         Ok(Self {
             signer,
+            standby,
             db: db.into(),
             block_store,
             sign_block_semaphore: Semaphore::new(1),

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::atomic::Ordering;
 
 use miden_node_proto::generated as grpc;
@@ -38,47 +39,97 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
             tonic::Status::internal(format!("sign_block semaphore closed: {err}"))
         })?;
 
-        // Load the current chain tip from the database.
-        let chain_tip = self
-            .db
-            .query("load_chain_tip", load_chain_tip)
-            .await
-            .map_err(|err| {
-                tonic::Status::internal(format!("Failed to load chain tip: {}", err.as_report()))
-            })?
-            .ok_or_else(|| tonic::Status::internal("Chain tip not found in database"))?;
+        // Forward the request to the standby validator, if one is configured. The forward runs
+        // concurrently with local processing (below) so the standby's latency is hidden behind the
+        // primary's own validation work, and stays inside the semaphore so the standby observes
+        // blocks in the same order as the primary.
+        let forward = self.forward_sign_block(&proposed_block);
 
-        // Validate the block against the current chain tip.
-        let (signature, header) =
-            self.validate_block(proposed_block, chain_tip).await.map_err(|err| {
-                tonic::Status::invalid_argument(format!(
-                    "Failed to validate block: {}",
-                    err.as_report()
-                ))
-            })?;
+        // Local processing of the block, run concurrently with the standby forward.
+        let local = async move {
+            // Load the current chain tip from the database.
+            let chain_tip = self
+                .db
+                .query("load_chain_tip", load_chain_tip)
+                .await
+                .map_err(|err| {
+                    tonic::Status::internal(format!(
+                        "Failed to load chain tip: {}",
+                        err.as_report()
+                    ))
+                })?
+                .ok_or_else(|| tonic::Status::internal("Chain tip not found in database"))?;
 
-        // Capture the commitment that was signed before `header` is moved into the persistence
-        // closure, so it can be returned to the block producer for cross-checking.
-        let block_commitment = header.commitment();
+            // Validate the block against the current chain tip.
+            let (signature, header) =
+                self.validate_block(proposed_block, chain_tip).await.map_err(|err| {
+                    tonic::Status::invalid_argument(format!(
+                        "Failed to validate block: {}",
+                        err.as_report()
+                    ))
+                })?;
 
-        // Persist the validated block header.
-        let new_block_num = header.block_num().as_u32();
-        self.db
-            .transact("upsert_block_header", move |conn| upsert_block_header(conn, &header))
-            .await
-            .map_err(|err| {
-                tonic::Status::internal(format!(
-                    "Failed to persist block header: {}",
-                    err.as_report()
-                ))
-            })?;
+            // Capture the commitment that was signed before `header` is moved into the persistence
+            // closure, so it can be returned to the block producer for cross-checking.
+            let block_commitment = header.commitment();
 
-        // Update the in-memory counters after successful persistence. The block has already been
-        // backed up to the block store by `validate_block`, so it is available to subscribers by
-        // the time they observe this new tip.
-        self.committed_tip.send_replace(BlockNumber::from(new_block_num));
-        self.signed_blocks_count.fetch_add(1, Ordering::Relaxed);
+            // Persist the validated block header.
+            let new_block_num = header.block_num().as_u32();
+            self.db
+                .transact("upsert_block_header", move |conn| upsert_block_header(conn, &header))
+                .await
+                .map_err(|err| {
+                    tonic::Status::internal(format!(
+                        "Failed to persist block header: {}",
+                        err.as_report()
+                    ))
+                })?;
 
-        Ok((signature, block_commitment))
+            // Update the in-memory counters after successful persistence. The block has already
+            // been backed up to the block store by `validate_block`, so it is available to
+            // subscribers by the time they observe this new tip.
+            self.committed_tip.send_replace(BlockNumber::from(new_block_num));
+            self.signed_blocks_count.fetch_add(1, Ordering::Relaxed);
+
+            Ok::<_, tonic::Status>((signature, block_commitment))
+        };
+
+        // Both the local processing and the standby forward must succeed. The primary's own
+        // validation error takes precedence; only if it succeeds do we surface a standby failure.
+        let (result, forward) = tokio::join!(local, forward);
+        let output = result?;
+        forward?;
+        Ok(output)
+    }
+}
+
+impl ValidatorService {
+    /// Forwards a `sign_block` request to the standby validator, if one is configured.
+    ///
+    /// `use<>` keeps the future from borrowing `proposed_block`, so the caller can move the block
+    /// into local validation while the forward is in flight.
+    fn forward_sign_block(
+        &self,
+        proposed_block: &ProposedBlock,
+    ) -> impl Future<Output = tonic::Result<()>> + use<> {
+        let forward = self.standby.clone().map(|mut client| {
+            let request = grpc::blockchain::ProposedBlock {
+                proposed_block: proposed_block.to_bytes(),
+            };
+            async move {
+                client.sign_block(request).await.map(|_| ()).map_err(|err| {
+                    tonic::Status::internal(format!(
+                        "failed to forward sign_block to standby validator: {}",
+                        err.as_report()
+                    ))
+                })
+            }
+        });
+        async move {
+            match forward {
+                Some(forward) => forward.await,
+                None => Ok(()),
+            }
+        }
     }
 }

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -112,24 +112,22 @@ impl ValidatorService {
         &self,
         proposed_block: &ProposedBlock,
     ) -> impl Future<Output = tonic::Result<()>> + use<> {
-        let forward = self.standby.clone().map(|mut client| {
+        let forward = self.standby.clone().map(|client| {
             let request = grpc::blockchain::ProposedBlock {
                 proposed_block: proposed_block.to_bytes(),
             };
-            async move {
-                client.sign_block(request).await.map(|_| ()).map_err(|err| {
-                    tonic::Status::internal(format!(
-                        "failed to forward sign_block to standby validator: {}",
-                        err.as_report()
-                    ))
-                })
-            }
+            (client, request)
         });
         async move {
-            match forward {
-                Some(forward) => forward.await,
-                None => Ok(()),
-            }
+            let Some((mut client, request)) = forward else {
+                return Ok(());
+            };
+            client.sign_block(request).await.map(|_| ()).map_err(|err| {
+                tonic::Status::internal(format!(
+                    "failed to forward sign_block to standby validator: {}",
+                    err.as_report()
+                ))
+            })
         }
     }
 }

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -1,10 +1,11 @@
+use std::future::Future;
 use std::sync::atomic::Ordering;
 
 use miden_node_proto::generated as grpc;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::transaction::{ProvenTransaction, TransactionInputs};
-use miden_tx::utils::serde::Deserializable;
+use miden_tx::utils::serde::{Deserializable, Serializable};
 use tonic::Status;
 
 use super::ValidatorService;
@@ -19,22 +20,35 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
         tracing::Span::current().set_attribute("transaction.id", input.tx.id());
 
-        // Validate the transaction.
-        let tx_info = validate_transaction(input.tx, input.inputs).await.map_err(|err| {
-            Status::invalid_argument(err.as_report_context("Invalid transaction"))
-        })?;
+        // Forward the request to the standby validator, if one is configured, concurrently with
+        // local processing so the standby's latency is hidden. The standby is best-effort: failures
+        // are logged but never propagated.
+        let forward = self.forward_submit_proven_transaction(&input.tx, &input.inputs);
 
-        // Store the validated transaction.
-        let count = self
-            .db
-            .transact("insert_transaction", move |conn| insert_transaction(conn, &tx_info))
-            .await
-            .map_err(|err| {
-                Status::internal(err.as_report_context("Failed to insert transaction"))
+        let local = async move {
+            // Validate the transaction.
+            let tx_info = validate_transaction(input.tx, input.inputs).await.map_err(|err| {
+                Status::invalid_argument(err.as_report_context("Invalid transaction"))
             })?;
 
-        self.validated_transactions_count.fetch_add(count as u64, Ordering::Relaxed);
-        Ok(())
+            // Store the validated transaction.
+            let count = self
+                .db
+                .transact("insert_transaction", move |conn| insert_transaction(conn, &tx_info))
+                .await
+                .map_err(|err| {
+                    Status::internal(err.as_report_context("Failed to insert transaction"))
+                })?;
+
+            self.validated_transactions_count.fetch_add(count as u64, Ordering::Relaxed);
+            Ok::<_, Status>(())
+        };
+
+        // Both the local processing and the standby forward must succeed. The primary's own
+        // validation error takes precedence; only if it succeeds do we surface a standby failure.
+        let (result, forward) = tokio::join!(local, forward);
+        result?;
+        forward
     }
 
     fn decode(request: grpc::transaction::ProvenTransaction) -> tonic::Result<Self::Input> {
@@ -53,6 +67,40 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
 
     fn encode(output: Self::Output) -> tonic::Result<()> {
         Ok(output)
+    }
+}
+
+impl ValidatorService {
+    /// Forwards a `submit_proven_transaction` request to the standby validator, if one is
+    /// configured.
+    ///
+    /// `use<>` keeps the future from borrowing the transaction, so the caller can move it into
+    /// local validation while the forward is in flight.
+    fn forward_submit_proven_transaction(
+        &self,
+        tx: &ProvenTransaction,
+        inputs: &TransactionInputs,
+    ) -> impl Future<Output = tonic::Result<()>> + use<> {
+        let forward = self.standby.clone().map(|mut client| {
+            let request = grpc::transaction::ProvenTransaction {
+                transaction: tx.to_bytes(),
+                transaction_inputs: Some(inputs.to_bytes()),
+            };
+            async move {
+                client.submit_proven_transaction(request).await.map(|_| ()).map_err(|err| {
+                    Status::internal(format!(
+                        "failed to forward submit_proven_transaction to standby validator: {}",
+                        err.as_report()
+                    ))
+                })
+            }
+        });
+        async move {
+            match forward {
+                Some(forward) => forward.await,
+                None => Ok(()),
+            }
+        }
     }
 }
 

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -81,25 +81,23 @@ impl ValidatorService {
         tx: &ProvenTransaction,
         inputs: &TransactionInputs,
     ) -> impl Future<Output = tonic::Result<()>> + use<> {
-        let forward = self.standby.clone().map(|mut client| {
+        let forward = self.standby.clone().map(|client| {
             let request = grpc::transaction::ProvenTransaction {
                 transaction: tx.to_bytes(),
                 transaction_inputs: Some(inputs.to_bytes()),
             };
-            async move {
-                client.submit_proven_transaction(request).await.map(|_| ()).map_err(|err| {
-                    Status::internal(format!(
-                        "failed to forward submit_proven_transaction to standby validator: {}",
-                        err.as_report()
-                    ))
-                })
-            }
+            (client, request)
         });
         async move {
-            match forward {
-                Some(forward) => forward.await,
-                None => Ok(()),
-            }
+            let Some((mut client, request)) = forward else {
+                return Ok(());
+            };
+            client.submit_proven_transaction(request).await.map(|_| ()).map_err(|err| {
+                Status::internal(format!(
+                    "failed to forward submit_proven_transaction to standby validator: {}",
+                    err.as_report()
+                ))
+            })
         }
     }
 }

--- a/bin/validator/src/server/validator_service/tests.rs
+++ b/bin/validator/src/server/validator_service/tests.rs
@@ -35,7 +35,7 @@ impl TestValidator {
         let (db, block_store, genesis_header) = setup_db_with_genesis(&key).await;
 
         Self {
-            server: ValidatorService::new(signer, db, block_store, 0, 0, 0).await.unwrap(),
+            server: ValidatorService::new(signer, db, block_store, 0, 0, 0, None).await.unwrap(),
             chain: PartialBlockchain::default(),
             chain_tip: genesis_header,
         }
@@ -147,7 +147,7 @@ async fn signing_key_mismatch_rejected() {
         "test requires a signing key that differs from the genesis validator key",
     );
 
-    let result = ValidatorService::new(rogue_signer, db, block_store, 0, 0, 0).await;
+    let result = ValidatorService::new(rogue_signer, db, block_store, 0, 0, 0, None).await;
     assert!(
         matches!(result, Err(ValidatorError::ValidatorKeyMismatch { .. })),
         "expected ValidatorKeyMismatch error",


### PR DESCRIPTION
## Summary

Closes https://github.com/0xMiden/node/issues/2264.

We want to run a standby Validator which acts as a backup. The Validator flow now involves forwarding block / transaction validation requests to the standby concurrently to the processing of the request.

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "validator"
impact      = "added"
description = "Added standby validator"
```
