### PR TITLE
feat(sequencer): dynamic batch production

### DIFF
--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -106,7 +106,7 @@ mod tests {
 
 #[derive(clap::Args, Clone, Debug)]
 pub struct BatchOptions {
-    /// Interval at which to produce batches.
+    /// Maximum interval between batch scheduler checks.
     #[arg(
         id = "batch.interval",
         long = "batch.interval",

--- a/bin/node/src/commands/block_producer.rs
+++ b/bin/node/src/commands/block_producer.rs
@@ -31,14 +31,14 @@ pub struct BlockProducerOptions {
 
 impl BlockProducerOptions {
     pub fn validate(&self) -> anyhow::Result<()> {
-        if self.block.max_batches > miden_protocol::MAX_BATCHES_PER_BLOCK {
+        if self.block.max_batches.get() > miden_protocol::MAX_BATCHES_PER_BLOCK {
             anyhow::bail!(
                 "block.max-batches cannot exceed protocol limit of {}",
                 miden_protocol::MAX_BATCHES_PER_BLOCK
             );
         }
 
-        if self.batch.max_txs > miden_protocol::MAX_ACCOUNTS_PER_BATCH {
+        if self.batch.max_txs.get() > miden_protocol::MAX_ACCOUNTS_PER_BATCH {
             anyhow::bail!(
                 "batch.max-txs cannot exceed protocol limit of {}",
                 miden_protocol::MAX_ACCOUNTS_PER_BATCH
@@ -51,6 +51,8 @@ impl BlockProducerOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use super::{
         BatchOptions,
         BlockOptions,
@@ -68,12 +70,12 @@ mod tests {
         BlockProducerOptions {
             batch: BatchOptions {
                 interval: DEFAULT_BATCH_INTERVAL,
-                max_txs,
+                max_txs: NonZeroUsize::new(max_txs).unwrap(),
                 prover_url: None,
             },
             block: BlockOptions {
                 interval: DEFAULT_BLOCK_INTERVAL,
-                max_batches,
+                max_batches: NonZeroUsize::new(max_batches).unwrap(),
                 max_concurrent_proofs: miden_node_block_producer::DEFAULT_MAX_CONCURRENT_PROOFS,
             },
             block_prover: BlockProverOptions { url: None },
@@ -86,7 +88,7 @@ mod tests {
     #[test]
     fn rejects_too_large_max_batches_per_block() {
         let too_large = miden_protocol::MAX_BATCHES_PER_BLOCK + 1;
-        let err = options(too_large, DEFAULT_MAX_TXS_PER_BATCH)
+        let err = options(too_large, DEFAULT_MAX_TXS_PER_BATCH.get())
             .validate()
             .expect_err("protocol limit should be enforced");
 
@@ -127,7 +129,7 @@ pub struct BatchOptions {
         default_value_t = DEFAULT_MAX_TXS_PER_BATCH,
         help_heading = super::section::BLOCK_PRODUCTION_HELP_HEADING
     )]
-    pub max_txs: usize,
+    pub max_txs: NonZeroUsize,
 
     /// The remote batch prover gRPC URL. If unset, a local prover will be used.
     #[arg(
@@ -163,7 +165,7 @@ pub struct BlockOptions {
         default_value_t = DEFAULT_MAX_BATCHES_PER_BLOCK,
         help_heading = super::section::BLOCK_PRODUCTION_HELP_HEADING
     )]
-    pub max_batches: usize,
+    pub max_batches: NonZeroUsize,
 
     /// Maximum number of concurrent block proofs to be scheduled.
     #[arg(

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -13,8 +13,8 @@ use miden_protocol::batch::{BatchId, ProposedBatch, ProvenBatch};
 use miden_remote_prover_client::RemoteBatchProver;
 use miden_tx_batch_prover::LocalBatchProver;
 use rand::Rng;
-use tokio::task::JoinSet;
-use tokio::time;
+use tokio::task::{JoinError, JoinSet};
+use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{Instrument, Span, instrument};
 use url::Url;
 
@@ -29,18 +29,14 @@ use crate::{COMPONENT, TelemetryInjectorExt};
 
 /// Builds [`ProvenBatch`] from sets of transactions.
 ///
-/// Transaction sets are pulled from the mempool at a configurable interval, and passed to
-/// a pool of provers for proof generation. Proving is currently unimplemented and is instead
-/// simulated via the given proof time and failure rate.
+/// Transaction sets are pulled from the mempool dynamically, and passed to a pool of provers for
+/// proof generation. Full batches are built immediately; partial batches are delayed briefly to
+/// give more transactions time to arrive.
 pub struct BatchBuilder {
-    /// Represents all batch building workers.
-    ///
-    /// This pool is always at maximum capacity. Idle workers will be in a [`std::future::Ready`]
-    /// state and are immediately available for a new batch building job.
-    ///
-    /// See also: [`BatchBuilder::wait_for_available_worker`].
-    worker_pool: JoinSet<Result<(), BuildBatchError>>,
-    batch_interval: Duration,
+    /// Batch building jobs currently running.
+    active_jobs: JoinSet<Result<(), BuildBatchError>>,
+    num_workers: NonZeroUsize,
+    intervals: BatchIntervals,
     /// The batch prover to use.
     ///
     /// If not provided, a local batch prover is used.
@@ -52,6 +48,36 @@ pub struct BatchBuilder {
     store: Arc<State>,
 }
 
+pub(crate) struct BatchIntervals {
+    /// Maximum time between spawned batch jobs before an any-size batch is attempted.
+    max_batch_interval: Duration,
+    /// How often the scheduler wakes to check whether a full batch can be spawned.
+    full_batch_check_interval: Duration,
+}
+
+impl BatchIntervals {
+    const MIN_SCHEDULER_INTERVAL: Duration = Duration::from_millis(50);
+
+    /// Derives batch scheduler intervals from the block and legacy batch intervals.
+    ///
+    /// Full batches are produced as often as possible, but a batch is attempted at
+    /// least every `batch_interval` if traffic is low.
+    pub(crate) fn derive_from(block_interval: Duration, batch_interval: Duration) -> Self {
+        let max_batch_interval = (block_interval / 2).max(Self::MIN_SCHEDULER_INTERVAL);
+        let full_batch_check_interval = (max_batch_interval / 10).max(Self::MIN_SCHEDULER_INTERVAL);
+        let full_batch_check_interval = if batch_interval.is_zero() {
+            full_batch_check_interval
+        } else {
+            full_batch_check_interval.min(batch_interval)
+        };
+
+        BatchIntervals {
+            max_batch_interval,
+            full_batch_check_interval,
+        }
+    }
+}
+
 impl BatchBuilder {
     /// Creates a new [`BatchBuilder`] with the given batch prover URL and maximum concurrent batch
     /// building workers.
@@ -61,53 +87,66 @@ impl BatchBuilder {
         store: Arc<State>,
         num_workers: NonZeroUsize,
         batch_prover_url: Option<Url>,
-        batch_interval: Duration,
+        intervals: BatchIntervals,
     ) -> Self {
         let batch_prover = batch_prover_url
             .map_or(BatchProver::local(MIN_PROOF_SECURITY_LEVEL), BatchProver::remote);
 
-        // It is important that the worker pool is filled to capacity with ready workers. See
-        // `Self::worker_pool` and `Self::wait_for_available_worker` for more context.
-        let worker_pool = (0..num_workers.get()).map(|_| std::future::ready(Ok(()))).collect();
-
         Self {
-            batch_interval,
-            worker_pool,
+            active_jobs: JoinSet::new(),
+            num_workers,
+            intervals,
             failure_rate: 0.0,
             batch_prover,
             store,
         }
     }
 
-    /// Starts the [`BatchBuilder`], creating and proving batches at the configured interval.
+    /// Starts the [`BatchBuilder`], creating and proving batches dynamically.
     ///
-    /// A pool of batch-proving workers is spawned, which are fed new batch jobs periodically.
-    /// A batch is skipped if there are no available workers, or if there are no transactions
-    /// available to batch.
+    /// Full batches are spawned on each check and job completion. A batch of any size is attempted
+    /// when no batch has been spawned for the maximum batch interval.
     pub async fn run(mut self, mempool: SharedMempool) -> anyhow::Result<()> {
         assert!(
             self.failure_rate < 1.0 && self.failure_rate.is_sign_positive(),
             "Failure rate must be a percentage"
         );
 
-        let mut interval = tokio::time::interval(self.batch_interval);
-        // We set the interval's missed tick behaviour to burst. This means we'll catch up missed
-        // batches as fast as possible. In other words, we try our best to keep the desired batch
-        // interval on average. The other options would result in at least one skipped batch.
-        interval.set_missed_tick_behavior(time::MissedTickBehavior::Burst);
+        let mut last_spawn = Instant::now();
+        let mut full_batch_check = tokio::time::interval(self.intervals.full_batch_check_interval);
+        full_batch_check.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
-            interval.tick().await;
-            self.build_batch(mempool.clone()).await?;
+            // Force a batch attempt after the maximum interval, even if it is partial.
+            let force_at = tokio::time::sleep_until(last_spawn + self.intervals.max_batch_interval);
+            let has_available_worker = self.has_available_worker();
+            let has_active_job = !self.active_jobs.is_empty();
+
+            tokio::select! {
+                _ = force_at => {
+                    last_spawn = Instant::now();
+                    if has_available_worker {
+                        self.spawn_any_batch_job(mempool.clone())?;
+                    }
+                },
+                result = self.active_jobs.join_next(), if has_active_job => {
+                    Self::handle_job_result(result.expect("active job set is not empty"))?;
+                },
+                _ = full_batch_check.tick() => {},
+            }
+
+            while self.has_available_worker() && self.spawn_full_batch_job(mempool.clone())? {
+                last_spawn = Instant::now();
+            }
         }
     }
 
     #[instrument(parent = None, target = COMPONENT, name = "batch_builder.build_batch", skip_all)]
-    async fn build_batch(&mut self, mempool: SharedMempool) -> Result<(), BuildBatchError> {
-        Span::current().set_attribute("workers.count", self.worker_pool.len());
+    fn build_batch(&mut self, mempool: SharedMempool, batch: SelectedBatch) {
+        Span::current().set_attribute("workers.active", self.active_jobs.len());
+        Span::current().set_attribute("workers.capacity", self.num_workers.get());
 
-        self.wait_for_available_worker().await?;
-
+        batch.inject_telemetry();
         let job = BatchJob {
             failure_rate: self.failure_rate,
             store: self.store.clone(),
@@ -115,28 +154,49 @@ impl BatchBuilder {
             batch_prover: self.batch_prover.clone(),
         };
 
-        self.worker_pool
-            .spawn(async move { job.build_batch().await }.instrument(tracing::Span::current()));
-
-        Ok(())
+        self.active_jobs.spawn(
+            async move { job.build_batch(batch).await }.instrument(tracing::Span::current()),
+        );
     }
 
-    /// Waits for a new batch building worker to become available.
-    ///
-    /// The worker pool is _always_ at full capacity because:
-    ///   - It is instantiated with a full cohort of [`std::future::ready()`].
-    ///   - This function removes a worker but it's _always_ added afterwards again in
-    ///     `build_batch`, keeping the pool at capacity.
-    ///
-    /// An alternate implementation might instead check the currently active jobs, but this would
-    /// require the same logic as here to handle the case when the pool is at capacity. This
-    /// design was chosen instead as it removes this branching logic by "always" having the pool
-    /// at max capacity. Instead completed workers wait to be culled by this function.
-    #[instrument(target = COMPONENT, name = "batch_builder.wait_for_available_worker", skip_all)]
-    async fn wait_for_available_worker(&mut self) -> Result<(), BuildBatchError> {
-        // We must crash here because otherwise we have a batch that has been selected from the
-        // mempool, but which is now in limbo. This effectively corrupts the mempool.
-        match self.worker_pool.join_next().await.expect("worker pool is never empty") {
+    fn spawn_full_batch_job(&mut self, mempool: SharedMempool) -> Result<bool, BuildBatchError> {
+        let Some(batch) = Self::select_full_batch(&mempool)? else {
+            return Ok(false);
+        };
+
+        self.build_batch(mempool, batch);
+        Ok(true)
+    }
+
+    fn spawn_any_batch_job(&mut self, mempool: SharedMempool) -> Result<bool, BuildBatchError> {
+        let Some(batch) = Self::select_any_batch(&mempool)? else {
+            return Ok(false);
+        };
+
+        self.build_batch(mempool, batch);
+        Ok(true)
+    }
+
+    #[instrument(target = COMPONENT, name = "batch_builder.select_full_batch", skip_all)]
+    fn select_full_batch(
+        mempool: &SharedMempool,
+    ) -> Result<Option<SelectedBatch>, BuildBatchError> {
+        Ok(mempool.lock().map_err(BuildBatchError::MempoolPoisoned)?.select_full_batch())
+    }
+
+    #[instrument(target = COMPONENT, name = "batch_builder.select_any_batch", skip_all)]
+    fn select_any_batch(mempool: &SharedMempool) -> Result<Option<SelectedBatch>, BuildBatchError> {
+        Ok(mempool.lock().map_err(BuildBatchError::MempoolPoisoned)?.select_any_batch())
+    }
+
+    fn has_available_worker(&self) -> bool {
+        self.active_jobs.len() < self.num_workers.get()
+    }
+
+    fn handle_job_result(
+        result: Result<Result<(), BuildBatchError>, JoinError>,
+    ) -> Result<(), BuildBatchError> {
+        match result {
             Ok(Ok(())) => Ok(()),
             Ok(Err(err)) => Err(err),
             Err(crash) => {
@@ -152,8 +212,8 @@ impl BatchBuilder {
 
 /// Represents a single batch building job.
 ///
-/// It is entirely self-contained and performs the full batch creation flow, from selecting the
-/// batch from the [`Mempool`] up to and including submitting the results back to the [`Mempool`].
+/// It is entirely self-contained and performs the full batch creation flow, from fetching the
+/// selected batch's inputs up to and including submitting the results back to the [`Mempool`].
 ///
 /// Recoverable errors are handled internally. Mempool poison is propagated as a fatal error.
 struct BatchJob {
@@ -167,13 +227,7 @@ struct BatchJob {
 }
 
 impl BatchJob {
-    async fn build_batch(&self) -> Result<(), BuildBatchError> {
-        let Some(batch) = self.select_batch()? else {
-            tracing::info!("No transactions available.");
-            return Ok(());
-        };
-
-        batch.inject_telemetry();
+    async fn build_batch(&self, batch: SelectedBatch) -> Result<(), BuildBatchError> {
         let batch_id = batch.id();
 
         let result = self
@@ -181,7 +235,6 @@ impl BatchJob {
             .and_then(|(txs, inputs)| Self::propose_batch(txs, inputs))
             .inspect_ok(TelemetryInjectorExt::inject_telemetry)
             .and_then(|proposed| self.prove_batch(proposed))
-
             // Failure must be injected before the final pipeline stage i.e. before commit is
             // called. The system cannot handle errors after it considers the process complete
             // (which makes sense).
@@ -200,11 +253,6 @@ impl BatchJob {
                 Ok(())
             },
         }
-    }
-
-    #[instrument(target = COMPONENT, name = "batch_builder.select_batch", skip_all)]
-    fn select_batch(&self) -> Result<Option<SelectedBatch>, BuildBatchError> {
-        Ok(self.mempool.lock().map_err(BuildBatchError::MempoolPoisoned)?.select_batch())
     }
 
     #[instrument(target = COMPONENT, name = "batch_builder.get_batch_inputs", skip_all, err)]

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -58,13 +58,8 @@ impl BatchIntervals {
     /// Full batches are produced as often as possible, but a batch is attempted at
     /// least every `batch_interval` if traffic is low.
     pub(crate) fn derive_from(block_interval: Duration, batch_interval: Duration) -> Self {
-        let max_batch_interval = (block_interval / 2).max(Self::MIN_SCHEDULER_INTERVAL);
-        let full_batch_check_interval = (max_batch_interval / 10).max(Self::MIN_SCHEDULER_INTERVAL);
-        let full_batch_check_interval = if batch_interval.is_zero() {
-            full_batch_check_interval
-        } else {
-            full_batch_check_interval.min(batch_interval)
-        };
+        let max_batch_interval = batch_interval.max(Self::MIN_SCHEDULER_INTERVAL);
+        let full_batch_check_interval = (block_interval / 10).max(Self::MIN_SCHEDULER_INTERVAL);
 
         BatchIntervals {
             max_batch_interval,

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -12,7 +12,6 @@ use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{BatchId, ProposedBatch, ProvenBatch};
 use miden_remote_prover_client::RemoteBatchProver;
 use miden_tx_batch_prover::LocalBatchProver;
-use rand::Rng;
 use tokio::task::{JoinError, JoinSet};
 use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{Instrument, Span, instrument};
@@ -41,10 +40,6 @@ pub struct BatchBuilder {
     ///
     /// If not provided, a local batch prover is used.
     batch_prover: BatchProver,
-    /// Simulated block failure rate as a percentage.
-    ///
-    /// Note: this _must_ be sign positive and less than 1.0.
-    failure_rate: f64,
     store: Arc<State>,
 }
 
@@ -96,7 +91,6 @@ impl BatchBuilder {
             active_jobs: JoinSet::new(),
             num_workers,
             intervals,
-            failure_rate: 0.0,
             batch_prover,
             store,
         }
@@ -107,11 +101,6 @@ impl BatchBuilder {
     /// Full batches are spawned on each check and job completion. A batch of any size is attempted
     /// when no batch has been spawned for the maximum batch interval.
     pub async fn run(mut self, mempool: SharedMempool) -> anyhow::Result<()> {
-        assert!(
-            self.failure_rate < 1.0 && self.failure_rate.is_sign_positive(),
-            "Failure rate must be a percentage"
-        );
-
         let mut last_spawn = Instant::now();
         let mut full_batch_check = tokio::time::interval(self.intervals.full_batch_check_interval);
         full_batch_check.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -148,7 +137,6 @@ impl BatchBuilder {
 
         batch.inject_telemetry();
         let job = BatchJob {
-            failure_rate: self.failure_rate,
             store: self.store.clone(),
             mempool,
             batch_prover: self.batch_prover.clone(),
@@ -217,10 +205,6 @@ impl BatchBuilder {
 ///
 /// Recoverable errors are handled internally. Mempool poison is propagated as a fatal error.
 struct BatchJob {
-    /// Simulated block failure rate as a percentage.
-    ///
-    /// Note: this _must_ be sign positive and less than 1.0.
-    failure_rate: f64,
     store: Arc<State>,
     batch_prover: BatchProver,
     mempool: SharedMempool,
@@ -235,10 +219,6 @@ impl BatchJob {
             .and_then(|(txs, inputs)| Self::propose_batch(txs, inputs))
             .inspect_ok(TelemetryInjectorExt::inject_telemetry)
             .and_then(|proposed| self.prove_batch(proposed))
-            // Failure must be injected before the final pipeline stage i.e. before commit is
-            // called. The system cannot handle errors after it considers the process complete
-            // (which makes sense).
-            .and_then(|x| self.inject_failure(x))
             .and_then(|proven_batch| async { self.commit_batch(proven_batch) })
             // Handle errors by propagating the error to the root span and rolling back the batch.
             .inspect_err(|err| Span::current().set_error(err))
@@ -331,20 +311,6 @@ impl BatchJob {
             ))
         } else {
             Ok(Arc::new(proven_batch))
-        }
-    }
-
-    #[instrument(target = COMPONENT, name = "batch_builder.inject_failure", skip_all, err)]
-    async fn inject_failure<T>(&self, value: T) -> Result<T, BuildBatchError> {
-        let roll = rand::rng().random::<f64>();
-
-        Span::current().set_attribute("failure_rate", self.failure_rate);
-        Span::current().set_attribute("dice_roll", roll);
-
-        if roll < self.failure_rate {
-            Err(BuildBatchError::InjectedFailure)
-        } else {
-            Ok(value)
         }
     }
 

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -23,11 +23,6 @@ pub struct BlockBuilder {
     /// The frequency at which blocks are produced.
     pub block_interval: Duration,
 
-    /// Simulated block failure rate as a percentage.
-    ///
-    /// Note: this _must_ be sign positive and less than 1.0.
-    pub failure_rate: f64,
-
     /// The store state for committing blocks.
     pub store: Arc<State>,
 
@@ -44,13 +39,7 @@ impl BlockBuilder {
         validator: BlockProducerValidatorClient,
         block_interval: Duration,
     ) -> Self {
-        Self {
-            block_interval,
-            // Note: The range cannot be empty.
-            failure_rate: 0.0,
-            store,
-            validator,
-        }
+        Self { block_interval, store, validator }
     }
     /// Starts the [`BlockBuilder`], infinitely producing blocks at the configured interval.
     ///
@@ -63,11 +52,6 @@ impl BlockBuilder {
     ///   3. Proving the block (this is simulated using random sleeps)
     ///   4. Committing the block to the store
     pub async fn run(self, mempool: SharedMempool) -> anyhow::Result<()> {
-        assert!(
-            self.failure_rate < 1.0 && self.failure_rate.is_sign_positive(),
-            "Failure rate must be a percentage"
-        );
-
         let mut interval = tokio::time::interval(self.block_interval);
         // We set the interval's missed tick behaviour to burst. This means we'll catch up missed
         // blocks as fast as possible. In other words, we try our best to keep the desired block

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -96,11 +96,6 @@ pub enum StateConflict {
 /// Error encountered while building a batch.
 #[derive(Debug, Error)]
 pub enum BuildBatchError {
-    /// We sometimes randomly inject errors into the batch building process to test our failure
-    /// responses.
-    #[error("nothing actually went wrong, failure was injected on purpose")]
-    InjectedFailure,
-
     #[error("batch proving task panic'd")]
     JoinError(#[from] tokio::task::JoinError),
 
@@ -152,9 +147,6 @@ pub enum BuildBlockError {
 
     #[error("mempool lock is poisoned")]
     MempoolPoisoned(#[source] MempoolPoisonError),
-
-    /// We sometimes randomly inject errors into the batch building process to test our failure
-    /// responses.
 
     /// Custom error variant for errors not covered by the other variants.
     #[error("{error_msg}")]

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -40,10 +40,10 @@ pub use server::{
 pub const COMPONENT: &str = "miden-block-producer";
 
 /// The number of transactions per batch.
-pub const DEFAULT_MAX_TXS_PER_BATCH: usize = 8;
+pub const DEFAULT_MAX_TXS_PER_BATCH: NonZeroUsize = NonZeroUsize::new(8).unwrap();
 
 /// Maximum number of batches per block.
-pub const DEFAULT_MAX_BATCHES_PER_BLOCK: usize = 8;
+pub const DEFAULT_MAX_BATCHES_PER_BLOCK: NonZeroUsize = NonZeroUsize::new(8).unwrap();
 
 /// Size of the batch building worker pool.
 const SERVER_NUM_BATCH_BUILDERS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
@@ -81,19 +81,19 @@ pub const DEFAULT_VALIDATOR_TIMEOUT: Duration = Duration::from_secs(30);
 /// minutes with a block time of 5s.
 #[expect(clippy::cast_sign_loss, reason = "Both durations are positive")]
 pub const DEFAULT_MEMPOOL_TX_CAPACITY: NonZeroUsize = NonZeroUsize::new(
-    DEFAULT_MAX_BATCHES_PER_BLOCK
-        * DEFAULT_MAX_TXS_PER_BATCH
+    DEFAULT_MAX_BATCHES_PER_BLOCK.get()
+        * DEFAULT_MAX_TXS_PER_BATCH.get()
         * (Duration::from_secs(60).div_duration_f32(DEFAULT_BLOCK_INTERVAL)) as usize,
 )
 .unwrap();
 
 const _: () = assert!(
-    DEFAULT_MAX_BATCHES_PER_BLOCK <= miden_protocol::MAX_BATCHES_PER_BLOCK,
+    DEFAULT_MAX_BATCHES_PER_BLOCK.get() <= miden_protocol::MAX_BATCHES_PER_BLOCK,
     "Server constraint cannot exceed the protocol's constraint"
 );
 
 const _: () = assert!(
-    DEFAULT_MAX_TXS_PER_BATCH <= miden_protocol::MAX_ACCOUNTS_PER_BATCH,
+    DEFAULT_MAX_TXS_PER_BATCH.get() <= miden_protocol::MAX_ACCOUNTS_PER_BATCH,
     "Server constraint cannot exceed the protocol's constraint"
 );
 

--- a/crates/block-producer/src/lib.rs
+++ b/crates/block-producer/src/lib.rs
@@ -66,7 +66,7 @@ const CACHED_MEMPOOL_STATS_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 /// How often a block is created.
 pub const DEFAULT_BLOCK_INTERVAL: Duration = Duration::from_secs(3);
 
-/// How often a batch is created.
+/// Maximum interval between batch scheduler checks.
 pub const DEFAULT_BATCH_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The request timeout for the sequencer's `sign_block` call to the validator.

--- a/crates/block-producer/src/mempool/budget.rs
+++ b/crates/block-producer/src/mempool/budget.rs
@@ -54,6 +54,14 @@ impl Default for BlockBudget {
 }
 
 impl BatchBudget {
+    /// Returns `true` if no more transaction resources can be consumed from this budget.
+    pub(crate) fn is_exhausted(&self) -> bool {
+        self.transactions == 0
+            || self.input_notes == 0
+            || self.output_notes == 0
+            || self.accounts == 0
+    }
+
     /// Attempts to consume the transaction's resources from the budget.
     ///
     /// Returns [`BudgetStatus::Exceeded`] if the transaction would exceed the remaining budget,

--- a/crates/block-producer/src/mempool/budget.rs
+++ b/crates/block-producer/src/mempool/budget.rs
@@ -39,7 +39,7 @@ pub(crate) enum BudgetStatus {
 impl Default for BatchBudget {
     fn default() -> Self {
         Self {
-            transactions: DEFAULT_MAX_TXS_PER_BATCH,
+            transactions: DEFAULT_MAX_TXS_PER_BATCH.get(),
             input_notes: MAX_INPUT_NOTES_PER_BATCH,
             output_notes: MAX_OUTPUT_NOTES_PER_BATCH,
             accounts: MAX_ACCOUNTS_PER_BATCH,
@@ -49,7 +49,9 @@ impl Default for BatchBudget {
 
 impl Default for BlockBudget {
     fn default() -> Self {
-        Self { batches: DEFAULT_MAX_BATCHES_PER_BLOCK }
+        Self {
+            batches: DEFAULT_MAX_BATCHES_PER_BLOCK.get(),
+        }
     }
 }
 

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -150,7 +150,7 @@ impl TransactionGraph {
                 // Full-batch selection is speculative; partial selections must not reserve txs.
                 self.deselect_batch(batch);
                 None
-            },
+            }
             BatchSelection::Empty => None,
         }
     }
@@ -207,33 +207,36 @@ impl TransactionGraph {
     fn select_internal_batch(&mut self, mut budget: BatchBudget) -> BatchSelection {
         let mut selected = SelectedBatch::builder();
 
-        loop {
+        'outer: loop {
             // Select arbitrary candidate which is _not_ part of a user batch.
             let candidates = self.inner.selection_candidates();
-            let Some(candidate) =
-                candidates.values().find(|tx| !self.user_batches.contains_tx(&tx.id()))
-            else {
-                break;
-            };
 
-            if budget.check_then_subtract(candidate) == BudgetStatus::Exceeded {
-                assert!(
-                    !selected.is_empty(),
-                    "selectable transaction {} exceeds the batch budget; \
-                     candidate resources: transactions=1, accounts=1, input_notes={}, \
-                     output_notes={}; batch budget: {:?}",
-                    candidate.id(),
-                    candidate.input_note_count(),
-                    candidate.output_note_count(),
-                    budget,
-                );
+            for tx in candidates
+                .values()
+                .filter(|tx| !self.user_batches.contains_tx(&tx.id()))
+            {
+                if budget.check_then_subtract(tx) == BudgetStatus::Exceeded {
+                    assert!(
+                        !selected.is_empty(),
+                        "selectable transaction {} exceeds the batch budget; \
+                         candidate resources: transactions=1, accounts=1, input_notes={}, \
+                         output_notes={}; batch budget: {:?}",
+                        tx.id(),
+                        tx.input_note_count(),
+                        tx.output_note_count(),
+                        budget,
+                    );
 
-                return BatchSelection::Full(selected.build());
+                    continue;
+                }
+
+                let candidate = Arc::clone(tx);
+                self.inner.select_candidate(candidate.id());
+                selected.push(candidate);
+                continue 'outer;
             }
 
-            let candidate = Arc::clone(candidate);
-            self.inner.select_candidate(candidate.id());
-            selected.push(candidate);
+            break;
         }
 
         if selected.is_empty() {
@@ -387,7 +390,10 @@ impl TransactionGraph {
 
         let tx_id = tx.id();
         let descendants = self.inner.descendants(&tx_id);
-        for descendant in descendants.into_iter().filter(|descendant| *descendant != tx_id) {
+        for descendant in descendants
+            .into_iter()
+            .filter(|descendant| *descendant != tx_id)
+        {
             if let Some(descendant) = self.inner.get_mut(&descendant) {
                 Arc::make_mut(descendant).mark_notes_authenticated(output_notes.iter().copied());
             }

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -150,7 +150,7 @@ impl TransactionGraph {
                 // Full-batch selection is speculative; partial selections must not reserve txs.
                 self.deselect_batch(batch);
                 None
-            }
+            },
             BatchSelection::Empty => None,
         }
     }
@@ -211,10 +211,7 @@ impl TransactionGraph {
             // Select arbitrary candidate which is _not_ part of a user batch.
             let candidates = self.inner.selection_candidates();
 
-            for tx in candidates
-                .values()
-                .filter(|tx| !self.user_batches.contains_tx(&tx.id()))
-            {
+            for tx in candidates.values().filter(|tx| !self.user_batches.contains_tx(&tx.id())) {
                 if budget.check_then_subtract(tx) == BudgetStatus::Exceeded {
                     assert!(
                         !selected.is_empty(),
@@ -390,10 +387,7 @@ impl TransactionGraph {
 
         let tx_id = tx.id();
         let descendants = self.inner.descendants(&tx_id);
-        for descendant in descendants
-            .into_iter()
-            .filter(|descendant| *descendant != tx_id)
-        {
+        for descendant in descendants.into_iter().filter(|descendant| *descendant != tx_id) {
             if let Some(descendant) = self.inner.get_mut(&descendant) {
                 Arc::make_mut(descendant).mark_notes_authenticated(output_notes.iter().copied());
             }

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -16,6 +16,21 @@ use crate::mempool::budget::BudgetStatus;
 use crate::mempool::graph::dag::Graph;
 use crate::mempool::graph::node::GraphNode;
 
+enum BatchSelection {
+    Empty,
+    Partial(SelectedBatch),
+    Full(SelectedBatch),
+}
+
+impl BatchSelection {
+    fn into_batch(self) -> Option<SelectedBatch> {
+        match self {
+            Self::Empty => None,
+            Self::Partial(batch) | Self::Full(batch) => Some(batch),
+        }
+    }
+}
+
 // TRANSACTION GRAPH NODE
 // ================================================================================================
 
@@ -119,8 +134,31 @@ impl TransactionGraph {
         Ok(())
     }
 
-    pub fn select_batch(&mut self, budget: BatchBudget) -> Option<SelectedBatch> {
-        self.select_user_batch().or_else(|| self.select_internal_batch(budget))
+    pub fn select_any_batch(&mut self, budget: BatchBudget) -> Option<SelectedBatch> {
+        self.select_user_batch()
+            .or_else(|| self.select_internal_batch(budget).into_batch())
+    }
+
+    pub fn select_full_batch(&mut self, budget: BatchBudget) -> Option<SelectedBatch> {
+        if let Some(user_batch) = self.select_user_batch() {
+            return Some(user_batch);
+        }
+
+        match self.select_internal_batch(budget) {
+            BatchSelection::Full(batch) => Some(batch),
+            BatchSelection::Partial(batch) => {
+                // Full-batch selection is speculative; partial selections must not reserve txs.
+                self.deselect_batch(batch);
+                None
+            },
+            BatchSelection::Empty => None,
+        }
+    }
+
+    fn deselect_batch(&mut self, batch: SelectedBatch) {
+        for tx in batch.into_transactions().into_iter().rev() {
+            self.inner.deselect(tx.id());
+        }
     }
 
     fn select_user_batch(&mut self) -> Option<SelectedBatch> {
@@ -166,7 +204,7 @@ impl TransactionGraph {
         Some(selected.build())
     }
 
-    fn select_internal_batch(&mut self, mut budget: BatchBudget) -> Option<SelectedBatch> {
+    fn select_internal_batch(&mut self, mut budget: BatchBudget) -> BatchSelection {
         let mut selected = SelectedBatch::builder();
 
         loop {
@@ -179,7 +217,18 @@ impl TransactionGraph {
             };
 
             if budget.check_then_subtract(candidate) == BudgetStatus::Exceeded {
-                break;
+                assert!(
+                    !selected.is_empty(),
+                    "selectable transaction {} exceeds the batch budget; \
+                     candidate resources: transactions=1, accounts=1, input_notes={}, \
+                     output_notes={}; batch budget: {:?}",
+                    candidate.id(),
+                    candidate.input_note_count(),
+                    candidate.output_note_count(),
+                    budget,
+                );
+
+                return BatchSelection::Full(selected.build());
             }
 
             let candidate = Arc::clone(candidate);
@@ -188,11 +237,14 @@ impl TransactionGraph {
         }
 
         if selected.is_empty() {
-            return None;
+            BatchSelection::Empty
+        } else if budget.is_exhausted() {
+            // The selected transactions may exactly consume the budget without another candidate
+            // being available to trigger the "would exceed" branch above.
+            BatchSelection::Full(selected.build())
+        } else {
+            BatchSelection::Partial(selected.build())
         }
-        let selected = selected.build();
-
-        Some(selected)
     }
 
     /// Reverts expired transactions and their descendants.

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -287,14 +287,29 @@ impl Mempool {
     /// Transactions are returned in a valid execution ordering.
     ///
     /// Returns `None` if no transactions are available.
-    #[instrument(target = COMPONENT, name = "mempool.select_batch", skip_all)]
-    pub fn select_batch(&mut self) -> Option<SelectedBatch> {
-        let batch = self.transactions.select_batch(self.config.batch_budget)?;
+    #[instrument(target = COMPONENT, name = "mempool.select_any_batch", skip_all)]
+    pub fn select_any_batch(&mut self) -> Option<SelectedBatch> {
+        let batch = self.transactions.select_any_batch(self.config.batch_budget)?;
+        Some(self.append_selected_batch(batch))
+    }
+
+    /// Returns a full set of transactions for the next batch.
+    ///
+    /// User batches count as full because they are externally chosen atomic batches.
+    /// Non-user batches are only returned when the selected set saturates the batch budget or when
+    /// another selectable transaction cannot fit into the remaining budget.
+    #[instrument(target = COMPONENT, name = "mempool.select_full_batch", skip_all)]
+    pub fn select_full_batch(&mut self) -> Option<SelectedBatch> {
+        let batch = self.transactions.select_full_batch(self.config.batch_budget)?;
+        Some(self.append_selected_batch(batch))
+    }
+
+    fn append_selected_batch(&mut self, batch: SelectedBatch) -> SelectedBatch {
         if let Err(err) = self.batches.append(batch.clone()) {
             panic!("failed to append batch to dependency graph: {}", err.as_report());
         }
         self.inject_telemetry();
-        Some(batch)
+        batch
     }
 
     /// Drops the proposed batch and all of its descendants.

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -81,6 +81,58 @@ fn full_batch_selection_returns_internal_batch_at_transaction_limit() {
     assert!(batch.transactions().contains(&tx_b));
 }
 
+#[test]
+fn internal_batch_selection_skips_candidates_exceeding_remaining_budget() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.batch_budget.output_notes = 3;
+
+    let parent = MockProvenTxBuilder::with_account_index(1000)
+        .private_notes_created_range(0..2)
+        .build();
+    let parent = Arc::new(AuthenticatedTransaction::from_inner(parent));
+    let (oversized, fitting) = output_budget_ordered_child_transactions();
+
+    uut.add_transaction(parent.clone()).unwrap();
+    uut.add_transaction(oversized.clone()).unwrap();
+    uut.add_transaction(fitting.clone()).unwrap();
+    let reference = uut.clone();
+
+    assert!(uut.select_full_batch().is_none());
+    assert_eq!(uut, reference);
+
+    let batch = uut.select_any_batch().unwrap();
+    assert_eq!(batch.transactions().len(), 2);
+    assert!(batch.transactions().contains(&parent));
+    assert!(batch.transactions().contains(&fitting));
+    assert!(!batch.transactions().contains(&oversized));
+}
+
+fn output_budget_ordered_child_transactions()
+-> (Arc<AuthenticatedTransaction>, Arc<AuthenticatedTransaction>) {
+    // Candidate selection is ordered by transaction ID, so find a deterministic pair where the
+    // oversized child is considered before the fitting child.
+    for oversized_account in 1001..1100 {
+        let oversized = MockProvenTxBuilder::with_account_index(oversized_account)
+            .unauthenticated_notes_range(0..1)
+            .private_notes_created_range(10..12)
+            .build();
+        let oversized = Arc::new(AuthenticatedTransaction::from_inner(oversized));
+
+        for fitting_account in 1100..1200 {
+            let fitting = MockProvenTxBuilder::with_account_index(fitting_account)
+                .unauthenticated_notes_range(1..2)
+                .build();
+            let fitting = Arc::new(AuthenticatedTransaction::from_inner(fitting));
+
+            if oversized.id() < fitting.id() {
+                return (oversized, fitting);
+            }
+        }
+    }
+
+    panic!("failed to find deterministic transaction ids for budget-ordering test");
+}
+
 // OTEL TRACE TESTS
 // ================================================================================================
 

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -48,6 +48,39 @@ impl Mempool {
     }
 }
 
+#[test]
+fn full_batch_selection_ignores_partial_internal_batch() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.batch_budget.transactions = 2;
+
+    let tx = MockProvenTxBuilder::with_account_index(100).build();
+    let tx = Arc::new(AuthenticatedTransaction::from_inner(tx));
+    uut.add_transaction(tx).unwrap();
+    let reference = uut.clone();
+
+    assert!(uut.select_full_batch().is_none());
+    assert_eq!(uut, reference);
+}
+
+#[test]
+fn full_batch_selection_returns_internal_batch_at_transaction_limit() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.batch_budget.transactions = 2;
+
+    let tx_a = MockProvenTxBuilder::with_account_index(101).build();
+    let tx_a = Arc::new(AuthenticatedTransaction::from_inner(tx_a));
+    let tx_b = MockProvenTxBuilder::with_account_index(102).build();
+    let tx_b = Arc::new(AuthenticatedTransaction::from_inner(tx_b));
+
+    uut.add_transaction(tx_a.clone()).unwrap();
+    uut.add_transaction(tx_b.clone()).unwrap();
+
+    let batch = uut.select_full_batch().unwrap();
+    assert_eq!(batch.transactions().len(), 2);
+    assert!(batch.transactions().contains(&tx_a));
+    assert!(batch.transactions().contains(&tx_b));
+}
+
 // OTEL TRACE TESTS
 // ================================================================================================
 
@@ -84,15 +117,15 @@ fn children_of_failed_batches_are_ignored() {
 
     let (mut uut, _) = Mempool::for_tests();
     uut.add_transaction(txs[0].clone()).unwrap();
-    let parent_batch = uut.select_batch().unwrap();
+    let parent_batch = uut.select_any_batch().unwrap();
     assert_eq!(parent_batch.transactions(), vec![txs[0].clone()]);
 
     uut.add_transaction(txs[1].clone()).unwrap();
-    let child_batch_a = uut.select_batch().unwrap();
+    let child_batch_a = uut.select_any_batch().unwrap();
     assert_eq!(child_batch_a.transactions(), vec![txs[1].clone()]);
 
     uut.add_transaction(txs[2].clone()).unwrap();
-    let next_batch = uut.select_batch().unwrap();
+    let next_batch = uut.select_any_batch().unwrap();
     assert_eq!(next_batch.transactions(), vec![txs[2].clone()]);
 
     // Child batch jobs are now dangling.
@@ -115,19 +148,19 @@ fn failed_batch_transactions_are_requeued() {
 
     let (mut uut, mut reference) = Mempool::for_tests();
     uut.add_transaction(txs[0].clone()).unwrap();
-    uut.select_batch().unwrap();
+    uut.select_any_batch().unwrap();
 
     uut.add_transaction(txs[1].clone()).unwrap();
-    let failed_batch = uut.select_batch().unwrap();
+    let failed_batch = uut.select_any_batch().unwrap();
 
     uut.add_transaction(txs[2].clone()).unwrap();
-    uut.select_batch().unwrap();
+    uut.select_any_batch().unwrap();
 
     // Middle batch failed, so it and its child transaction should be re-entered into the queue.
     uut.rollback_batch(failed_batch.id());
 
     reference.add_transaction(txs[0].clone()).unwrap();
-    reference.select_batch().unwrap();
+    reference.select_any_batch().unwrap();
     reference.add_transaction(txs[1].clone()).unwrap();
     reference.add_transaction(txs[2].clone()).unwrap();
     reference
@@ -152,7 +185,7 @@ fn block_commit_reverts_expired_txns() {
 
     // Force the tx into the next block by batching it.
     uut.add_transaction(tx_to_commit.clone()).unwrap();
-    uut.select_batch().unwrap();
+    uut.select_any_batch().unwrap();
     uut.commit_batch(Arc::new(ProvenBatch::mocked_from_transactions([
         tx_to_commit.raw_proven_transaction()
     ])));
@@ -171,7 +204,7 @@ fn block_commit_reverts_expired_txns() {
 
     // A reverted transaction behaves as if it never existed.
     reference.add_transaction(tx_to_commit.clone()).unwrap();
-    reference.select_batch().unwrap();
+    reference.select_any_batch().unwrap();
     reference.commit_batch(Arc::new(ProvenBatch::mocked_from_transactions([
         tx_to_commit.raw_proven_transaction()
     ])));
@@ -223,7 +256,7 @@ fn pruned_committed_notes_are_authenticated_for_inflight_descendants() {
     let child = Arc::new(AuthenticatedTransaction::from_inner(child));
 
     uut.add_transaction(parent.clone()).unwrap();
-    let parent_batch = uut.select_batch().unwrap();
+    let parent_batch = uut.select_any_batch().unwrap();
     assert_eq!(parent_batch.transactions(), std::slice::from_ref(&parent));
 
     uut.add_transaction(child.clone()).unwrap();
@@ -239,7 +272,7 @@ fn pruned_committed_notes_are_authenticated_for_inflight_descendants() {
     let header = BlockHeader::mock(block.block_number, None, None, &[], Word::empty());
     uut.commit_block(&header);
 
-    let child_batch = uut.select_batch().unwrap();
+    let child_batch = uut.select_any_batch().unwrap();
 
     assert_eq!(child_batch.transactions().len(), 1);
     assert_eq!(child_batch.transactions()[0].id(), child.id());
@@ -274,7 +307,7 @@ fn rollbacks_of_already_proven_batches_are_ignored() {
 
     let (mut uut, _) = Mempool::for_tests();
     uut.add_transaction(txs[0].clone()).unwrap();
-    let batch = uut.select_batch().unwrap();
+    let batch = uut.select_any_batch().unwrap();
 
     let proof = Arc::new(ProvenBatch::mocked_from_transactions([txs[0].raw_proven_transaction()]));
     uut.commit_batch(Arc::clone(&proof));
@@ -295,7 +328,7 @@ fn block_failure_increments_tx_failures() {
     let reverted_txs = MockProvenTxBuilder::sequential();
 
     uut.add_transaction(reverted_txs[0].clone()).unwrap();
-    uut.select_batch().unwrap();
+    uut.select_any_batch().unwrap();
     uut.commit_batch(Arc::new(ProvenBatch::mocked_from_transactions([
         reverted_txs[0].raw_proven_transaction()
     ])));
@@ -305,7 +338,7 @@ fn block_failure_increments_tx_failures() {
 
     // Create another dependent batch.
     uut.add_transaction(reverted_txs[1].clone()).unwrap();
-    uut.select_batch();
+    uut.select_any_batch();
     // Create another dependent transaction.
     uut.add_transaction(reverted_txs[2].clone()).unwrap();
 
@@ -360,11 +393,11 @@ fn transactions_from_reverted_batches_are_requeued() {
 
     uut.add_transaction(tx_set_b[0].clone()).unwrap();
     uut.add_transaction(tx_set_a[0].clone()).unwrap();
-    uut.select_batch().unwrap();
+    uut.select_any_batch().unwrap();
 
     uut.add_transaction(tx_set_b[1].clone()).unwrap();
     uut.add_transaction(tx_set_a[1].clone()).unwrap();
-    let batch = uut.select_batch().unwrap();
+    let batch = uut.select_any_batch().unwrap();
 
     uut.add_transaction(tx_set_b[2].clone()).unwrap();
     uut.add_transaction(tx_set_a[2].clone()).unwrap();
@@ -372,7 +405,7 @@ fn transactions_from_reverted_batches_are_requeued() {
 
     reference.add_transaction(tx_set_b[0].clone()).unwrap();
     reference.add_transaction(tx_set_a[0].clone()).unwrap();
-    reference.select_batch().unwrap();
+    reference.select_any_batch().unwrap();
     reference.add_transaction(tx_set_b[1].clone()).unwrap();
     reference.add_transaction(tx_set_a[1].clone()).unwrap();
     reference.add_transaction(tx_set_b[2].clone()).unwrap();
@@ -412,7 +445,7 @@ fn pass_through_txs_on_an_empty_account() {
     uut.add_transaction(tx_pass_through_b.clone()).unwrap();
     uut.add_transaction(tx_final.clone()).unwrap();
 
-    let batch = uut.select_batch().unwrap();
+    let batch = uut.select_any_batch().unwrap();
 
     // Ensure the batch correctly aggregates the account update.
     let expected = std::iter::once((
@@ -464,11 +497,11 @@ fn pass_through_txs_with_note_dependencies() {
     // We then rollback batch (a) and check that batch (b) is also reverted which tests that the
     // relationship was correctly inferred by the mempool.
     uut.add_transaction(tx_pass_through_a.clone()).unwrap();
-    let batch_a = uut.select_batch().unwrap();
+    let batch_a = uut.select_any_batch().unwrap();
     assert_eq!(batch_a.transactions(), std::slice::from_ref(&tx_pass_through_a));
 
     uut.add_transaction(tx_pass_through_b.clone()).unwrap();
-    let batch_b = uut.select_batch().unwrap();
+    let batch_b = uut.select_any_batch().unwrap();
     assert_eq!(batch_b.transactions(), std::slice::from_ref(&tx_pass_through_b));
 
     // Rollback (a) and check that (b) also reverted by comparing to the reference.
@@ -513,7 +546,7 @@ fn intra_batch_unauthenticated_note() {
     uut.add_transaction(tx_a.clone()).unwrap();
     uut.add_transaction(tx_b.clone()).unwrap();
 
-    let batch = uut.select_batch().unwrap();
+    let batch = uut.select_any_batch().unwrap();
 
     assert!(batch.transactions().contains(&tx_a));
     assert!(batch.transactions().contains(&tx_b));

--- a/crates/block-producer/src/mempool/tests/add_user_batch.rs
+++ b/crates/block-producer/src/mempool/tests/add_user_batch.rs
@@ -29,8 +29,8 @@ fn user_batch_is_isolated_from_other_transactions() {
         BatchId::from_transactions(user_batch_txs.iter().map(|tx| tx.raw_proven_transaction()));
     uut.add_user_batch(&user_batch_txs).unwrap();
 
-    let batch_a = uut.select_batch().unwrap();
-    let batch_b = uut.select_batch().unwrap();
+    let batch_a = uut.select_any_batch().unwrap();
+    let batch_b = uut.select_any_batch().unwrap();
 
     let (user, conventional) = if batch_a.id() == user_batch_id {
         (batch_a, batch_b)
@@ -55,6 +55,18 @@ fn user_batch_respects_batch_budget() {
     let result = uut.add_user_batch(&user_batch_txs[..2]);
 
     assert_matches!(result, Err(MempoolSubmissionError::CapacityExceeded));
+}
+
+#[test]
+fn user_batch_counts_as_full_batch() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.batch_budget.transactions = 3;
+
+    let user_batch_txs = MockProvenTxBuilder::sequential();
+    uut.add_user_batch(&user_batch_txs[..1]).unwrap();
+
+    let batch = uut.select_full_batch().unwrap();
+    assert_eq!(batch.transactions(), &user_batch_txs[..1]);
 }
 
 #[test]

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -35,9 +35,9 @@ mod tests;
 #[derive(Clone, Copy, Debug)]
 pub struct BlockProducerApiConfig {
     /// The maximum number of transactions per batch.
-    pub max_txs_per_batch: usize,
+    pub max_txs_per_batch: NonZeroUsize,
     /// The maximum number of batches per block.
-    pub max_batches_per_block: usize,
+    pub max_batches_per_block: NonZeroUsize,
     /// The maximum number of inflight transactions allowed in the mempool at once.
     pub mempool_tx_capacity: NonZeroUsize,
 }
@@ -56,10 +56,12 @@ impl BlockProducerApiConfig {
     fn mempool_config(self) -> MempoolConfig {
         MempoolConfig {
             batch_budget: BatchBudget {
-                transactions: self.max_txs_per_batch,
+                transactions: self.max_txs_per_batch.get(),
                 ..BatchBudget::default()
             },
-            block_budget: BlockBudget { batches: self.max_batches_per_block },
+            block_budget: BlockBudget {
+                batches: self.max_batches_per_block.get(),
+            },
             tx_capacity: self.mempool_tx_capacity,
             ..Default::default()
         }
@@ -85,9 +87,9 @@ pub struct Sequencer {
     /// The interval at which to produce blocks.
     pub block_interval: Duration,
     /// The maximum number of transactions per batch.
-    pub max_txs_per_batch: usize,
+    pub max_txs_per_batch: NonZeroUsize,
     /// The maximum number of batches per block.
-    pub max_batches_per_block: usize,
+    pub max_batches_per_block: NonZeroUsize,
     /// The maximum number of concurrent block proofs to schedule.
     pub max_concurrent_proofs: NonZeroUsize,
 

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument};
 use url::Url;
 
-use crate::batch_builder::BatchBuilder;
+use crate::batch_builder::{BatchBuilder, BatchIntervals};
 use crate::block_builder::BlockBuilder;
 use crate::block_prover::BlockProver;
 use crate::domain::transaction::AuthenticatedTransaction;
@@ -80,7 +80,7 @@ pub struct Sequencer {
     pub batch_prover_url: Option<Url>,
     /// The address of the block prover component.
     pub block_prover_url: Option<Url>,
-    /// The interval at which to produce batches.
+    /// Maximum interval between batch scheduler checks.
     pub batch_interval: Duration,
     /// The interval at which to produce blocks.
     pub block_interval: Duration,
@@ -110,11 +110,12 @@ impl Sequencer {
         info!(target: COMPONENT, "Sequencer initialized");
 
         let block_builder = BlockBuilder::new(Arc::clone(&store), validator, self.block_interval);
+        let batch_intervals = BatchIntervals::derive_from(self.block_interval, self.batch_interval);
         let batch_builder = BatchBuilder::new(
             Arc::clone(&store),
             SERVER_NUM_BATCH_BUILDERS,
             self.batch_prover_url,
-            self.batch_interval,
+            batch_intervals,
         );
         let api_config = BlockProducerApiConfig {
             max_txs_per_batch: self.max_txs_per_batch,

--- a/docs/external/src/network-operator/sequencer.md
+++ b/docs/external/src/network-operator/sequencer.md
@@ -54,7 +54,7 @@ block data when this occurs. See [Recovery](/network-operator/recovery) for the 
 | `--rpc.network-tx-auth-header-value` | Shared secret for authorized network transaction flow. |
 | `--validator.url`                    | Internal validator service URL.                        |
 | `--ntx-builder.url`                  | Internal network transaction builder service URL.      |
-| `--batch.interval`                   | Batch production interval.                             |
+| `--batch.interval`                   | Maximum interval between batch scheduler checks.       |
 | `--block.interval`                   | Block production interval.                             |
 
 Use `miden-node sequencer --help` for the complete current option list.


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

This PR changes batch production from a fixed interval, to producing as many full batches as possible. The current `batch.interval: Duration` CLI is instead now used to configure the time after which a non-full batch will be scheduled if no full batch can be produced.

The new algorithm is essentially:

- Whenever a batch completes, attempt to build a full batch if possible.
- If no batch has been produced for `batch.interval` seconds, attempt to build a batch of any size.
- If idle, check for full batches every `block.interval / 10` seconds.

In addition, I've removed the failure injection we had in place for batch and block production. These have actually never been used, so they're not really worth the LoC.

Closes #2287 

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "node"
impact      = "changed"
description = "Batch production is now dynamic, creating full batches as often as possible, while maintaining a minimum batch rate"
```
