### PR TITLE
feat: stdout logging

### DIFF
--- a/bin/node/src/commands/recover.rs
+++ b/bin/node/src/commands/recover.rs
@@ -15,6 +15,7 @@ use url::Url;
 
 use super::ENV_DATA_DIRECTORY;
 use super::store::StoreOptions;
+use crate::LOG_TARGET;
 
 // RECOVER
 // ================================================================================================
@@ -83,8 +84,9 @@ async fn recover_from_validator(
     let local_tip = state.chain_tip(Finality::Committed).await;
     if local_tip >= validator_tip {
         info!(
-            local.tip = local_tip.as_u32(),
-            validator.tip = validator_tip.as_u32(),
+            target: LOG_TARGET,
+            local_tip = local_tip.as_u32(),
+            validator_tip = validator_tip.as_u32(),
             "Local chain is already at the validator's chain tip; nothing to recover",
         );
         return Ok(());
@@ -92,6 +94,7 @@ async fn recover_from_validator(
 
     let block_from = local_tip.child().as_u32();
     info!(
+        target: LOG_TARGET,
         block_from,
         validator.tip = validator_tip.as_u32(),
         "Recovering blocks from validator",
@@ -109,7 +112,7 @@ async fn recover_from_validator(
             .context("failed to deserialize block from validator")?;
         let block_num = block.header().block_num();
         state.apply_block(block).await.context("failed to apply recovered block")?;
-        info!(block.number = block_num.as_u32(), "Applied recovered block");
+        info!(target: LOG_TARGET, block_number = %block_num.as_u32(), "Applied recovered block");
 
         // Stop once we reach the tip captured at the start of recovery.
         if block_num >= validator_tip {
@@ -126,6 +129,6 @@ async fn recover_from_validator(
         validator_tip.as_u32(),
     );
 
-    info!(chain_tip = final_tip.as_u32(), "Block recovery complete");
+    info!(target: LOG_TARGET, chain_tip = final_tip.as_u32(), "Block recovery complete");
     Ok(())
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -8,6 +8,8 @@ use commands::Command;
 
 mod commands;
 
+const LOG_TARGET: &str = "user::miden-node";
+
 // COMMANDS
 // ================================================================================================
 

--- a/bin/remote-prover/src/main.rs
+++ b/bin/remote-prover/src/main.rs
@@ -5,13 +5,14 @@ use tracing::info;
 mod server;
 
 const COMPONENT: &str = "miden-prover";
+const LOG_TARGET: &str = "user::miden-prover";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let server = server::Server::parse();
 
     let _otel_guard = miden_node_utils::logging::setup_tracing(server.open_telemetry())?;
-    info!(target: COMPONENT, "Tracing initialized");
+    info!(target: LOG_TARGET, "Tracing initialized");
 
     let (handle, _port) = server.spawn().await.context("failed to spawn server")?;
 

--- a/bin/remote-prover/src/server/mod.rs
+++ b/bin/remote-prover/src/server/mod.rs
@@ -14,6 +14,7 @@ use tonic_web::GrpcWebLayer;
 use tower_http::catch_panic::CatchPanicLayer;
 use tower_http::trace::TraceLayer;
 
+use crate::LOG_TARGET;
 use crate::server::service::ProverService;
 
 mod proof_kind;
@@ -66,11 +67,12 @@ impl Server {
             .port();
 
         tracing::info!(
-            server.timeout=%humantime::Duration::from(self.timeout),
-            server.capacity=self.capacity,
-            proof.kind = %self.kind,
-            server.port = port,
-            "proof server listening"
+            target: LOG_TARGET,
+            server_timeout=%humantime::Duration::from(self.timeout),
+            server_capacity=self.capacity,
+            proof_kind = %self.kind,
+            server_port = port,
+            "Proof server listening"
         );
 
         let status_service =

--- a/bin/validator/src/db/migrations.rs
+++ b/bin/validator/src/db/migrations.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use miden_node_db::DatabaseError;
 use tracing::instrument;
 
-use crate::COMPONENT;
+use crate::{COMPONENT, LOG_TARGET};
 
 include!(concat!(env!("OUT_DIR"), "/db_migrator.rs"));
 
@@ -11,7 +11,7 @@ include!(concat!(env!("OUT_DIR"), "/db_migrator.rs"));
 pub fn bootstrap_database(database_filepath: &Path) -> std::result::Result<(), DatabaseError> {
     let migrator = migrator().map_err(DatabaseError::migration)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         migration_count = migrator.schema_hashes().len(),
         "Bootstrapping database schema"
     );
@@ -24,7 +24,7 @@ pub fn bootstrap_database(database_filepath: &Path) -> std::result::Result<(), D
 pub fn migrate_database(database_filepath: &Path) -> std::result::Result<(), DatabaseError> {
     let migrator = migrator().map_err(DatabaseError::migration)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         migration_count = migrator.schema_hashes().len(),
         "Applying database migrations"
     );
@@ -37,7 +37,7 @@ pub fn migrate_database(database_filepath: &Path) -> std::result::Result<(), Dat
 pub fn verify_latest_schema(database_filepath: &Path) -> std::result::Result<(), DatabaseError> {
     let migrator = migrator().map_err(DatabaseError::migration)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         migration_count = migrator.schema_hashes().len(),
         "Verifying database schema"
     );

--- a/bin/validator/src/db/mod.rs
+++ b/bin/validator/src/db/mod.rs
@@ -14,10 +14,10 @@ use miden_protocol::transaction::TransactionId;
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use tracing::instrument;
 
-use crate::COMPONENT;
 use crate::db::migrations::{bootstrap_database, migrate_database, verify_latest_schema};
 use crate::db::models::{BlockHeaderRowInsert, ValidatedTransactionRowInsert};
 use crate::tx_validation::ValidatedTransaction;
+use crate::{COMPONENT, LOG_TARGET};
 
 /// Open a connection to the DB after verifying that it is at the latest schema version.
 #[instrument(target = COMPONENT, skip_all)]
@@ -67,7 +67,7 @@ fn open_with_pool_size(
 ) -> Result<Db, DatabaseError> {
     let db = Db::new_with_pool_size(database_filepath, connection_pool_size)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         sqlite= %database_filepath.display(),
         connection_pool_size = %connection_pool_size,
         "Connected to the database"

--- a/bin/validator/src/lib.rs
+++ b/bin/validator/src/lib.rs
@@ -13,3 +13,6 @@ pub use signers::{KmsSigner, ValidatorSigner};
 
 /// The name of the validator component.
 pub const COMPONENT: &str = "miden-validator";
+
+/// The target to use for user-visible events.
+pub const LOG_TARGET: &str = "user::miden-validator";

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -19,7 +19,7 @@ use crate::db::{
     load_chain_tip,
     load_with_pool_size,
 };
-use crate::{COMPONENT, DataDirectory, ValidatorSigner};
+use crate::{COMPONENT, DataDirectory, LOG_TARGET, ValidatorSigner};
 
 mod validator_service;
 
@@ -55,7 +55,7 @@ impl ValidatorServer {
     /// Executes in place (i.e. not spawned) and will run indefinitely until a fatal error is
     /// encountered.
     pub async fn serve(self) -> anyhow::Result<()> {
-        tracing::info!(target: COMPONENT, endpoint=?self.address, "Initializing server");
+        tracing::info!(target: LOG_TARGET, endpoint=?self.address, "Initializing server");
 
         // Initialize database connection.
         let db = load_with_pool_size(

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -19,7 +19,7 @@ use crate::db::{
     load_chain_tip,
     load_with_pool_size,
 };
-use crate::{COMPONENT, DataDirectory, LOG_TARGET, ValidatorSigner};
+use crate::{DataDirectory, LOG_TARGET, ValidatorSigner};
 
 mod validator_service;
 

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -169,7 +169,7 @@ struct BatchJob {
 impl BatchJob {
     async fn build_batch(&self) -> Result<(), BuildBatchError> {
         let Some(batch) = self.select_batch()? else {
-            tracing::info!("No transactions available.");
+            tracing::trace!("No transactions available.");
             return Ok(());
         };
 
@@ -181,7 +181,6 @@ impl BatchJob {
             .and_then(|(txs, inputs)| Self::propose_batch(txs, inputs))
             .inspect_ok(TelemetryInjectorExt::inject_telemetry)
             .and_then(|proposed| self.prove_batch(proposed))
-
             // Failure must be injected before the final pipeline stage i.e. before commit is
             // called. The system cannot handle errors after it considers the process complete
             // (which makes sense).

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -308,7 +308,7 @@ impl BlockBuilder {
 
         if num_transactions > 0 {
             let transaction_ids =
-                signed_block.body().transactions().as_slice().iter().map(|tx| tx.id());
+                signed_block.body().transactions().as_slice().iter().map(TransactionHeader::id);
             tracing::debug!(target: LOG_TARGET, transactions = %format_array(transaction_ids), "Included transactions");
         }
 

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -3,18 +3,19 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use miden_node_store::state::State;
+use miden_node_utils::formatting::format_array;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::batch::{OrderedBatches, ProvenBatch};
 use miden_protocol::block::{BlockInputs, BlockNumber, ProposedBlock, ProvenBlock, SignedBlock};
 use miden_protocol::transaction::TransactionHeader;
 use tokio::time::Duration;
-use tracing::{Span, instrument};
+use tracing::{Span, field, instrument};
 
 use crate::errors::{BuildBlockError, StoreError};
 use crate::mempool::SharedMempool;
 use crate::validator::BlockProducerValidatorClient;
-use crate::{COMPONENT, TelemetryInjectorExt};
+use crate::{COMPONENT, LOG_TARGET, TelemetryInjectorExt};
 
 // BLOCK BUILDER
 // =================================================================================================
@@ -276,7 +277,17 @@ impl BlockBuilder {
         })
     }
 
-    #[instrument(target = COMPONENT, name = "block_builder.commit_block", skip_all, err)]
+    #[instrument(
+        target = COMPONENT,
+        name = "block_builder.commit_block",
+        skip_all,
+        err,
+        fields(
+            block_num = field::Empty,
+            block_commitment = field::Empty,
+            num_transactions = field::Empty,
+        )
+    )]
     async fn commit_block(
         &self,
         mempool: &SharedMempool,
@@ -288,6 +299,18 @@ impl BlockBuilder {
             signed_block,
         } = block_commit;
         let header = signed_block.header().clone();
+        let num_transactions = signed_block.body().transactions().as_slice().len();
+
+        let span = Span::current();
+        span.record("block_num", field::display(header.block_num()));
+        span.record("block_commitment", field::display(header.commitment()));
+        span.record("num_transactions", num_transactions);
+
+        if num_transactions > 0 {
+            let transaction_ids =
+                signed_block.body().transactions().as_slice().iter().map(|tx| tx.id());
+            tracing::debug!(target: LOG_TARGET, transactions = %format_array(transaction_ids), "Included transactions");
+        }
 
         self.store
             .apply_block_with_proving_inputs(ordered_batches, block_inputs, signed_block)

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -39,6 +39,9 @@ pub use server::{
 /// The name of the block producer component.
 pub const COMPONENT: &str = "miden-block-producer";
 
+/// The tracing target used for stdout-visible events.
+pub const LOG_TARGET: &str = "user::miden-block-producer";
+
 /// The number of transactions per batch.
 pub const DEFAULT_MAX_TXS_PER_BATCH: usize = 8;
 

--- a/crates/block-producer/src/proof_scheduler.rs
+++ b/crates/block-producer/src/proof_scheduler.rs
@@ -26,11 +26,11 @@ use miden_remote_prover_client::RemoteProverClientError;
 use thiserror::Error;
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{Instrument, info, instrument};
+use tracing::{Instrument, debug, info, instrument};
 
-use crate::COMPONENT;
 use crate::block_prover::{BlockProver, ProverError};
 use crate::errors::ProofSchedulerError;
+use crate::{COMPONENT, LOG_TARGET};
 
 // CONSTANTS
 // ================================================================================================
@@ -106,7 +106,7 @@ pub(crate) async fn run(
     mut chain_tip_rx: watch::Receiver<BlockNumber>,
     max_concurrent_proofs: NonZeroUsize,
 ) -> anyhow::Result<()> {
-    info!(target: COMPONENT, "Proof scheduler started");
+    info!(target: LOG_TARGET, "Proof scheduler started");
 
     // In-flight proving tasks.
     let mut proving_tasks = ProofTaskJoinSet::new();
@@ -144,7 +144,7 @@ pub(crate) async fn run(
             // New chain tip received - re-enter the scheduling loop on next iteration.
             result = chain_tip_rx.changed() => {
                 if result.is_err() {
-                    info!(target: COMPONENT, "Chain tip channel closed, proof scheduler exiting");
+                    debug!(target: LOG_TARGET, "Chain tip channel closed, proof scheduler exiting");
                     return Ok(());
                 }
             },

--- a/crates/block-producer/src/rpc_sync.rs
+++ b/crates/block-producer/src/rpc_sync.rs
@@ -12,7 +12,9 @@ use miden_protocol::utils::serde::Deserializable;
 use tokio_stream::StreamExt;
 use tonic_health::ServingStatus;
 use tonic_health::server::HealthReporter;
-use tracing::{info, warn};
+use tracing::{info, instrument, warn};
+
+use crate::{COMPONENT, LOG_TARGET};
 
 pub(crate) const RECONNECT_DELAY: Duration = Duration::from_secs(5);
 
@@ -110,9 +112,10 @@ impl BlockSync {
         .await
     }
 
+    #[instrument(target = COMPONENT, skip_all, err)]
     async fn sync(&self) -> anyhow::Result<()> {
         let block_from = self.state.chain_tip(Finality::Committed).await.child().as_u32();
-        info!(block_from, "Connecting to upstream RPC for blocks");
+        info!(target: LOG_TARGET, block_from, "Connecting to upstream RPC for blocks");
 
         let mut client = self.source_rpc.clone();
         let mut stream = client
@@ -162,7 +165,7 @@ impl ProofSync {
     async fn sync(&self) -> anyhow::Result<()> {
         // Subscribe from next proven tip.
         let starting_block = self.state.chain_tip(Finality::Proven).await.child().as_u32();
-        info!(starting_block, "Connecting to upstream RPC for proofs");
+        info!(target: LOG_TARGET, starting_block, "Connecting to upstream RPC for proofs");
         let mut client = self.source_rpc.clone();
         let mut stream = client
             .proof_subscription(ProofSubscriptionRequest { block_from: starting_block })

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -11,7 +11,7 @@ use miden_protocol::block::BlockNumber;
 use miden_protocol::transaction::ProvenTransaction;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
-use tracing::{debug, info, instrument};
+use tracing::instrument;
 use url::Url;
 
 use crate::batch_builder::BatchBuilder;
@@ -24,6 +24,7 @@ use crate::validator::BlockProducerValidatorClient;
 use crate::{
     CACHED_MEMPOOL_STATS_UPDATE_INTERVAL,
     COMPONENT,
+    LOG_TARGET,
     SERVER_NUM_BATCH_BUILDERS,
     proof_scheduler,
 };
@@ -101,13 +102,13 @@ pub struct Sequencer {
 impl Sequencer {
     /// Spawns the sequencer tasks and returns its in-process API.
     pub async fn spawn(self) -> Result<SequencerHandle> {
-        info!(target: COMPONENT, "Initializing sequencer");
+        tracing::info!(target: LOG_TARGET, "Initializing sequencer");
         let store = self.store;
         let validator =
             BlockProducerValidatorClient::new(self.validator_url.clone(), self.validator_timeout)?;
         let chain_tip = store.chain_tip(Finality::Committed).await;
 
-        info!(target: COMPONENT, "Sequencer initialized");
+        tracing::info!(target: LOG_TARGET, "Sequencer initialized");
 
         let block_builder = BlockBuilder::new(Arc::clone(&store), validator, self.block_interval);
         let batch_builder = BatchBuilder::new(
@@ -292,8 +293,8 @@ impl BlockProducerApi {
     ) -> Result<BlockNumber, MempoolSubmissionError> {
         let tx_id = tx.id();
 
-        debug!(
-            target: COMPONENT,
+        tracing::debug!(
+            target: LOG_TARGET,
             tx_id = %tx_id.to_hex(),
             account_id = %tx.account_id().to_hex(),
             initial_state_commitment = %tx.account_update().initial_state_commitment(),
@@ -303,7 +304,6 @@ impl BlockProducerApi {
             ref_block_commitment = %tx.ref_block_commitment(),
             "Submitting transaction"
         );
-        debug!(target: COMPONENT, proof = ?tx.proof());
 
         let inputs = crate::store::get_tx_inputs(&self.store, &tx)
             .await

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -10,10 +10,10 @@ use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::Nullifier;
 use miden_protocol::transaction::ProvenTransaction;
-use tracing::{debug, info, instrument};
+use tracing::instrument;
 
-use crate::COMPONENT;
 use crate::errors::StoreError;
+use crate::{COMPONENT, LOG_TARGET};
 
 // TRANSACTION INPUTS
 // ================================================================================================
@@ -91,13 +91,11 @@ impl Display for TransactionInputs {
 // STORE STATE
 // ================================================================================================
 
-#[instrument(target = COMPONENT, name = "store.state.get_tx_inputs", skip_all, err)]
+#[instrument(target = COMPONENT, name = "store.state.get_tx_inputs", skip_all, err, fields(transaction.id = %proven_tx.id().to_hex()))]
 pub async fn get_tx_inputs(
     state: &State,
     proven_tx: &ProvenTransaction,
 ) -> Result<TransactionInputs, StoreError> {
-    info!(target: COMPONENT, tx_id = %proven_tx.id().to_hex());
-
     let nullifiers = proven_tx.nullifiers().collect::<Vec<_>>();
     let unauthenticated_note_commitments =
         proven_tx.unauthenticated_notes().map(|header| header.id().as_word()).collect();
@@ -126,7 +124,7 @@ pub async fn get_tx_inputs(
         current_block_height,
     );
 
-    debug!(target: COMPONENT, %tx_inputs);
+    tracing::debug!(target: LOG_TARGET, ?tx_inputs, "Transaction inputs");
 
     Ok(tx_inputs)
 }

--- a/crates/block-producer/src/validator/mod.rs
+++ b/crates/block-producer/src/validator/mod.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tracing::{info, instrument};
 use url::Url;
 
-use crate::COMPONENT;
+use crate::{COMPONENT, LOG_TARGET};
 
 // VALIDATOR ERROR
 // ================================================================================================
@@ -42,7 +42,7 @@ impl BlockProducerValidatorClient {
     /// connection surfaces as a fast, retryable error instead of hanging on the OS-level TCP
     /// timeout and halting block production.
     pub fn new(validator_url: Url, timeout: Duration) -> anyhow::Result<Self> {
-        info!(target: COMPONENT, validator_endpoint = %validator_url, "Initializing validator client");
+        info!(target: LOG_TARGET, validator_endpoint = %validator_url, "Initializing validator client");
 
         let validator = Builder::new(validator_url)
             .with_tls()?

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -7,3 +7,4 @@ pub use server::{Rpc, RpcMode};
 // CONSTANTS
 // =================================================================================================
 pub const COMPONENT: &str = "miden-rpc";
+pub const LOG_TARGET: &str = "user::miden-rpc";

--- a/crates/rpc/src/server/api/block_subscription.rs
+++ b/crates/rpc/src/server/api/block_subscription.rs
@@ -4,20 +4,19 @@ use std::sync::Arc;
 use miden_node_proto::generated as proto;
 use miden_node_store::state::SubscriptionStreamError;
 use miden_node_utils::grpc::ClientIp;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
 use tonic::{Request, Status};
-use tracing::{Span, debug};
+use tracing::{debug, instrument};
 
 use super::{
     BlockSubscriptionStream,
-    COMPONENT,
     GuardedStream,
     RpcService,
     block_subscription_error_to_status,
     subscription_ban_status,
 };
+use crate::{COMPONENT, LOG_TARGET};
 
 pub struct BlockSubscriptionInput {
     request: proto::rpc::BlockSubscriptionRequest,
@@ -48,11 +47,19 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         self.handle(input).await
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "block_subscription",
+        skip_all,
+        fields(
+            block.from = %input.request.block_from,
+        ),
+        err,
+    )]
     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream> {
         let BlockSubscriptionInput { request, client_ip } = input;
-        Span::current().set_attribute("block.from", request.block_from);
 
-        debug!(target: COMPONENT, ?request);
+        debug!(target: LOG_TARGET, "Subscribing to blocks");
 
         // Reject clients that were recently disconnected for being too slow.
         if let Some(until) = client_ip.and_then(|ip| self.subscription_ban.banned_until(ip)) {

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -7,11 +7,11 @@ use miden_node_proto::domain::account::{
 use miden_node_proto::generated as proto;
 use miden_node_store::GetAccountError;
 use miden_node_utils::limiter::QueryParamStorageMapKeyTotalLimit;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use tonic::Status;
-use tracing::{Span, debug, info_span};
+use tracing::{Span, debug, field, info_span, instrument};
 
-use super::{COMPONENT, RpcService, check};
+use super::{RpcService, check};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetAccount for RpcService {
@@ -26,14 +26,22 @@ impl proto::server::rpc_api::GetAccount for RpcService {
         Ok(output.into())
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_account",
+        skip_all,
+        fields(
+            account.id = %request.account_id,
+            block.number = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, ?request);
-
-        let span = Span::current();
-        span.set_attribute("account.id", request.account_id);
         if let Some(block) = request.block_num {
-            span.set_attribute("block.number", block);
+            Span::current().record("block.number", field::display(block));
         }
+        tracing::trace!(target: LOG_TARGET, ?request);
+        debug!(target: LOG_TARGET, "Getting account");
 
         // Validate total storage map key limit before forwarding to store
         if let Some(details) = &request.details {

--- a/crates/rpc/src/server/api/get_block_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_by_number.rs
@@ -1,9 +1,9 @@
 use miden_node_proto::generated as proto;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
-use tracing::{Span, debug};
+use tracing::{debug, instrument};
 
-use super::{COMPONENT, RpcService, database_error_to_status};
+use super::{RpcService, database_error_to_status};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetBlockByNumber for RpcService {
@@ -18,9 +18,17 @@ impl proto::server::rpc_api::GetBlockByNumber for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_block_by_number",
+        skip_all,
+        fields(
+            block.number = %request.block_num,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        Span::current().set_attribute("block.number", request.block_num);
-        debug!(target: COMPONENT, ?request);
+        debug!(target: LOG_TARGET, ?request, "Getting block by number");
 
         let block_num = BlockNumber::from(request.block_num);
         let block = self

--- a/crates/rpc/src/server/api/get_block_header_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_header_by_number.rs
@@ -1,9 +1,9 @@
 use miden_node_proto::generated as proto;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
-use tracing::{Span, debug};
+use tracing::{debug, instrument};
 
 use super::{COMPONENT, RpcService};
+use crate::LOG_TARGET;
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
@@ -18,10 +18,17 @@ impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_block_header_by_number",
+        skip_all,
+        fields(
+            block.number = %request.block_num(),
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, ?request);
-
-        Span::current().set_attribute("block.number", request.block_num());
+        debug!(target: LOG_TARGET, ?request, "Getting block header by number");
 
         let block_num = request.block_num.map(BlockNumber::from);
         let (block_header, mmr_proof) = self

--- a/crates/rpc/src/server/api/get_limits.rs
+++ b/crates/rpc/src/server/api/get_limits.rs
@@ -1,7 +1,8 @@
 use miden_node_proto::generated as proto;
-use tracing::debug;
+use tracing::{debug, instrument};
 
-use super::{COMPONENT, RPC_LIMITS, RpcService};
+use super::{RPC_LIMITS, RpcService};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetLimits for RpcService {
@@ -16,8 +17,14 @@ impl proto::server::rpc_api::GetLimits for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_limits",
+        skip_all,
+        err,
+    )]
     async fn handle(&self, _request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, request = ?());
+        debug!(target: LOG_TARGET, "Getting limits");
 
         Ok(RPC_LIMITS.clone())
     }

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -1,9 +1,11 @@
 use miden_node_proto::generated as proto;
+use miden_protocol::Word;
 use tonic::Request;
 use tonic::metadata::{Ascii, MetadataValue};
-use tracing::debug;
+use tracing::{Span, debug, field, instrument};
 
-use super::{COMPONENT, RpcMode, RpcService};
+use super::{RpcMode, RpcService};
+use crate::{COMPONENT, LOG_TARGET};
 
 pub struct GetNetworkNoteStatusInput {
     request: proto::note::NoteId,
@@ -32,10 +34,30 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
         Self::encode(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_network_note_status",
+        skip_all,
+        fields(
+            note.id = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
         let GetNetworkNoteStatusInput { request, original_accept_header } = request;
 
-        debug!(target: COMPONENT, ?request);
+        tracing::trace!(target: LOG_TARGET, ?request);
+
+        let note_id_digest: Word = request
+            .id
+            .as_ref()
+            .ok_or_else(|| tonic::Status::invalid_argument("missing note ID digest"))?
+            .try_into()
+            .map_err(|_| tonic::Status::invalid_argument("invalid note ID digest"))?;
+        let note_id = miden_protocol::note::NoteId::from_raw(note_id_digest);
+        Span::current().record("note.id", field::display(note_id));
+
+        debug!(target: LOG_TARGET, "Getting network note status");
 
         let mut forwarded_request = Request::new(request);
         if let Some(accept) = original_accept_header {

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -2,9 +2,10 @@ use miden_node_proto::decode::read_root;
 use miden_node_proto::generated as proto;
 use miden_protocol::note::NoteScript;
 use tonic::Status;
-use tracing::debug;
+use tracing::{Span, debug, field, instrument};
 
-use super::{COMPONENT, RpcService, database_error_to_status};
+use super::{RpcService, database_error_to_status};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
@@ -19,10 +20,23 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
         Ok(proto::rpc::MaybeNoteScript { script: output.map(Into::into) })
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_note_script_by_root",
+        skip_all,
+        fields(
+            script.root = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, ?request);
+        tracing::trace!(target: LOG_TARGET, ?request);
 
         let root = read_root::<Status>(request.root, "NoteScriptRoot")?;
+        Span::current().record("script.root", field::display(root));
+
+        debug!(target: LOG_TARGET, "Getting note script by root");
+
         let script = self
             .store
             .get_note_script_by_root(root)

--- a/crates/rpc/src/server/api/get_notes_by_id.rs
+++ b/crates/rpc/src/server/api/get_notes_by_id.rs
@@ -7,9 +7,10 @@ use miden_protocol::Word;
 use miden_protocol::note::NoteId;
 use miden_protocol::utils::serde::Serializable;
 use tonic::Status;
-use tracing::debug;
+use tracing::instrument;
 
-use super::{COMPONENT, RpcService, check, database_error_to_status};
+use super::{RpcService, check, database_error_to_status};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetNotesById for RpcService {
@@ -24,13 +25,20 @@ impl proto::server::rpc_api::GetNotesById for RpcService {
         Ok(proto::note::CommittedNoteList { notes })
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "get_notes_by_id",
+        skip_all,
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, ?request);
+        tracing::trace!(target: LOG_TARGET, ?request);
 
         check::<QueryParamNoteIdLimit>(request.ids.len())?;
 
         let note_ids: Vec<Word> = convert_digests_to_words::<Status, _>(request.ids)?;
         let note_ids: Vec<NoteId> = note_ids.into_iter().map(NoteId::from_raw).collect();
+
         let notes = self
             .store
             .get_notes_by_id(note_ids)

--- a/crates/rpc/src/server/api/proof_subscription.rs
+++ b/crates/rpc/src/server/api/proof_subscription.rs
@@ -4,20 +4,19 @@ use std::sync::Arc;
 use miden_node_proto::generated as proto;
 use miden_node_store::state::SubscriptionStreamError;
 use miden_node_utils::grpc::ClientIp;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tokio_stream::StreamExt;
 use tonic::{Request, Status};
-use tracing::{Span, debug};
+use tracing::{debug, instrument};
 
 use super::{
-    COMPONENT,
     GuardedStream,
     ProofSubscriptionStream,
     RpcService,
     proof_subscription_error_to_status,
     subscription_ban_status,
 };
+use crate::{COMPONENT, LOG_TARGET};
 
 pub struct ProofSubscriptionInput {
     request: proto::rpc::ProofSubscriptionRequest,
@@ -48,11 +47,19 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         self.handle(input).await
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "proof_subscription",
+        skip_all,
+        fields(
+            block.from = %input.request.block_from,
+        ),
+        err,
+    )]
     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream> {
         let ProofSubscriptionInput { request, client_ip } = input;
-        Span::current().set_attribute("block.from", request.block_from);
 
-        debug!(target: COMPONENT, ?request);
+        debug!(target: LOG_TARGET, "Subscribing to block proofs");
 
         // Reject clients that were recently disconnected for being too slow.
         if let Some(until) = client_ip.and_then(|ip| self.subscription_ban.banned_until(ip)) {

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -1,8 +1,9 @@
 use miden_node_block_producer::{BlockProducerStatus, MempoolStats};
 use miden_node_proto::generated as proto;
-use tracing::debug;
+use tracing::{debug, instrument};
 
-use super::{COMPONENT, Finality, ProtoMempoolStats, Request, RpcMode, RpcService};
+use super::{Finality, ProtoMempoolStats, Request, RpcMode, RpcService};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::Status for RpcService {
@@ -17,9 +18,13 @@ impl proto::server::rpc_api::Status for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "status",
+        skip_all,
+        err,
+    )]
     async fn handle(&self, _request: Self::Input) -> tonic::Result<Self::Output> {
-        debug!(target: COMPONENT, request = ?());
-
         let block_producer_status = match &self.mode {
             RpcMode::Sequencer { block_producer, .. } => {
                 Some(block_producer_status_to_proto(block_producer.status().await))
@@ -32,6 +37,8 @@ impl proto::server::rpc_api::Status for RpcService {
                 .ok()
                 .and_then(|response| response.into_inner().block_producer),
         };
+
+        debug!(target: LOG_TARGET, "Getting status");
 
         Ok(proto::rpc::RpcStatus {
             version: env!("CARGO_PKG_VERSION").to_string(),

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -1,7 +1,6 @@
 use miden_node_proto::generated as proto;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::transaction::{
     OutputNote,
@@ -13,9 +12,10 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx::TransactionVerifier;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::{Request, Status};
-use tracing::{Span, debug};
+use tracing::{Span, debug, field, instrument};
 
 use super::{COMPONENT, RpcMode, RpcService};
+use crate::LOG_TARGET;
 
 pub struct SubmitProvenTxInput {
     request: proto::transaction::ProvenTransaction,
@@ -56,24 +56,44 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
         Self::encode(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "submit_proven_tx",
+        skip_all,
+        fields(
+            COMPONENT = field::Empty,
+            transaction.id = field::Empty,
+            account.id = field::Empty,
+            transaction.expires_at = field::Empty,
+            transaction.reference_block.number = field::Empty,
+            transaction.reference_block.commitment = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
         let SubmitProvenTxInput {
             mut request,
             is_authorized_network_tx,
             original_accept_header,
         } = input;
-        debug!(target: COMPONENT, ?request);
+
+        tracing::trace!(target: LOG_TARGET, ?request);
 
         let tx = ProvenTransaction::read_from_bytes(&request.transaction).map_err(|err| {
             Status::invalid_argument(err.as_report_context("invalid transaction"))
         })?;
 
         let span = Span::current();
-        span.set_attribute("transaction.id", tx.id());
-        span.set_attribute("account.id", tx.account_id());
-        span.set_attribute("transaction.expires_at", tx.expiration_block_num());
-        span.set_attribute("transaction.reference_block.number", tx.ref_block_num());
-        span.set_attribute("transaction.reference_block.commitment", tx.ref_block_commitment());
+        span.record("transaction.id", field::display(tx.id()));
+        span.record("account.id", field::display(tx.account_id()));
+        span.record("transaction.expires_at", field::display(tx.expiration_block_num()));
+        span.record("transaction.reference_block.number", field::display(tx.ref_block_num()));
+        span.record(
+            "transaction.reference_block.commitment",
+            field::display(tx.ref_block_commitment()),
+        );
+
+        debug!(target: LOG_TARGET, "Submitting transaction");
 
         // Verify the reference block is actually part of the chain.
         self.verify_reference_commitment(tx.ref_block_num(), tx.ref_block_commitment())

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -1,16 +1,16 @@
 use miden_node_proto::generated as proto;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx_batch_prover::LocalBatchProver;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::{Request, Status};
-use tracing::Span;
+use tracing::{Span, field, instrument};
 
 use super::{RpcMode, RpcService};
+use crate::{COMPONENT, LOG_TARGET};
 
 pub struct SubmitProvenTxBatchInput {
     request: proto::transaction::TransactionBatch,
@@ -50,6 +50,18 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         Self::encode(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "submit_proven_tx_batch",
+        skip_all,
+        fields(
+            batch.id = field::Empty,
+            batch.expires_at = field::Empty,
+            batch.reference_block.number = field::Empty,
+            batch.reference_block.commitment = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
         let SubmitProvenTxBatchInput {
             request,
@@ -57,17 +69,22 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
             original_accept_header,
         } = input;
 
+        tracing::trace!(target: LOG_TARGET, ?request);
+
         let proven_batch = ProvenBatch::read_from_bytes(&request.batch_proof).map_err(|err| {
             Status::invalid_argument(err.as_report_context("invalid proven_batch"))
         })?;
 
         let span = Span::current();
-        span.set_attribute("batch.id", proven_batch.id());
-        span.set_attribute("batch.expires_at", proven_batch.batch_expiration_block_num());
-        span.set_attribute("batch.reference_block.number", proven_batch.reference_block_num());
-        span.set_attribute(
+        span.record("batch.id", field::display(proven_batch.id()));
+        span.record("batch.expires_at", field::display(proven_batch.batch_expiration_block_num()));
+        span.record(
+            "batch.reference_block.number",
+            field::display(proven_batch.reference_block_num()),
+        );
+        span.record(
             "batch.reference_block.commitment",
-            proven_batch.reference_block_commitment(),
+            field::display(proven_batch.reference_block_commitment()),
         );
 
         let proposed_batch = request
@@ -79,6 +96,8 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
                 Status::invalid_argument(err.as_report_context("invalid proposed_batch"))
             })?
             .ok_or(Status::invalid_argument("missing `proposed_batch` field"))?;
+
+        tracing::debug!(target: LOG_TARGET, "Submitting transaction batch");
 
         // Verify the reference block is actually part of the chain.
         self.verify_reference_commitment(

--- a/crates/rpc/src/server/api/sync_account_storage_maps.rs
+++ b/crates/rpc/src/server/api/sync_account_storage_maps.rs
@@ -1,16 +1,15 @@
 use miden_node_proto::decode::{read_account_id, read_block_range};
 use miden_node_proto::generated as proto;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use tonic::Status;
-use tracing::{Span, debug};
+use tracing::{Span, field, instrument};
 
 use super::{
-    COMPONENT,
     RpcInvalidBlockRange,
     RpcService,
     database_error_to_status,
     invalid_block_range_to_status,
 };
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
@@ -25,7 +24,20 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "sync_account_storage_maps",
+        skip_all,
+        fields(
+            account.id = field::Empty,
+            block_range.from = field::Empty,
+            block_range.to = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+        tracing::trace!(target: LOG_TARGET, ?request);
+
         let account_id = read_account_id::<proto::rpc::SyncAccountStorageMapsRequest, Status>(
             request.account_id.clone(),
         )?;
@@ -33,11 +45,11 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
             read_block_range::<Status>(request.block_range, "SyncAccountStorageMapsRequest")?;
 
         let span = Span::current();
-        span.set_attribute("account.id", account_id);
-        span.set_attribute("block_range.from", range.block_from);
-        span.set_attribute("block_range.to", range.block_to);
+        span.record("account.id", field::display(account_id));
+        span.record("block_range.from", range.block_from);
+        span.record("block_range.to", range.block_to);
 
-        debug!(target: COMPONENT, ?request);
+        tracing::debug!(target: LOG_TARGET, "Syncing account storage maps");
 
         if !account_id.is_public() {
             return Err(Status::invalid_argument(format!("account {account_id} is not public")));

--- a/crates/rpc/src/server/api/sync_account_vault.rs
+++ b/crates/rpc/src/server/api/sync_account_vault.rs
@@ -1,17 +1,16 @@
 use miden_node_proto::decode::{read_account_id, read_block_range};
 use miden_node_proto::generated as proto;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::Word;
 use tonic::Status;
-use tracing::{Span, debug};
+use tracing::{Span, field, instrument};
 
 use super::{
-    COMPONENT,
     RpcInvalidBlockRange,
     RpcService,
     database_error_to_status,
     invalid_block_range_to_status,
 };
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::SyncAccountVault for RpcService {
@@ -26,18 +25,31 @@ impl proto::server::rpc_api::SyncAccountVault for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "sync_account_vault",
+        skip_all,
+        fields(
+            account.id = field::Empty,
+            block_range.from = field::Empty,
+            block_range.to = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+        tracing::trace!(target: LOG_TARGET, ?request);
+
         let account_id = read_account_id::<proto::rpc::SyncAccountVaultRequest, Status>(
             request.account_id.clone(),
         )?;
         let range = read_block_range::<Status>(request.block_range, "SyncAccountVaultRequest")?;
 
         let span = Span::current();
-        span.set_attribute("account.id", account_id);
-        span.set_attribute("block_range.from", range.block_from);
-        span.set_attribute("block_range.to", range.block_to);
+        span.record("account.id", field::display(account_id));
+        span.record("block_range.from", range.block_from);
+        span.record("block_range.to", range.block_to);
 
-        debug!(target: COMPONENT, ?request);
+        tracing::debug!(target: LOG_TARGET, "Syncing account vault");
 
         if !account_id.is_public() {
             return Err(Status::invalid_argument(format!("account {account_id} is not public")));

--- a/crates/rpc/src/server/api/sync_chain_mmr.rs
+++ b/crates/rpc/src/server/api/sync_chain_mmr.rs
@@ -1,10 +1,10 @@
 use miden_node_proto::generated as proto;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::block::BlockNumber;
 use tonic::Status;
-use tracing::{Span, debug};
+use tracing::{debug, instrument};
 
-use super::{COMPONENT, Finality, RpcService};
+use super::{Finality, RpcService};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::SyncChainMmr for RpcService {
@@ -19,12 +19,18 @@ impl proto::server::rpc_api::SyncChainMmr for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "sync_chain_mmr",
+        skip_all,
+        fields(
+            current_client_block_height = %request.current_client_block_height,
+            finality_level = %request.finality_level().as_str_name(),
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        let span = Span::current();
-        span.set_attribute("current_client_block_height", request.current_client_block_height);
-        span.set_attribute("finality_level", request.finality_level().as_str_name());
-
-        debug!(target: COMPONENT, ?request);
+        debug!(target: LOG_TARGET, "Syncing chain MMR");
 
         let current_client_block_height = BlockNumber::from(request.current_client_block_height);
         let sync_target = match request.finality_level() {

--- a/crates/rpc/src/server/api/sync_notes.rs
+++ b/crates/rpc/src/server/api/sync_notes.rs
@@ -2,11 +2,11 @@ use miden_node_proto::decode::read_block_range;
 use miden_node_proto::generated as proto;
 use miden_node_store::{NoteSyncError, NoteSyncRecord};
 use miden_node_utils::limiter::QueryParamNoteTagLimit;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use tonic::Status;
-use tracing::{Span, debug};
+use tracing::{Span, debug, field, instrument};
 
-use super::{COMPONENT, RpcInvalidBlockRange, RpcService, check, invalid_block_range_to_status};
+use super::{RpcInvalidBlockRange, RpcService, check, invalid_block_range_to_status};
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::SyncNotes for RpcService {
@@ -21,13 +21,26 @@ impl proto::server::rpc_api::SyncNotes for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "sync_notes",
+        skip_all,
+        fields(
+            block_range.from = field::Empty,
+            block_range.to = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+        tracing::trace!(target: LOG_TARGET, ?request);
+
         let range = read_block_range::<Status>(request.block_range, "SyncNotesRequest")?;
 
         let span = Span::current();
-        span.set_attribute("block_range.from", range.block_from);
-        span.set_attribute("block_range.to", range.block_to);
-        debug!(target: COMPONENT, ?request);
+        span.record("block_range.from", range.block_from);
+        span.record("block_range.to", range.block_to);
+
+        debug!(target: LOG_TARGET, "Syncing notes");
 
         check::<QueryParamNoteTagLimit>(request.note_tags.len())?;
 

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -1,18 +1,17 @@
 use miden_node_proto::decode::read_block_range;
 use miden_node_proto::generated as proto;
 use miden_node_utils::limiter::QueryParamNullifierPrefixLimit;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use tonic::Status;
-use tracing::{Span, debug};
+use tracing::{Span, debug, field, instrument};
 
 use super::{
-    COMPONENT,
     RpcInvalidBlockRange,
     RpcService,
     check,
     database_error_to_status,
     invalid_block_range_to_status,
 };
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::SyncNullifiers for RpcService {
@@ -27,14 +26,26 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "sync_nullifiers",
+        skip_all,
+        fields(
+            block_range.from = field::Empty,
+            block_range.to = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+        tracing::trace!(target: LOG_TARGET, ?request);
+
         let range = read_block_range::<Status>(request.block_range, "SyncNullifiersRequest")?;
 
         let span = Span::current();
-        span.set_attribute("block_range.from", range.block_from);
-        span.set_attribute("block_range.to", range.block_to);
+        span.record("block_range.from", range.block_from);
+        span.record("block_range.to", range.block_to);
 
-        debug!(target: COMPONENT, ?request);
+        debug!(target: LOG_TARGET, "Syncing nullifiers");
 
         check::<QueryParamNullifierPrefixLimit>(request.nullifiers.len())?;
 

--- a/crates/rpc/src/server/api/sync_transactions.rs
+++ b/crates/rpc/src/server/api/sync_transactions.rs
@@ -2,19 +2,18 @@ use miden_node_proto::decode::{read_account_ids, read_block_range};
 use miden_node_proto::generated as proto;
 use miden_node_store::{NoteSyncRecord, TransactionRecord};
 use miden_node_utils::limiter::QueryParamAccountIdLimit;
-use miden_node_utils::tracing::OpenTelemetrySpanExt;
 use miden_protocol::asset::Asset;
 use tonic::Status;
-use tracing::{Span, debug};
+use tracing::{Span, debug, field, instrument};
 
 use super::{
-    COMPONENT,
     RpcInvalidBlockRange,
     RpcService,
     check,
     database_error_to_status,
     invalid_block_range_to_status,
 };
+use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::SyncTransactions for RpcService {
@@ -29,19 +28,33 @@ impl proto::server::rpc_api::SyncTransactions for RpcService {
         Ok(output)
     }
 
+    #[instrument(
+        target = COMPONENT,
+        name = "sync_transactions",
+        skip_all,
+        fields(
+            block_range.from = field::Empty,
+            block_range.to = field::Empty,
+            account.ids = field::Empty,
+            account.ids.count = field::Empty,
+        ),
+        err,
+    )]
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+        tracing::trace!(target: LOG_TARGET, ?request);
+
         let range = read_block_range::<Status>(request.block_range, "SyncTransactionsRequest")?;
         let n_accounts = request.account_ids.len();
         let account_ids =
             read_account_ids::<Status, _>(request.account_ids.iter().take(10).cloned())?;
 
         let span = Span::current();
-        span.set_attribute("block_range.from", range.block_from);
-        span.set_attribute("block_range.to", range.block_to);
-        span.set_attribute("account.ids", format!("{account_ids:?}").as_str());
-        span.set_attribute("account.ids.count", n_accounts);
+        span.record("block_range.from", range.block_from);
+        span.record("block_range.to", range.block_to);
+        span.record("account.ids", format!("{account_ids:?}").as_str());
+        span.record("account.ids.count", n_accounts);
 
-        debug!(target: COMPONENT, ?request);
+        debug!(target: LOG_TARGET, "Syncing transactions");
 
         check::<QueryParamAccountIdLimit>(request.account_ids.len())?;
 

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -23,8 +23,8 @@ use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-use crate::COMPONENT;
 use crate::server::health::HealthCheckLayer;
+use crate::{COMPONENT, LOG_TARGET};
 
 mod accept;
 pub(crate) mod api;
@@ -107,7 +107,7 @@ impl Rpc {
 
         let api_service = rpc_api::service(api);
 
-        info!(target: COMPONENT, endpoint=?self.listener, mode=?self.mode, "Server initialized");
+        info!(target: LOG_TARGET, endpoint=?self.listener, mode=?self.mode, "Server initialized");
 
         let mut tasks = Tasks::new();
 

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -23,8 +23,8 @@ use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
+use crate::LOG_TARGET;
 use crate::server::health::HealthCheckLayer;
-use crate::{COMPONENT, LOG_TARGET};
 
 mod accept;
 pub(crate) mod api;

--- a/crates/store/src/account_state_forest/mod.rs
+++ b/crates/store/src/account_state_forest/mod.rs
@@ -458,7 +458,7 @@ impl<B: Backend> AccountStateForest<B> {
     /// # Errors
     ///
     /// Returns an error if applying a vault delta results in a negative balance.
-    #[instrument(target = COMPONENT, skip_all, fields(block.number = %block_num))]
+    #[instrument(target = COMPONENT, skip_all, fields(block.number = %block_num, num_pruned = tracing::field::Empty))]
     pub(crate) fn apply_block_updates(
         &mut self,
         block_num: BlockNumber,
@@ -467,8 +467,8 @@ impl<B: Backend> AccountStateForest<B> {
         for delta in account_updates {
             self.update_account(block_num, &delta)?;
 
-            tracing::debug!(
-                target: crate::COMPONENT,
+            tracing::trace!(
+                target: crate::LOG_TARGET,
                 account_id = %delta.id(),
                 %block_num,
                 is_full_state = delta.is_full_state(),
@@ -476,7 +476,8 @@ impl<B: Backend> AccountStateForest<B> {
             );
         }
 
-        self.prune(block_num);
+        let number_of_pruned_blocks = self.prune(block_num);
+        tracing::Span::current().record("num_pruned", number_of_pruned_blocks);
 
         Ok(())
     }
@@ -550,8 +551,8 @@ impl<B: Backend> AccountStateForest<B> {
             let lineage = Self::vault_lineage_id(account_id);
             let new_root = self.apply_forest_updates(lineage, block_num, Vec::new());
 
-            tracing::debug!(
-                target: crate::COMPONENT,
+            tracing::trace!(
+                target: crate::LOG_TARGET,
                 %account_id,
                 %block_num,
                 %new_root,
@@ -588,8 +589,8 @@ impl<B: Backend> AccountStateForest<B> {
         let operations = Self::build_forest_operations(entries);
         let new_root = self.apply_forest_updates(lineage, block_num, operations);
 
-        tracing::debug!(
-            target: crate::COMPONENT,
+        tracing::trace!(
+            target: crate::LOG_TARGET,
             %account_id,
             %block_num,
             %new_root,
@@ -639,8 +640,8 @@ impl<B: Backend> AccountStateForest<B> {
 
             let num_entries = raw_map_entries.len();
 
-            tracing::debug!(
-                target: crate::COMPONENT,
+            tracing::trace!(
+                target: crate::LOG_TARGET,
                 %account_id,
                 %block_num,
                 ?slot_name,
@@ -729,8 +730,8 @@ impl<B: Backend> AccountStateForest<B> {
         let operations = Self::build_forest_operations(entries);
         let new_root = self.apply_forest_updates(lineage, block_num, operations);
 
-        tracing::debug!(
-            target: crate::COMPONENT,
+        tracing::trace!(
+            target: crate::LOG_TARGET,
             %account_id,
             %block_num,
             %new_root,
@@ -782,8 +783,8 @@ impl<B: Backend> AccountStateForest<B> {
             let operations = Self::build_forest_operations(hashed_entries);
             let new_root = self.apply_forest_updates(lineage, block_num, operations);
 
-            tracing::debug!(
-                target: crate::COMPONENT,
+            tracing::trace!(
+                target: crate::LOG_TARGET,
                 %account_id,
                 %block_num,
                 ?slot_name,
@@ -802,7 +803,6 @@ impl<B: Backend> AccountStateForest<B> {
     /// The `LargeSmtForest` itself is truncated to drop historical versions beyond the cutoff.
     ///
     /// Returns the number of pruned roots for observability.
-    #[instrument(target = COMPONENT, skip_all, ret, fields(block.number = %chain_tip))]
     pub(crate) fn prune(&mut self, chain_tip: BlockNumber) -> usize {
         let cutoff_block = chain_tip
             .checked_sub(HISTORICAL_BLOCK_RETENTION)

--- a/crates/store/src/db/migrations.rs
+++ b/crates/store/src/db/migrations.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use miden_node_db::DatabaseError;
 use tracing::instrument;
 
-use crate::COMPONENT;
+use crate::{COMPONENT, LOG_TARGET};
 
 include!(concat!(env!("OUT_DIR"), "/db_migrator.rs"));
 
@@ -11,7 +11,7 @@ include!(concat!(env!("OUT_DIR"), "/db_migrator.rs"));
 pub fn bootstrap_database(database_filepath: &Path) -> std::result::Result<(), DatabaseError> {
     let migrator = migrator().map_err(DatabaseError::migration)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         migration_count = migrator.schema_hashes().len(),
         "Bootstrapping database schema"
     );
@@ -25,7 +25,7 @@ pub fn bootstrap_database(database_filepath: &Path) -> std::result::Result<(), D
 pub fn migrate_database(database_filepath: &Path) -> std::result::Result<(), DatabaseError> {
     let migrator = migrator().map_err(DatabaseError::migration)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         migration_count = migrator.schema_hashes().len(),
         "Applying database migrations"
     );
@@ -39,7 +39,7 @@ pub fn migrate_database(database_filepath: &Path) -> std::result::Result<(), Dat
 pub fn verify_latest_schema(database_filepath: &Path) -> std::result::Result<(), DatabaseError> {
     let migrator = migrator().map_err(DatabaseError::migration)?;
     tracing::info!(
-        target: COMPONENT,
+        target: LOG_TARGET,
         migration_count = migrator.schema_hashes().len(),
         "Verifying database schema"
     );

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -29,7 +29,6 @@ use miden_protocol::utils::serde::Deserializable;
 use tokio::sync::oneshot;
 use tracing::{info, instrument};
 
-use crate::COMPONENT;
 use crate::db::migrations::{migrate_database, verify_latest_schema};
 use crate::db::models::conv::SqlTypeConvert;
 use crate::db::models::queries;
@@ -42,6 +41,7 @@ pub use crate::db::models::queries::{
 use crate::db::models::queries::{BlockHeaderCommitment, StorageMapValuesPage};
 use crate::errors::{DatabaseError, NoteSyncError};
 use crate::genesis::GenesisBlock;
+use crate::{COMPONENT, LOG_TARGET};
 
 const STORAGE_MAP_VALUE_PER_ROW_BYTES: usize =
     2 * size_of::<Word>() + size_of::<u32>() + size_of::<u8>();
@@ -230,7 +230,7 @@ impl Db {
 
         let db = miden_node_db::Db::new_with_pool_size(&database_filepath, connection_pool_size)?;
         info!(
-            target: COMPONENT,
+            target: LOG_TARGET,
             sqlite= %database_filepath.display(),
             connection_pool_size = %connection_pool_size,
             "Connected to the database"
@@ -247,7 +247,7 @@ impl Db {
     }
 
     /// Returns a page of nullifiers for tree rebuilding.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_nullifiers_paged(
         &self,
         page_size: std::num::NonZeroUsize,
@@ -265,7 +265,6 @@ impl Db {
         target = COMPONENT,
         skip_all,
         fields(prefix_len, prefixes = nullifier_prefixes.len()),
-        ret(level = "debug"),
         err
     )]
     pub async fn select_nullifiers_by_prefix(
@@ -292,7 +291,7 @@ impl Db {
     /// Search for a [`BlockHeader`] from the database by its `block_num`.
     ///
     /// When `block_number` is [None], the latest block header is returned.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_block_header_by_block_num(
         &self,
         maybe_block_number: Option<BlockNumber>,
@@ -305,7 +304,7 @@ impl Db {
     }
 
     /// Search for a [`BlockHeader`] and its [`Signature`] from the database by its `block_num`.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_block_header_and_signature_by_block_num(
         &self,
         block_number: BlockNumber,
@@ -318,7 +317,7 @@ impl Db {
     }
 
     /// Loads multiple block headers from the DB.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_block_headers(
         &self,
         blocks: impl Iterator<Item = BlockNumber> + Send + 'static,
@@ -331,7 +330,7 @@ impl Db {
     }
 
     /// Loads all the block headers from the DB.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_all_block_header_commitments(&self) -> Result<Vec<BlockHeaderCommitment>> {
         self.transact("all block headers", |conn| {
             let raw = queries::select_all_block_header_commitments(conn)?;
@@ -341,7 +340,7 @@ impl Db {
     }
 
     /// Returns a page of account commitments for tree rebuilding.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_account_commitments_paged(
         &self,
         page_size: std::num::NonZeroUsize,
@@ -354,7 +353,7 @@ impl Db {
     }
 
     /// Returns a page of public account IDs for forest rebuilding.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_public_account_ids_paged(
         &self,
         page_size: std::num::NonZeroUsize,
@@ -367,7 +366,7 @@ impl Db {
     }
 
     /// Returns a page of public account state roots for forest consistency verification.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_public_account_state_roots_paged(
         &self,
         page_size: std::num::NonZeroUsize,
@@ -380,14 +379,14 @@ impl Db {
     }
 
     /// Loads public account details from the DB.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_account(&self, id: AccountId) -> Result<AccountInfo> {
         self.transact("Get account details", move |conn| queries::select_account(conn, id))
             .await
     }
 
     /// Returns the subset of the provided account IDs that classify as network accounts.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_network_accounts_subset(
         &self,
         account_ids: Vec<AccountId>,
@@ -428,7 +427,7 @@ impl Db {
         .await
     }
 
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn get_note_sync_multi(
         &self,
         block_range: RangeInclusive<BlockNumber>,
@@ -442,7 +441,7 @@ impl Db {
 
     /// Loads all the [`miden_protocol::note::Note`]s matching a certain [`NoteId`] from the
     /// database.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_notes_by_id(&self, note_ids: Vec<NoteId>) -> Result<Vec<NoteRecord>> {
         self.transact("note by id", move |conn| {
             queries::select_notes_by_id(conn, note_ids.as_slice())
@@ -451,7 +450,7 @@ impl Db {
     }
 
     /// Returns all note commitments from the DB that match the provided ones.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_existing_note_commitments(
         &self,
         note_commitments: Vec<Word>,
@@ -463,7 +462,7 @@ impl Db {
     }
 
     /// Loads inclusion proofs for notes matching the given note commitments.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn select_note_inclusion_proofs(
         &self,
         note_commitments: BTreeSet<Word>,

--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -40,7 +40,7 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 
-use crate::GenesisState;
+use crate::{GenesisState, LOG_TARGET};
 
 mod errors;
 use self::errors::GenesisConfigError;
@@ -221,7 +221,7 @@ impl GenesisConfig {
         // Setup all wallet accounts, which reference the faucet's for their provided assets.
         for (index, WalletConfig { account_type, assets }) in wallet_configs.into_iter().enumerate()
         {
-            tracing::debug!(index, assets = ?assets, "Adding wallet account");
+            tracing::debug!(target: LOG_TARGET, index, assets = ?assets, "Adding wallet account");
 
             let mut rng = ChaCha20Rng::from_seed(rand::random());
             let secret_key = RpoSecretKey::with_rng(&mut get_random_coin(&mut rng));
@@ -292,6 +292,7 @@ impl GenesisConfig {
                 let slot = updated_faucet.token_config_slot_value();
                 storage_delta.set_item(slot.name().clone(), slot.value())?;
                 tracing::debug!(
+                    target: LOG_TARGET,
                     "Reducing faucet account {faucet} for {symbol} by {amount}",
                     faucet = faucet_id.to_hex(),
                     symbol = symbol,
@@ -299,6 +300,7 @@ impl GenesisConfig {
                 );
             } else {
                 tracing::debug!(
+                    target: LOG_TARGET,
                     "No wallet is referencing {faucet} for {symbol}",
                     faucet = faucet_id.to_hex(),
                     symbol = symbol,
@@ -578,6 +580,7 @@ fn prepare_fungible_asset_update(
         let faucet_id = vault_key.faucet_id();
         let issuance: &mut u64 = faucet_issuance.entry(faucet_id).or_default();
         tracing::debug!(
+            target: LOG_TARGET,
             "Updating faucet issuance {faucet} with {issuance} += {amount}",
             faucet = faucet_id.to_hex()
         );

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -95,3 +95,4 @@ pub mod test_support {
 // CONSTANTS
 // =================================================================================================
 const COMPONENT: &str = "miden-store";
+const LOG_TARGET: &str = "user::miden-store";

--- a/crates/store/src/state/apply_block.rs
+++ b/crates/store/src/state/apply_block.rs
@@ -12,12 +12,12 @@ use miden_protocol::note::{NoteDetails, Nullifier};
 use miden_protocol::transaction::OutputNote;
 use miden_protocol::utils::serde::Serializable;
 use tokio::sync::oneshot;
-use tracing::{Instrument, info, info_span, instrument};
+use tracing::{Instrument, field, info_span, instrument};
 
 use crate::db::NoteRecord;
 use crate::errors::{ApplyBlockError, ApplyBlockWithProvingInputsError, InvalidBlockError};
 use crate::state::{BlockNotification, State};
-use crate::{COMPONENT, HistoricalError};
+use crate::{COMPONENT, HistoricalError, LOG_TARGET};
 
 impl State {
     /// Saves proving inputs for a signed block and applies it to the state.
@@ -72,7 +72,13 @@ impl State {
     /// - the in-memory structures are updated, including the latest block pointer and the lock is
     ///   released.
     // TODO: This span is logged in a root span, we should connect it to the parent span.
-    #[instrument(target = COMPONENT, skip_all, err)]
+    #[instrument(target = COMPONENT, skip_all, err,
+                fields(
+                    block_num = field::Empty,
+                    block_commitment = field::Empty,
+                    num_transactions = field::Empty,
+                )
+    )]
     pub async fn apply_block(&self, signed_block: SignedBlock) -> Result<(), ApplyBlockError> {
         let _lock = self.writer.try_lock().map_err(|_| ApplyBlockError::ConcurrentWrite)?;
 
@@ -81,6 +87,12 @@ impl State {
 
         let block_num = header.block_num();
         let block_commitment = header.commitment();
+        let num_transactions = body.transactions().as_slice().len();
+
+        let span = tracing::Span::current();
+        span.record("block_num", field::display(block_num));
+        span.record("block_commitment", field::display(block_commitment));
+        span.record("num_transactions", num_transactions);
 
         self.validate_block_header(header, body).await?;
 
@@ -186,7 +198,7 @@ impl State {
             .expect("block cache receives sequential block numbers");
         let _ = self.committed_tip_tx.send(block_num);
 
-        info!(%block_commitment, block_num = block_num.as_u32(), COMPONENT, "apply_block successful");
+        tracing::debug!(target: LOG_TARGET, "Block applied");
 
         Ok(())
     }

--- a/crates/store/src/state/bootstrap.rs
+++ b/crates/store/src/state/bootstrap.rs
@@ -7,7 +7,7 @@ use crate::blocks::BlockStore;
 use crate::db::Db;
 use crate::genesis::GenesisBlock;
 use crate::state::State;
-use crate::{COMPONENT, DataDirectory};
+use crate::{COMPONENT, DataDirectory, LOG_TARGET};
 
 impl State {
     /// Bootstraps the store state, creating the database state and inserting the genesis block
@@ -23,20 +23,20 @@ impl State {
             DataDirectory::load(data_directory.to_path_buf()).with_context(|| {
                 format!("failed to load data directory at {}", data_directory.display())
             })?;
-        tracing::info!(target=COMPONENT, path=%data_directory.display(), "Data directory loaded");
+        tracing::info!(target: LOG_TARGET, path=%data_directory.display(), "Data directory loaded");
 
         let block_store_path = data_directory.block_store_dir();
         let block_store =
             BlockStore::bootstrap(block_store_path.clone(), &genesis).with_context(|| {
                 format!("failed to bootstrap block store at {}", block_store_path.display())
             })?;
-        tracing::info!(target=COMPONENT, path=%block_store.display(), "Block store created");
+        tracing::info!(target: LOG_TARGET, path=%block_store.display(), "Block store created");
 
         let database_filepath = data_directory.database_path();
         Db::bootstrap(database_filepath.clone(), genesis).with_context(|| {
             format!("failed to bootstrap database at {}", database_filepath.display())
         })?;
-        tracing::info!(target=COMPONENT, path=%database_filepath.display(), "Database created");
+        tracing::info!(target: LOG_TARGET, path=%database_filepath.display(), "Database created");
 
         Ok(())
     }

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -32,11 +32,11 @@ use miden_protocol::{Felt, Word};
 use tracing::info;
 use tracing::instrument;
 
-use crate::COMPONENT;
 use crate::account_state_forest::AccountStateForest;
 use crate::db::Db;
 use crate::db::models::queries::BlockHeaderCommitment;
 use crate::errors::{DatabaseError, StateInitializationError};
+use crate::{COMPONENT, LOG_TARGET};
 
 // CONSTANTS
 // ================================================================================================
@@ -330,6 +330,7 @@ impl TreeStorageLoader for RocksDbStorage {
         db: &mut Db,
     ) -> Result<NullifierTree<LargeSmt<Self>>, StateInitializationError> {
         // If RocksDB storage has data, load from it directly
+
         let has_data = self
             .has_leaves()
             .map_err(|e| StateInitializationError::NullifierTreeIoError(e.to_string()))?;

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -277,6 +277,8 @@ impl TreeStorageLoader for RocksDbStorage {
         db: &mut Db,
     ) -> Result<AccountTree<LargeSmt<Self>>, StateInitializationError> {
         // If RocksDB storage has data, load from it directly
+
+        use crate::LOG_TARGET;
         let has_data = self
             .has_leaves()
             .map_err(|e| StateInitializationError::AccountTreeIoError(e.to_string()))?;
@@ -286,7 +288,7 @@ impl TreeStorageLoader for RocksDbStorage {
                 .map_err(StateInitializationError::FailedToCreateAccountsTree);
         }
 
-        info!(target: COMPONENT, "RocksDB account tree storage is empty, populating from SQLite");
+        info!(target: LOG_TARGET, "RocksDB account tree storage is empty, populating from SQLite");
 
         let mut smt = LargeSmt::with_entries(self, std::iter::empty())
             .map_err(account_tree_large_smt_error_to_init_error)?;
@@ -336,7 +338,7 @@ impl TreeStorageLoader for RocksDbStorage {
             return Ok(NullifierTree::new_unchecked(smt));
         }
 
-        info!(target: COMPONENT, "RocksDB nullifier tree storage is empty, populating from SQLite");
+        info!(target: LOG_TARGET, "RocksDB nullifier tree storage is empty, populating from SQLite");
 
         let mut smt = LargeSmt::with_entries(self, std::iter::empty())
             .map_err(account_tree_large_smt_error_to_init_error)?;
@@ -439,7 +441,7 @@ impl AccountForestLoader for ForestPersistentBackend {
         }
 
         info!(
-            target: COMPONENT,
+            target: LOG_TARGET,
             "RocksDB account state forest storage is empty, populating from SQLite"
         );
         rebuild_account_state_forest(&mut forest, db, block_num).await?;

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -21,7 +21,7 @@ use miden_protocol::crypto::merkle::smt::{LargeSmt, SmtStorage};
 use miden_protocol::note::{NoteId, NoteScript, Nullifier};
 use miden_protocol::transaction::PartialBlockchain;
 use tokio::sync::{Mutex, RwLock, watch};
-use tracing::{Instrument, Span, info, instrument};
+use tracing::{Instrument, Span, instrument};
 
 use crate::account_state_forest::{AccountStateForest, AccountStateForestBackend};
 use crate::accounts::AccountTreeWithHistory;
@@ -372,7 +372,7 @@ impl State {
     ///
     /// If [None] is given as the value of `block_num`, the data for the latest [BlockHeader] is
     /// returned.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn get_block_header(
         &self,
         block_num: Option<BlockNumber>,
@@ -655,15 +655,13 @@ impl State {
     }
 
     /// Returns data needed by the block producer to verify transactions validity.
-    #[instrument(target = COMPONENT, skip_all, ret)]
+    #[instrument(target = COMPONENT, skip_all, fields(account.id=%account_id, nullifiers = %format_array(nullifiers)))]
     pub async fn get_transaction_inputs(
         &self,
         account_id: AccountId,
         nullifiers: &[Nullifier],
         unauthenticated_note_commitments: Vec<Word>,
     ) -> Result<TransactionInputs, DatabaseError> {
-        info!(target: COMPONENT, account_id = %account_id.to_string(), nullifiers = %format_array(nullifiers));
-
         let tree_inputs = self.with_inner_read_blocking(|inner| {
             let account_commitment = inner.account_tree.get_latest_commitment(account_id);
 

--- a/crates/store/src/state/sync_state.rs
+++ b/crates/store/src/state/sync_state.rs
@@ -27,7 +27,7 @@ impl State {
     }
 
     /// Returns the chain MMR delta and the `block_to` block header for the specified block range.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn sync_chain_mmr(
         &self,
         block_range: RangeInclusive<BlockNumber>,
@@ -89,7 +89,7 @@ impl State {
     ///
     /// Also returns the last block number checked. If this equals `block_range.end()`, the
     /// sync is complete.
-    #[instrument(level = "debug", target = COMPONENT, skip_all, ret(level = "debug"), err)]
+    #[instrument(level = "debug", target = COMPONENT, skip_all, err)]
     pub async fn sync_notes(
         &self,
         note_tags: Vec<u32>,

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -11,7 +11,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::subscriber::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::{Filter, SubscriberExt};
-use tracing_subscriber::{Layer, Registry};
+use tracing_subscriber::{EnvFilter, Layer, Registry};
 
 use crate::tracing::OpenTelemetrySpanExt;
 
@@ -94,6 +94,45 @@ impl OpenTelemetry {
     }
 }
 
+/// Tracing subscriber configuration.
+#[derive(Clone)]
+pub struct TracingConfig {
+    pub open_telemetry: OpenTelemetry,
+    pub stdout_filter: String,
+    pub otel_filter: String,
+}
+
+impl TracingConfig {
+    #[must_use]
+    pub fn from_env(open_telemetry: OpenTelemetry) -> Self {
+        Self {
+            open_telemetry,
+            stdout_filter: filter_env_or_default("MIDEN_STDOUT_FILTER", "info,user=debug"),
+            otel_filter: filter_env_or_default("MIDEN_OTEL_FILTER", "info,axum::rejection=trace"),
+        }
+    }
+}
+
+fn filter_env_or_default(var: &str, default: &str) -> String {
+    std::env::var(var)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var(EnvFilter::DEFAULT_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| default.to_owned())
+}
+
+fn filter_from_string<S>(
+    filter: &str,
+) -> anyhow::Result<Box<dyn Filter<S> + Send + Sync + 'static>> {
+    use tracing_subscriber::filter::FilterExt;
+
+    Ok(FilterExt::boxed(EnvFilter::from_str(filter)?))
+}
+
 /// A guard that shuts down the tracer provider when dropped. This ensures that the logs are flushed
 /// to the exporter before the program exits.
 pub struct OtelGuard {
@@ -110,8 +149,9 @@ impl Drop for OtelGuard {
 
 /// Initializes tracing to stdout and optionally an open-telemetry exporter.
 ///
-/// Trace filtering defaults to `INFO` and can be configured using the conventional `RUST_LOG`
-/// environment variable.
+/// Stdout trace filtering is configured with `MIDEN_STDOUT_FILTER`, then `RUST_LOG`, then `info,user=debug`.
+/// OpenTelemetry export filtering is configured with `MIDEN_OTEL_FILTER`, then `RUST_LOG`, then
+/// `info,axum::rejection=trace`.
 ///
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)
@@ -121,6 +161,20 @@ impl Drop for OtelGuard {
 /// Returns an [`OtelGuard`] if open-telemetry is enabled, otherwise `None`. When this guard is
 /// dropped, the tracer provider is shutdown.
 pub fn setup_tracing(otel: OpenTelemetry) -> anyhow::Result<Option<OtelGuard>> {
+    setup_tracing_with_config(TracingConfig::from_env(otel))
+}
+
+/// Initializes tracing from explicit stdout and OpenTelemetry filter configuration.
+///
+/// Returns an [`OtelGuard`] if open-telemetry is enabled, otherwise `None`. When this guard is
+/// dropped, the tracer provider is shutdown.
+pub fn setup_tracing_with_config(config: TracingConfig) -> anyhow::Result<Option<OtelGuard>> {
+    let TracingConfig {
+        open_telemetry: otel,
+        stdout_filter,
+        otel_filter,
+    } = config;
+
     if otel.is_enabled() {
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     }
@@ -149,8 +203,8 @@ pub fn setup_tracing(otel: OpenTelemetry) -> anyhow::Result<Option<OtelGuard>> {
     });
 
     let subscriber = Registry::default()
-        .with(stdout_layer().with_filter(env_or_default_filter()))
-        .with(otel_layer.with_filter(env_or_default_filter()));
+        .with(stdout_layer().with_filter(filter_from_string(&stdout_filter)?))
+        .with(otel_layer.with_filter(filter_from_string(&otel_filter)?));
     tracing::subscriber::set_global_default(subscriber).map_err(Into::<anyhow::Error>::into)?;
 
     // Register panic hook now that tracing is initialized. This chains with the default panic hook
@@ -270,8 +324,8 @@ pub fn setup_test_tracing() -> anyhow::Result<(
     let otel_layer =
         OpenTelemetryLayer::new(tracer_provider.tracer("tracing-otel-subscriber")).boxed();
     let subscriber = Registry::default()
-        .with(stdout_layer().with_filter(env_or_default_filter()))
-        .with(otel_layer.with_filter(env_or_default_filter()));
+        .with(stdout_layer().with_filter(filter_from_string("debug")?))
+        .with(otel_layer.with_filter(filter_from_string("info,axum::rejection=trace")?));
     tracing::subscriber::set_global_default(subscriber)?;
     Ok((rx_export, rx_shutdown))
 }
@@ -282,16 +336,12 @@ where
     S: Subscriber,
     for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
 {
-    use tracing_subscriber::fmt::format::FmtSpan;
-
     tracing_subscriber::fmt::layer()
-        .pretty()
         .compact()
         .with_level(true)
-        .with_file(true)
-        .with_line_number(true)
-        .with_target(true)
-        .with_span_events(FmtSpan::CLOSE)
+        .with_file(false)
+        .with_line_number(false)
+        .with_target(false)
         .boxed()
 }
 
@@ -302,35 +352,6 @@ where
     for<'a> S: tracing_subscriber::registry::LookupSpan<'a>,
 {
     tracing_forest::ForestLayer::default().boxed()
-}
-
-/// Creates a filter from the `RUST_LOG` env var with a default of `INFO` if unset.
-///
-/// # Panics
-///
-/// Panics if `RUST_LOG` fails to parse.
-fn env_or_default_filter<S>() -> Box<dyn Filter<S> + Send + Sync + 'static> {
-    use tracing::level_filters::LevelFilter;
-    use tracing_subscriber::EnvFilter;
-    use tracing_subscriber::filter::{FilterExt, Targets};
-
-    // `tracing` does not allow differentiating between invalid and missing env var so we manually
-    // do this instead. The alternative is to silently ignore parsing errors which I think is worse.
-    match std::env::var(EnvFilter::DEFAULT_ENV) {
-        Ok(rust_log) => FilterExt::boxed(
-            EnvFilter::from_str(&rust_log)
-                .expect("RUST_LOG should contain a valid filter configuration"),
-        ),
-        Err(std::env::VarError::NotUnicode(_)) => panic!("RUST_LOG contained non-unicode"),
-        Err(std::env::VarError::NotPresent) => {
-            // Default level is INFO, and additionally enable logs from axum extractor rejections.
-            FilterExt::boxed(
-                Targets::new()
-                    .with_default(LevelFilter::INFO)
-                    .with_target("axum::rejection", LevelFilter::TRACE),
-            )
-        },
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR is the first part of a series of PRs implementing the solution outlined in issue #1406.

This separates user-visible stdout logging from production telemetry by giving stdout its own filter and moving local-development messages onto `user::` log targets.

### Changes

- Add separate tracing filters for stdout and OpenTelemetry:
  - `MIDEN_STDOUT_FILTER`, falling back to `RUST_LOG`, then `info,user=debug`
  - `MIDEN_OTEL_FILTER`, falling back to `RUST_LOG`, then `info,axum::rejection=trace`
- Keep stdout formatting compact and focused on user-visible output.
- Add `user::...` log targets for node, remote prover, validator, block producer, RPC, and store components.
- Move local-development state/action logs to `debug!` events on `user::` targets.
- Keep telemetry-oriented attributes on spans so they remain available to OpenTelemetry exporters.
- Add per-handler RPC spans and record request-derived fields such as account IDs, block ranges, transaction IDs, and reference blocks after parsing.
- Reduce noisy emitted events by moving verbose request payloads and internal details to `trace!`.
- Remove several verbose `ret(level = "debug")` instrumented return logs from store queries.
- Clean up block producer and store tracing around block application, transaction input loading, proof scheduling, and RPC/store connectivity.

### Notes

The default stdout behavior now shows normal `info` logs plus user-targeted `debug` events, without raising debug verbosity for production telemetry. OpenTelemetry keeps its own independent filter so span export behavior can be tuned separately from local console output.


## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "general"
impact      = "changed"
description = "Logs printed to standard output have been changed to be human readable. gRPC requests and internal state changes should be now visible."
```
