### PR TITLE
fix: select_transactions_records edge case

### DIFF
--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -305,9 +305,7 @@ fn database_error_to_status(err: &DatabaseError) -> Status {
         DatabaseError::AccountNotFoundInDb(_)
         | DatabaseError::AccountsNotFoundInDb(_)
         | DatabaseError::AccountNotPublic(_) => Status::not_found(message),
-        DatabaseError::TransactionPageExceedsPayloadLimit { .. } => {
-            Status::resource_exhausted(message)
-        },
+        DatabaseError::TransactionPageExceedsPayloadLimit { .. } => Status::out_of_range(message),
         _ => Status::internal(message),
     }
 }

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -305,6 +305,9 @@ fn database_error_to_status(err: &DatabaseError) -> Status {
         DatabaseError::AccountNotFoundInDb(_)
         | DatabaseError::AccountsNotFoundInDb(_)
         | DatabaseError::AccountNotPublic(_) => Status::not_found(message),
+        DatabaseError::TransactionPageExceedsPayloadLimit { .. } => {
+            Status::resource_exhausted(message)
+        },
         _ => Status::internal(message),
     }
 }

--- a/crates/store/src/db/models/queries/transactions.rs
+++ b/crates/store/src/db/models/queries/transactions.rs
@@ -305,9 +305,8 @@ pub fn select_transactions_records(
         });
     }
 
-    // SAFETY: block_num came from the database and was previously validated. Subtraction is
-    // safe under the assumption that genesis block (where it could fail) does not have any
-    // transactions.
+    // SAFETY: block_num came from the database and was previously validated. Subtraction is safe
+    // under the assumption that genesis block (where it could fail) does not have any transactions.
     let last_included_block = BlockNumber::from_raw_sql(truncation_block.saturating_sub(1))?;
     Ok((last_included_block, with_output_note_proofs(conn, complete_transactions)?))
 }

--- a/crates/store/src/db/models/queries/transactions.rs
+++ b/crates/store/src/db/models/queries/transactions.rs
@@ -225,6 +225,10 @@ pub fn select_transactions_records(
     let mut total_size = 0i64;
     let mut last_block_num: Option<i64> = None;
     let mut last_transaction_id: Option<Vec<u8>> = None;
+    // Set to the block number of the first transaction that did not fit within the payload cap.
+    // This is the explicit "we truncated" signal; the accumulated byte total cannot be used as a
+    // proxy, since a transaction can fail to fit while `total_size` is still below the cap.
+    let mut truncated_at_block: Option<i64> = None;
 
     loop {
         let mut query =
@@ -265,40 +269,47 @@ pub fn select_transactions_records(
                 all_transactions.push(tx);
                 added_from_chunk += 1;
             } else {
-                // Can't fit this transaction, stop here
+                // This transaction does not fit, so the response is truncated at its block.
+                truncated_at_block = Some(tx.block_num);
                 break;
             }
         }
 
-        // Break if chunk incomplete (size limit hit or data exhausted)
-        if added_from_chunk < NUM_TXS_PER_CHUNK {
+        // Break if we truncated due to the payload cap, or the chunk was incomplete (i.e. the
+        // matching transactions are exhausted).
+        if truncated_at_block.is_some() || added_from_chunk < NUM_TXS_PER_CHUNK {
             break;
         }
     }
 
-    // Ensure block consistency: remove the last block if it's incomplete (we may have stopped
-    // loading mid-block due to size constraints)
-    if total_size >= max_payload_bytes {
-        // SAFETY: We're guaranteed to have at least one transaction since total_size > 0
-        let last_block_num = last_block_num.expect(
-            "guaranteed to have processed at least one transaction when size limit is reached",
-        );
-        let filtered_transactions = with_output_note_proofs(
-            conn,
-            all_transactions
-                .into_iter()
-                .take_while(|row| row.block_num != last_block_num)
-                .collect(),
-        )?;
+    let Some(truncation_block) = truncated_at_block else {
+        // Every matching transaction in the range fit within the payload cap.
+        return Ok((*block_range.end(), with_output_note_proofs(conn, all_transactions)?));
+    };
 
-        // SAFETY: block_num came from the database and was previously validated. Subtraction is
-        // safe under the assumption that genesis block (where it could fail) does not have any
-        // transactions.
-        let last_included_block = BlockNumber::from_raw_sql(last_block_num.saturating_sub(1))?;
-        Ok((last_included_block, filtered_transactions))
-    } else {
-        Ok((*block_range.end(), with_output_note_proofs(conn, all_transactions)?))
+    // We stopped within `truncation_block`, so that block may be partial. Block-based pagination
+    // can only report fully-included blocks, so drop every transaction at or after the truncation
+    // block and report the previous block as the cursor. Transactions are ordered ascending by
+    // block number, so this keeps exactly the blocks that were loaded in full.
+    let complete_transactions: Vec<_> = all_transactions
+        .into_iter()
+        .take_while(|row| row.block_num < truncation_block)
+        .collect();
+
+    if complete_transactions.is_empty() {
+        // A single block's transactions exceed the payload cap. Reporting `truncation_block - 1`
+        // here would tell the client to resume from `truncation_block`, which can never fit, so
+        // pagination would loop forever. Surface the condition instead of silently looping.
+        return Err(DatabaseError::TransactionPageExceedsPayloadLimit {
+            block_num: BlockNumber::from_raw_sql(truncation_block)?,
+        });
     }
+
+    // SAFETY: block_num came from the database and was previously validated. Subtraction is
+    // safe under the assumption that genesis block (where it could fail) does not have any
+    // transactions.
+    let last_included_block = BlockNumber::from_raw_sql(truncation_block.saturating_sub(1))?;
+    Ok((last_included_block, with_output_note_proofs(conn, complete_transactions)?))
 }
 
 fn with_output_note_proofs(

--- a/crates/store/src/db/models/queries/transactions.rs
+++ b/crates/store/src/db/models/queries/transactions.rs
@@ -221,13 +221,13 @@ pub fn select_transactions_records(
 
     // Read transactions in chunks to prevent loading excessive data and to stop as soon as we
     // approach the size limit
-    let mut all_transactions = Vec::new();
+    let mut transactions = Vec::new();
     let mut total_size = 0i64;
     let mut last_block_num: Option<i64> = None;
     let mut last_transaction_id: Option<Vec<u8>> = None;
-    // Set to the block number of the first transaction that did not fit within the payload cap.
-    // This is the explicit "we truncated" signal; the accumulated byte total cannot be used as a
-    // proxy, since a transaction can fail to fit while `total_size` is still below the cap.
+    // Track the block number of the first transaction that did not fit within the payload cap. This
+    // is the explicit "we truncated" signal; the accumulated byte total cannot be used as a proxy,
+    // since a transaction can fail to fit while `total_size` is still below the cap.
     let mut truncated_at_block: Option<i64> = None;
 
     loop {
@@ -266,7 +266,7 @@ pub fn select_transactions_records(
                 total_size += tx.size_in_bytes;
                 last_block_num = Some(tx.block_num);
                 last_transaction_id = Some(tx.transaction_id.clone());
-                all_transactions.push(tx);
+                transactions.push(tx);
                 added_from_chunk += 1;
             } else {
                 // This transaction does not fit, so the response is truncated at its block.
@@ -284,19 +284,19 @@ pub fn select_transactions_records(
 
     let Some(truncation_block) = truncated_at_block else {
         // Every matching transaction in the range fit within the payload cap.
-        return Ok((*block_range.end(), with_output_note_proofs(conn, all_transactions)?));
+        return Ok((*block_range.end(), with_output_note_proofs(conn, transactions)?));
     };
 
     // We stopped within `truncation_block`, so that block may be partial. Block-based pagination
-    // can only report fully-included blocks, so drop every transaction at or after the truncation
+    // can only report fully-included blocks, so drop every transaction belonging to the truncation
     // block and report the previous block as the cursor. Transactions are ordered ascending by
-    // block number, so this keeps exactly the blocks that were loaded in full.
-    let complete_transactions: Vec<_> = all_transactions
-        .into_iter()
-        .take_while(|row| row.block_num < truncation_block)
-        .collect();
+    // block number, so the truncation block's transactions form a contiguous suffix:
+    // `partition_point` locates the boundary and `truncate` drops the suffix in place, without
+    // allocating a new vector, with O(log n) complexity.
+    let complete_len = transactions.partition_point(|row| row.block_num < truncation_block);
+    transactions.truncate(complete_len);
 
-    if complete_transactions.is_empty() {
+    if transactions.is_empty() {
         // A single block's transactions exceed the payload cap. Reporting `truncation_block - 1`
         // here would tell the client to resume from `truncation_block`, which can never fit, so
         // pagination would loop forever. Surface the condition instead of silently looping.
@@ -308,7 +308,7 @@ pub fn select_transactions_records(
     // SAFETY: block_num came from the database and was previously validated. Subtraction is safe
     // under the assumption that genesis block (where it could fail) does not have any transactions.
     let last_included_block = BlockNumber::from_raw_sql(truncation_block.saturating_sub(1))?;
-    Ok((last_included_block, with_output_note_proofs(conn, complete_transactions)?))
+    Ok((last_included_block, with_output_note_proofs(conn, transactions)?))
 }
 
 fn with_output_note_proofs(

--- a/crates/store/src/db/tests.rs
+++ b/crates/store/src/db/tests.rs
@@ -1616,6 +1616,52 @@ fn mock_block_transaction(account_id: AccountId, num: u64) -> TransactionHeader 
     )
 }
 
+/// Like [`mock_block_transaction`], but emits `num_output_notes` output notes so the recorded
+/// `size_in_bytes` can be driven above or below the response payload cap in pagination tests.
+fn mock_block_transaction_with_output_notes(
+    account_id: AccountId,
+    num: u64,
+    num_output_notes: usize,
+) -> TransactionHeader {
+    let initial_state_commitment = Word::try_from([num, 0, 0, 0]).unwrap();
+    let final_account_commitment = Word::try_from([0, num, 0, 0]).unwrap();
+    let input_notes_commitment = Word::try_from([0, 0, num, 0]).unwrap();
+    let output_notes_commitment = Word::try_from([0, 0, 0, num]).unwrap();
+
+    let notes = vec![InputNoteCommitment::from(num_to_nullifier(num))];
+    let input_notes = InputNotes::new_unchecked(notes);
+
+    let output_notes: Vec<NoteHeader> = (0..num_output_notes)
+        .map(|i| {
+            NoteHeader::new(
+                NoteDetailsCommitment::from_raw(Word::try_from([num, i as u64, 0, 0]).unwrap()),
+                NoteMetadata::new(
+                    PartialNoteMetadata::new(account_id, NoteType::Public)
+                        .with_tag(NoteTag::new(num as u32)),
+                    &NoteAttachments::default(),
+                ),
+            )
+        })
+        .collect();
+
+    let fee = test_fee();
+    TransactionHeader::new_unchecked(
+        TransactionId::new(
+            initial_state_commitment,
+            final_account_commitment,
+            input_notes_commitment,
+            output_notes_commitment,
+            fee,
+        ),
+        account_id,
+        initial_state_commitment,
+        final_account_commitment,
+        input_notes,
+        output_notes,
+        fee,
+    )
+}
+
 fn insert_transactions(conn: &mut SqliteConnection) -> usize {
     let block_num = 1.into();
     create_block(conn, block_num);
@@ -3466,6 +3512,89 @@ fn db_roundtrip_transactions_filters_missing_output_note_sync_records() {
     };
 
     assert_eq!(*record, expected);
+}
+
+/// Per-output-note contribution to a transaction's recorded `size_in_bytes`, mirroring
+/// `OUTPUT_NOTE_SYNC_RECORD_SIZE_BYTES` in the query module.
+const OUTPUT_NOTE_SIZE_BYTES: usize = 700;
+
+/// When truncation stops mid-range while the accumulated payload is still below the cap, the
+/// response must report the last *complete* block as the cursor, not `block_range.end()`. Reporting
+/// the requested upper bound would tell the client the range was fully covered and silently drop
+/// every transaction after the one that did not fit.
+#[test]
+fn select_transactions_records_reports_truncation_below_payload_cap() {
+    let mut conn = create_db();
+    let bob = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
+
+    let block1 = BlockNumber::from(1);
+    let block2 = BlockNumber::from(2);
+    create_block(&mut conn, block1);
+    create_block(&mut conn, block2);
+    queries::upsert_accounts(&mut conn, &[mock_block_account_update(bob, 0)], block1).unwrap();
+    queries::upsert_accounts(&mut conn, &[mock_block_account_update(bob, 1)], block2).unwrap();
+
+    let cap = miden_node_utils::limiter::MAX_RESPONSE_PAYLOAD_BYTES;
+    // `block1` nearly fills the cap on its own, then `block2` pushes the running total past it. The
+    // running total when `block2` is rejected stays below the cap, which is exactly the case the
+    // old `total_size >= cap` check mishandled.
+    let block1_notes = (cap * 9 / 10) / OUTPUT_NOTE_SIZE_BYTES;
+    let block2_notes = (cap / 5) / OUTPUT_NOTE_SIZE_BYTES;
+
+    let tx1 = mock_block_transaction_with_output_notes(bob, 1, block1_notes);
+    let tx2 = mock_block_transaction_with_output_notes(bob, 2, block2_notes);
+    queries::insert_transactions(
+        &mut conn,
+        block1,
+        &OrderedTransactionHeaders::new_unchecked(vec![tx1.clone()]),
+    )
+    .unwrap();
+    queries::insert_transactions(
+        &mut conn,
+        block2,
+        &OrderedTransactionHeaders::new_unchecked(vec![tx2]),
+    )
+    .unwrap();
+
+    let (last_block_included, records) =
+        queries::select_transactions_records(&mut conn, &[bob], BlockNumber::GENESIS..=block2)
+            .unwrap();
+
+    assert_eq!(last_block_included, block1, "cursor must point at the last complete block");
+    assert_eq!(records.len(), 1, "only the complete block's transaction should be returned");
+    assert_eq!(records[0].header.id(), tx1.id());
+}
+
+/// When a single block's transactions exceed the payload cap, no complete block fits. Reporting
+/// `truncation_block - 1` would loop the client forever on a block that can never be returned, so
+/// the query must surface an explicit error instead.
+#[test]
+fn select_transactions_records_errors_when_single_block_exceeds_payload_cap() {
+    let mut conn = create_db();
+    let bob = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
+
+    let block1 = BlockNumber::from(1);
+    create_block(&mut conn, block1);
+    queries::upsert_accounts(&mut conn, &[mock_block_account_update(bob, 0)], block1).unwrap();
+
+    let cap = miden_node_utils::limiter::MAX_RESPONSE_PAYLOAD_BYTES;
+    let oversized_notes = cap / OUTPUT_NOTE_SIZE_BYTES + 100;
+    let tx = mock_block_transaction_with_output_notes(bob, 1, oversized_notes);
+    queries::insert_transactions(
+        &mut conn,
+        block1,
+        &OrderedTransactionHeaders::new_unchecked(vec![tx]),
+    )
+    .unwrap();
+
+    let result =
+        queries::select_transactions_records(&mut conn, &[bob], BlockNumber::GENESIS..=block1);
+
+    assert_matches!(
+        result,
+        Err(crate::errors::DatabaseError::TransactionPageExceedsPayloadLimit { block_num })
+            if block_num == block1
+    );
 }
 
 #[test]

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -71,6 +71,11 @@ pub enum DatabaseError {
     AccountNotPublic(AccountId),
     #[error("invalid block parameters: block_from ({from}) > block_to ({to})")]
     InvalidBlockRange { from: BlockNumber, to: BlockNumber },
+    #[error(
+        "transaction records for block {block_num} exceed the maximum response payload size and \
+         cannot be paginated"
+    )]
+    TransactionPageExceedsPayloadLimit { block_num: BlockNumber },
     #[error("data corrupted: {0}")]
     DataCorrupted(String),
     #[error(transparent)]

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -72,8 +72,8 @@ pub enum DatabaseError {
     #[error("invalid block parameters: block_from ({from}) > block_to ({to})")]
     InvalidBlockRange { from: BlockNumber, to: BlockNumber },
     #[error(
-        "transaction records for block {block_num} exceed the maximum response payload size and \
-         cannot be paginated"
+        "transactions for block {block_num} would exceed maximum response size, \
+         use a stricter filter to reduce the number of transactions returned"
     )]
     TransactionPageExceedsPayloadLimit { block_num: BlockNumber },
     #[error("data corrupted: {0}")]


### PR DESCRIPTION
## Summary
`select_transactions_records` paginates by payload size, but it inferred truncation from `total_size >= cap`, which missed the common case where a transaction fails to fit while the running total is still below the cap — making a partial page look complete.

The fix tracks an explicit "transaction didn't fit" signal so a truncated page reports the last complete block as the cursor, and errors when a single block exceeds the payload cap. 

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```

