### PR TITLE
fix: Delete pending notes

### DIFF
--- a/bin/ntx-builder/src/builder.rs
+++ b/bin/ntx-builder/src/builder.rs
@@ -248,6 +248,21 @@ impl NetworkTransactionBuilder {
             .await
             .context("failed to apply committed block to DB")?;
 
+        // Bound persistence of notes whose target account is never created as a network account:
+        // expire any note that has stayed pending for longer than the retention window. Runs on the
+        // pinned loop connection per block; consumed notes are retained for status reporting.
+        let expired = loop_db
+            .delete_expired_pending_notes(block_num, self.config.pending_note_retention_blocks)
+            .await
+            .context("failed to expire stale pending notes")?;
+        if expired > 0 {
+            tracing::info!(
+                num_expired = expired,
+                block.number = %block_num,
+                "expired stale pending network notes",
+            );
+        }
+
         self.last_applied_block = block_num;
 
         Ok(effects)

--- a/bin/ntx-builder/src/coordinator.rs
+++ b/bin/ntx-builder/src/coordinator.rs
@@ -194,8 +194,8 @@ impl Coordinator {
 
     /// Reacts to a committed block: spawns actors for any newly-targeted network accounts whose
     /// committed state exists (deferring the rest until their creation commits), releases deferred
-    /// spawns for accounts created by this block, and wakes every active actor so it can
-    /// re-evaluate its state.
+    /// spawns for accounts created by this block, prunes deferred spawns whose notes have since
+    /// been expired, and wakes every active actor so it can re-evaluate its state.
     pub async fn handle_committed_block(
         &mut self,
         effects: &CommittedBlockEffects,
@@ -212,13 +212,44 @@ impl Coordinator {
             .iter()
             .map(AccountTargetNetworkNote::target_account_id)
             .collect();
-        for account_id in targeted {
-            self.spawn_actor_when_committed(account_id).await?;
+        for account_id in &targeted {
+            self.spawn_actor_when_committed(*account_id).await?;
         }
+
+        self.prune_pending_spawns(&targeted).await?;
 
         for handle in self.actor_registry.values() {
             handle.notify();
         }
+        Ok(())
+    }
+
+    /// Drops deferred spawns whose target no longer has a live pending note.
+    ///
+    /// A spawn is deferred when a note targets an account whose creation has not committed. If that
+    /// account is never created, the event loop eventually expires the note; Accounts targeted by the
+    /// current block are retained unconditionally since their note was just persisted.
+    async fn prune_pending_spawns(
+        &mut self,
+        targeted_this_block: &HashSet<AccountId>,
+    ) -> anyhow::Result<()> {
+        if self.pending_spawns.is_empty() {
+            return Ok(());
+        }
+
+        let live: HashSet<AccountId> = self
+            .actor_context
+            .state
+            .db
+            .accounts_with_pending_notes(self.actor_context.config.max_note_attempts)
+            .await
+            .context("failed to load accounts with pending notes for pruning")?
+            .into_iter()
+            .collect();
+
+        self.pending_spawns.retain(|account_id| {
+            targeted_this_block.contains(account_id) || live.contains(account_id)
+        });
         Ok(())
     }
 
@@ -374,6 +405,52 @@ mod tests {
         assert!(
             coordinator.pending_spawns.is_empty(),
             "a released spawn must leave the pending set",
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_committed_block_prunes_deferred_spawn_after_note_expiry() {
+        use miden_protocol::crypto::merkle::mmr::PartialMmr;
+
+        let (mut coordinator, _dir, _rx) = Coordinator::test().await;
+        let db = coordinator.actor_context.state.db.clone();
+
+        // A note in block 1 targets an account whose creation has not committed, so its spawn is
+        // deferred. Persist the note first, mirroring the event loop applying the block to the DB
+        // before handing it to the coordinator.
+        let account_id = mock_network_account_id();
+        let note = mock_single_target_note(account_id, 10);
+        let block_1 = CommittedBlockEffects {
+            header: mock_block_header(1_u32.into()),
+            network_notes: vec![note],
+            nullifiers: vec![],
+            network_account_updates: vec![],
+            account_transactions: vec![],
+        };
+        db.apply_committed_block(block_1.clone(), PartialMmr::default()).await.unwrap();
+        coordinator.handle_committed_block(&block_1).await.unwrap();
+        assert!(
+            coordinator.pending_spawns.contains(&account_id),
+            "the spawn must be deferred while the note is pending",
+        );
+
+        // The account is never created, so the event loop eventually expires the pending note.
+        let deleted = db.delete_expired_pending_notes(1000_u32.into(), 10).await.unwrap();
+        assert_eq!(deleted, 1);
+
+        // A later block with no work for the account must prune the now-noteless deferred spawn so
+        // the set cannot grow without bound.
+        let block_2 = CommittedBlockEffects {
+            header: mock_block_header(1001_u32.into()),
+            network_notes: vec![],
+            nullifiers: vec![],
+            network_account_updates: vec![],
+            account_transactions: vec![],
+        };
+        coordinator.handle_committed_block(&block_2).await.unwrap();
+        assert!(
+            coordinator.pending_spawns.is_empty(),
+            "a deferred spawn whose note has expired must be pruned",
         );
     }
 

--- a/bin/ntx-builder/src/db/migrations.rs
+++ b/bin/ntx-builder/src/db/migrations.rs
@@ -57,9 +57,10 @@ mod tests {
 
     use super::*;
 
-    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 1] = [SchemaHash::from_hex(
-        "c631b773787903a3dd5ea4df5e7374119b3f02b35bacf14d11eacd8d8500e3d9",
-    )];
+    const EXPECTED_SCHEMA_HASHES: [SchemaHash; 2] = [
+        SchemaHash::from_hex("c631b773787903a3dd5ea4df5e7374119b3f02b35bacf14d11eacd8d8500e3d9"),
+        SchemaHash::from_hex("3695b88451d84af7de1a4d490a4df6023d354623ac6777d5851d9332336ad5c2"),
+    ];
 
     #[test]
     fn migration_schema_hashes_are_stable() -> Result<()> {

--- a/bin/ntx-builder/src/db/migrations/002_note_retention.sql
+++ b/bin/ntx-builder/src/db/migrations/002_note_retention.sql
@@ -1,0 +1,16 @@
+-- Records the block in which each network note was first observed (i.e. persisted) so the event
+-- loop can expire notes that have been pending for too many blocks.
+--
+-- Without this bound, notes targeting accounts that are never created as network accounts (e.g. an
+-- attacker committing notes to arbitrary public account IDs) would accumulate forever, since rows
+-- are only ever marked consumed, never deleted.
+--
+-- Existing rows default to 0xFFFFFFFF (the maximum block number) so that notes persisted before this
+-- migration are treated as freshly received and are never age-expired; they still leave the table
+-- normally once consumed.
+ALTER TABLE notes
+    ADD COLUMN received_at_block BIGINT NOT NULL DEFAULT 0xFFFFFFFF
+    CHECK (received_at_block BETWEEN 0 AND 0xFFFFFFFF);
+
+-- Covers the age-expiry sweep (`committed_at IS NULL AND received_at_block < ?`).
+CREATE INDEX idx_notes_pending_received ON notes(received_at_block) WHERE committed_at IS NULL;

--- a/bin/ntx-builder/src/db/mod.rs
+++ b/bin/ntx-builder/src/db/mod.rs
@@ -225,6 +225,21 @@ impl Db {
             .await
     }
 
+    /// Deletes still-pending notes first observed more than `retention_blocks` blocks before
+    /// `chain_tip`, bounding persistence of notes whose target account is never created as a
+    /// network account. Returns the number of rows deleted.
+    pub async fn delete_expired_pending_notes(
+        &self,
+        chain_tip: BlockNumber,
+        retention_blocks: u32,
+    ) -> Result<usize> {
+        self.inner
+            .transact("delete_expired_pending_notes", move |conn| {
+                queries::delete_expired_pending_notes(conn, chain_tip, retention_blocks)
+            })
+            .await
+    }
+
     /// Returns the latest transaction recorded against `account_id` in a committed block, if any.
     /// An actor waiting on its submission compares this against its own transaction id to confirm
     /// landing.
@@ -360,6 +375,19 @@ impl LoopDb {
         self.conn
             .query("accounts_with_pending_notes", move |conn| {
                 queries::accounts_with_pending_notes(conn, max_attempts)
+            })
+            .await
+    }
+
+    /// Deletes pending notes older than `retention_blocks` on the pinned connection.
+    pub async fn delete_expired_pending_notes(
+        &self,
+        chain_tip: BlockNumber,
+        retention_blocks: u32,
+    ) -> Result<usize> {
+        self.conn
+            .transact("delete_expired_pending_notes", move |conn| {
+                queries::delete_expired_pending_notes(conn, chain_tip, retention_blocks)
             })
             .await
     }

--- a/bin/ntx-builder/src/db/models/queries/mod.rs
+++ b/bin/ntx-builder/src/db/models/queries/mod.rs
@@ -87,7 +87,7 @@ pub fn apply_committed_block(
         }
     }
 
-    insert_network_notes(conn, &effects.network_notes)?;
+    insert_network_notes(conn, &effects.network_notes, effects.header.block_num())?;
 
     mark_notes_consumed(conn, &effects.nullifiers, effects.header.block_num())?;
 

--- a/bin/ntx-builder/src/db/models/queries/notes.rs
+++ b/bin/ntx-builder/src/db/models/queries/notes.rs
@@ -38,6 +38,7 @@ pub struct NoteInsert {
     pub last_attempt: Option<i64>,
     pub last_error: Option<String>,
     pub committed_at: Option<i64>,
+    pub received_at_block: i64,
 }
 
 /// Row returned by `get_note_status()`.
@@ -58,10 +59,15 @@ pub struct NoteStatusRow {
 /// Inserts network notes from a committed block. Uses `INSERT OR IGNORE` so re-applying the same
 /// block (e.g. on a redelivery from the subscription stream) is a no-op rather than a constraint
 /// violation.
+///
+/// `block_num` is the block in which the notes were observed; it is recorded as `received_at_block`
+/// so the event loop can age-expire notes that stay pending for too many blocks.
 pub fn insert_network_notes(
     conn: &mut SqliteConnection,
     notes: &[AccountTargetNetworkNote],
+    block_num: BlockNumber,
 ) -> Result<(), DatabaseError> {
+    let received_at_block = conversions::block_num_to_i64(block_num);
     for note in notes {
         let row = NoteInsert {
             nullifier: conversions::nullifier_to_bytes(&note.as_note().nullifier()),
@@ -72,10 +78,48 @@ pub fn insert_network_notes(
             last_attempt: None,
             last_error: None,
             committed_at: None,
+            received_at_block,
         };
         diesel::insert_or_ignore_into(schema::notes::table).values(&row).execute(conn)?;
     }
     Ok(())
+}
+
+/// Deletes still-pending notes that were first observed more than `retention_blocks` blocks before
+/// `chain_tip`.
+///
+/// The ntx-builder persists every network note from a committed block, including notes targeting
+/// accounts it does not (yet) track. Notes whose target account is never created as a network
+/// account can never be consumed, so without this sweep they would accumulate forever. Notes that
+/// have already been consumed (`committed_at` set) are retained for `GetNetworkNoteStatus` lifecycle
+/// reporting and are never touched here.
+///
+/// Returns the number of rows deleted.
+///
+/// # Raw SQL
+///
+/// ```sql
+/// DELETE FROM notes
+/// WHERE committed_at IS NULL AND received_at_block < ?1
+/// ```
+pub fn delete_expired_pending_notes(
+    conn: &mut SqliteConnection,
+    chain_tip: BlockNumber,
+    retention_blocks: u32,
+) -> Result<usize, DatabaseError> {
+    // Saturating: until the chain advances past the retention window there is nothing old enough to
+    // expire, so the cutoff is clamped at 0 (notes received at block 0 are not `< 0`).
+    let cutoff = chain_tip.as_u32().saturating_sub(retention_blocks);
+    let cutoff = conversions::block_num_to_i64(BlockNumber::from(cutoff));
+
+    let deleted = diesel::delete(
+        schema::notes::table
+            .filter(schema::notes::committed_at.is_null())
+            .filter(schema::notes::received_at_block.lt(cutoff)),
+    )
+    .execute(conn)?;
+
+    Ok(deleted)
 }
 
 /// Marks notes as consumed by setting `committed_at` to the block number whose committed body

--- a/bin/ntx-builder/src/db/models/queries/tests.rs
+++ b/bin/ntx-builder/src/db/models/queries/tests.rs
@@ -57,9 +57,9 @@ fn insert_network_notes_is_idempotent() {
     let account_id = mock_network_account_id();
     let note = mock_single_target_note(account_id, 7);
 
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
     // Re-applying the same block (e.g. on a subscription redelivery) must not error or duplicate.
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
 
     assert_eq!(count_notes(conn), 1);
 }
@@ -71,7 +71,7 @@ fn mark_notes_consumed_keeps_rows_and_sets_committed_at() {
     let note_a = mock_single_target_note(account_id, 1);
     let note_b = mock_single_target_note(account_id, 2);
 
-    insert_network_notes(conn, &[note_a.clone(), note_b.clone()]).unwrap();
+    insert_network_notes(conn, &[note_a.clone(), note_b.clone()], BlockNumber::from(1u32)).unwrap();
     assert_eq!(count_notes(conn), 2);
 
     let consumed_at = BlockNumber::from(42);
@@ -98,7 +98,7 @@ fn mark_notes_consumed_is_noop_when_unknown() {
     let (conn, _dir) = &mut test_conn();
     let account_id = mock_network_account_id();
     let note = mock_single_target_note(account_id, 3);
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
 
     // A nullifier we never inserted should not affect existing rows.
     let phantom = mock_single_target_note(account_id, 99).as_note().nullifier();
@@ -117,7 +117,7 @@ fn available_notes_excludes_consumed_notes() {
     let (conn, _dir) = &mut test_conn();
     let account_id = mock_network_account_id();
     let note = mock_single_target_note(account_id, 21);
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
 
     assert_eq!(available_notes(conn, account_id, BlockNumber::from(1), 30).unwrap().len(), 1);
 
@@ -138,7 +138,7 @@ fn available_notes_returns_unconsumed_under_attempt_cap() {
     let (conn, _dir) = &mut test_conn();
     let account_id = mock_network_account_id();
     let note = mock_single_target_note(account_id, 11);
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
 
     let available = available_notes(conn, account_id, BlockNumber::from(1), 30).unwrap();
     assert_eq!(available.len(), 1);
@@ -149,7 +149,7 @@ fn available_notes_excludes_attempts_at_cap() {
     let (conn, _dir) = &mut test_conn();
     let account_id = mock_network_account_id();
     let note = mock_single_target_note(account_id, 13);
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
 
     // Push attempt_count up to the cap.
     let nullifier = note.as_note().nullifier();
@@ -159,6 +159,72 @@ fn available_notes_excludes_attempts_at_cap() {
 
     let available = available_notes(conn, account_id, BlockNumber::from(1000), 30).unwrap();
     assert!(available.is_empty(), "notes at the attempt cap should not be available");
+}
+
+// PENDING NOTE EXPIRY
+// ================================================================================================
+
+#[test]
+fn delete_expired_pending_notes_removes_old_keeps_recent() {
+    let (conn, _dir) = &mut test_conn();
+    let account_id = mock_network_account_id();
+
+    // An old note (received long ago) and a recent one for the same account.
+    let old_note = mock_single_target_note(account_id, 1);
+    let recent_note = mock_single_target_note(account_id, 2);
+    insert_network_notes(conn, std::slice::from_ref(&old_note), BlockNumber::from(1u32)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&recent_note), BlockNumber::from(100u32))
+        .unwrap();
+    assert_eq!(count_notes(conn), 2);
+
+    // Tip 100, retention 50 → cutoff block 50. Only the note received at block 1 is older.
+    let deleted = delete_expired_pending_notes(conn, BlockNumber::from(100u32), 50).unwrap();
+    assert_eq!(deleted, 1);
+
+    assert!(
+        get_note_status(conn, &crate::db::models::conv::note_id_to_bytes(&old_note.as_note().id()))
+            .unwrap()
+            .is_none(),
+        "the stale pending note should be deleted",
+    );
+    assert!(
+        get_note_status(
+            conn,
+            &crate::db::models::conv::note_id_to_bytes(&recent_note.as_note().id())
+        )
+        .unwrap()
+        .is_some(),
+        "the recent pending note should be retained",
+    );
+}
+
+#[test]
+fn delete_expired_pending_notes_keeps_consumed_notes() {
+    let (conn, _dir) = &mut test_conn();
+    let account_id = mock_network_account_id();
+
+    // An old note that has since been consumed must be retained for status reporting even though it
+    // is well past the retention window.
+    let note = mock_single_target_note(account_id, 1);
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
+    mark_notes_consumed(conn, &[note.as_note().nullifier()], BlockNumber::from(5)).unwrap();
+
+    let deleted = delete_expired_pending_notes(conn, BlockNumber::from(1000u32), 10).unwrap();
+    assert_eq!(deleted, 0, "consumed notes are exempt from age expiry");
+    assert_eq!(count_notes(conn), 1);
+}
+
+#[test]
+fn delete_expired_pending_notes_is_noop_before_window_elapses() {
+    let (conn, _dir) = &mut test_conn();
+    let account_id = mock_network_account_id();
+    let note = mock_single_target_note(account_id, 1);
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
+
+    // Tip below the retention window: cutoff saturates to 0, so nothing is old enough yet.
+    let deleted = delete_expired_pending_notes(conn, BlockNumber::from(5u32), 50).unwrap();
+    assert_eq!(deleted, 0);
+    assert_eq!(count_notes(conn), 1);
 }
 
 // CHAIN STATE
@@ -244,6 +310,7 @@ fn accounts_with_pending_notes_distinct_and_filters_consumed_and_capped() {
     insert_network_notes(
         conn,
         &[alice_note_1.clone(), alice_note_2, bob_note.clone(), carol_note.clone()],
+        BlockNumber::from(1u32),
     )
     .unwrap();
 
@@ -347,7 +414,7 @@ fn notes_failed_increments_attempt_and_records_error() {
     let (conn, _dir) = &mut test_conn();
     let account_id = mock_network_account_id();
     let note = mock_single_target_note(account_id, 19);
-    insert_network_notes(conn, std::slice::from_ref(&note)).unwrap();
+    insert_network_notes(conn, std::slice::from_ref(&note), BlockNumber::from(1u32)).unwrap();
 
     let nullifier = note.as_note().nullifier();
     notes_failed(conn, &[(nullifier, test_note_error("nope"))], BlockNumber::from(5)).unwrap();

--- a/bin/ntx-builder/src/db/schema.rs
+++ b/bin/ntx-builder/src/db/schema.rs
@@ -35,6 +35,7 @@ diesel::table! {
         last_attempt -> Nullable<BigInt>,
         last_error -> Nullable<Text>,
         committed_at -> Nullable<BigInt>,
+        received_at_block -> BigInt,
     }
 }
 

--- a/bin/ntx-builder/src/lib.rs
+++ b/bin/ntx-builder/src/lib.rs
@@ -143,6 +143,14 @@ const DEFAULT_MAX_TX_CYCLES: u32 = 1 << 19;
 /// waits in `WaitForBlock` before resubmitting. Must be within the kernel's `1..=u16::MAX` range.
 const DEFAULT_TX_EXPIRATION_DELTA: NonZeroU16 = NonZeroU16::new(30).unwrap();
 
+/// Default number of blocks a network note may stay pending before it is expired and deleted.
+///
+/// The ntx-builder persists every network note from a committed block, including notes targeting
+/// accounts it does not track. Notes whose target is never created as a network account can never be
+/// consumed, so they are deleted once they have been pending for this many blocks. Sized to comfortably
+/// exceed both the time a legitimate target takes to be created and the per-note retry budget.
+const DEFAULT_PENDING_NOTE_RETENTION_BLOCKS: u32 = 100_000;
+
 // CONFIGURATION
 // =================================================================================================
 
@@ -203,6 +211,10 @@ pub struct NtxBuilderConfig {
     /// within `1..=u16::MAX` (enforced by the transaction kernel).
     pub tx_expiration_delta: NonZeroU16,
 
+    /// Number of blocks a network note may stay pending (unconsumed) before the event loop deletes
+    /// it. Bounds persistence of notes whose target account is never created as a network account.
+    pub pending_note_retention_blocks: u32,
+
     /// Initial sleep applied between per-request retries on transient infrastructure failures (e.g.
     /// prover unreachable, RPC crash, transport error, RPC gRPC hiccup). Doubles on each retry up
     /// to [`Self::request_backoff_max`]. Per-note `attempt_count` is *not* advanced while retries
@@ -235,6 +247,7 @@ impl NtxBuilderConfig {
             max_account_crashes: DEFAULT_MAX_ACCOUNT_CRASHES,
             max_cycles: DEFAULT_MAX_TX_CYCLES,
             tx_expiration_delta: DEFAULT_TX_EXPIRATION_DELTA,
+            pending_note_retention_blocks: DEFAULT_PENDING_NOTE_RETENTION_BLOCKS,
             request_backoff_initial: DEFAULT_REQUEST_BACKOFF_INITIAL,
             request_backoff_max: DEFAULT_REQUEST_BACKOFF_MAX,
             database_filepath,
@@ -329,6 +342,13 @@ impl NtxBuilderConfig {
     #[must_use]
     pub fn with_tx_expiration_delta(mut self, delta: NonZeroU16) -> Self {
         self.tx_expiration_delta = delta;
+        self
+    }
+
+    /// Sets the number of blocks a pending network note is retained before being expired.
+    #[must_use]
+    pub fn with_pending_note_retention_blocks(mut self, blocks: u32) -> Self {
+        self.pending_note_retention_blocks = blocks;
         self
     }
 


### PR DESCRIPTION
## Problem

`apply_committed_block` → `insert_network_notes` persists every extracted `AccountTargetNetworkNote` which has the following problems:
- unbounded `notes` rows (kept forever if target account is never created), and
- unbounded growth of the coordinator's `pending_spawns` set , since `spawn_actor_when_committed` defers every untracked target indefinitely and only releases it if that exact ID is later created as a network account.

## Solution

Age-expire pending network notes (new `received_at_block` column + per-block sweep in the event loop) so notes targeting accounts that are never created as network accounts can't accumulate unbounded.

Prune the coordinator's matching `pending_spawns` entries the same way. Retention is configurable via `pending_note_retention_blocks`.
<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```

