### PR TITLE
validator: disable API while recovery stream is active

### DIFF
--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -1,4 +1,5 @@
 use std::pin::Pin;
+use std::sync::Arc;
 
 use miden_node_proto::generated as grpc;
 use miden_node_store::BlockStore;
@@ -37,10 +38,21 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
         Span::current().set_attribute("block.from", request.block_from);
 
+        // Hold the exclusive backup lock for the entire lifetime of the stream. While a backup
+        // subscription is active no other RPCs may run, and vice versa. `try_write_owned` rejects
+        // the backup outright if any request is in flight, and yields a `'static` guard that we can
+        // move into the stream so it is released only once the stream is dropped.
+        let guard = Arc::clone(&self.serve_lock).try_write_owned().map_err(|_| {
+            Status::resource_exhausted("cannot stream backup while validator is serving requests")
+        })?;
+
         let from = BlockNumber::from(request.block_from);
         let source = BlockStoreSource { block_store: self.block_store.clone() };
-        let stream = run_stream(from, self.committed_tip.subscribe(), source)
-            .map(|event| event.map_err(subscription_error_to_status));
+        let stream = run_stream(from, self.committed_tip.subscribe(), source).map(move |event| {
+            // Keep the guard alive for as long as the stream is polled.
+            let _guard = &guard;
+            event.map_err(subscription_error_to_status)
+        });
 
         Ok(Box::pin(stream))
     }

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -38,18 +38,18 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
     async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
         Span::current().set_attribute("block.from", request.block_from);
 
-        // Hold the exclusive backup lock for the entire lifetime of the stream. While a backup
-        // subscription is active no other RPCs may run, and vice versa.
-        let guard = Arc::clone(&self.serve_lock).try_write_owned().map_err(|_| {
-            Status::resource_exhausted("cannot stream backup while validator is serving requests")
-        })?;
-
         let committed_tip = self.committed_tip.borrow().as_u32();
         if request.block_from > committed_tip {
             return Err(Status::out_of_range(
                 "subscriber's requested starting block should be <= the committed chain tip",
             ));
         }
+
+        // Hold the exclusive backup lock for the entire lifetime of the stream. While a backup
+        // subscription is active no other RPCs may run, and vice versa.
+        let guard = Arc::clone(&self.serve_lock).try_write_owned().map_err(|_| {
+            Status::resource_exhausted("cannot stream backup while validator is serving requests")
+        })?;
 
         let from = BlockNumber::from(request.block_from);
         let source = BlockStoreSource { block_store: self.block_store.clone() };

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -39,9 +39,7 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
         Span::current().set_attribute("block.from", request.block_from);
 
         // Hold the exclusive backup lock for the entire lifetime of the stream. While a backup
-        // subscription is active no other RPCs may run, and vice versa. `try_write_owned` rejects
-        // the backup outright if any request is in flight, and yields a `'static` guard that we can
-        // move into the stream so it is released only once the stream is dropped.
+        // subscription is active no other RPCs may run, and vice versa.
         let guard = Arc::clone(&self.serve_lock).try_write_owned().map_err(|_| {
             Status::resource_exhausted("cannot stream backup while validator is serving requests")
         })?;

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -44,11 +44,12 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
             Status::resource_exhausted("cannot stream backup while validator is serving requests")
         })?;
 
-        // Clamp the requested block so that the stream ends when the committed tip is reached. This
-        // prevents the stream from continuing indefinitely, even if the requested block is far
-        // ahead.
         let committed_tip = self.committed_tip.borrow().as_u32();
-        let block_from = request.block_from.min(committed_tip);
+        if request.block_from > committed_tip {
+            return Err(Status::out_of_range(
+                "subscriber's requested starting block should be <= the committed chain tip",
+            ));
+        }
 
         let from = BlockNumber::from(block_from);
         let source = BlockStoreSource { block_store: self.block_store.clone() };

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -51,7 +51,7 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
             ));
         }
 
-        let from = BlockNumber::from(block_from);
+        let from = BlockNumber::from(request.block_from);
         let source = BlockStoreSource { block_store: self.block_store.clone() };
         let stream = run_stream(from, self.committed_tip.subscribe(), source).map(move |event| {
             // Keep the guard alive for as long as the stream is polled.

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -44,7 +44,13 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
             Status::resource_exhausted("cannot stream backup while validator is serving requests")
         })?;
 
-        let from = BlockNumber::from(request.block_from);
+        // Clamp the requested block so that the stream ends when the committed tip is reached. This
+        // prevents the stream from continuing indefinitely, even if the requested block is far
+        // ahead.
+        let committed_tip = self.committed_tip.borrow().as_u32();
+        let block_from = request.block_from.min(committed_tip);
+
+        let from = BlockNumber::from(block_from);
         let source = BlockStoreSource { block_store: self.block_store.clone() };
         let stream = run_stream(from, self.committed_tip.subscribe(), source).map(move |event| {
             // Keep the guard alive for as long as the stream is polled.

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -65,6 +65,11 @@ pub(crate) struct ValidatorService {
     signer: ValidatorSigner,
     db: Arc<Db>,
     block_store: BlockStore,
+    /// Enforces mutual exclusion between backup block subscriptions and all other RPCs. Regular
+    /// RPCs take the read side (any number may run concurrently); a backup subscription takes the
+    /// exclusive write side for its entire lifetime. Acquired with `try_*` on both sides so that a
+    /// conflicting request fails fast with `resource_exhausted` rather than blocking.
+    serve_lock: Arc<tokio::sync::RwLock<()>>,
     /// Serializes `sign_block` requests so that concurrent calls are processed sequentially,
     /// ensuring consistent chain tip reads and preventing race conditions.
     sign_block_semaphore: Semaphore,
@@ -104,6 +109,7 @@ impl ValidatorService {
 
         Ok(Self {
             signer,
+            serve_lock: Arc::new(tokio::sync::RwLock::new(())),
             db: db.into(),
             block_store,
             sign_block_semaphore: Semaphore::new(1),

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -32,6 +32,11 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
     }
 
     async fn handle(&self, proposed_block: Self::Input) -> tonic::Result<Self::Output> {
+        // Reject requests while a backup subscription is streaming.
+        let _guard = self.serve_lock.try_read().map_err(|_| {
+            tonic::Status::resource_exhausted("validator is busy streaming a backup")
+        })?;
+
         // Serialize sign_block requests to prevent race conditions between loading the chain tip
         // and persisting the validated block header.
         let _permit = self.sign_block_semaphore.acquire().await.map_err(|err| {

--- a/bin/validator/src/server/validator_service/status.rs
+++ b/bin/validator/src/server/validator_service/status.rs
@@ -13,6 +13,11 @@ impl grpc::server::validator_api::Status for ValidatorService {
         &self,
         _request: tonic::Request<()>,
     ) -> tonic::Result<grpc::validator::ValidatorStatus> {
+        // Reject requests while a backup subscription is streaming. Fails fast rather than blocking.
+        let _guard = self.serve_lock.try_read().map_err(|_| {
+            tonic::Status::resource_exhausted("validator is busy streaming a backup")
+        })?;
+
         Ok(grpc::validator::ValidatorStatus {
             version: env!("CARGO_PKG_VERSION").to_string(),
             status: "OK".to_string(),

--- a/bin/validator/src/server/validator_service/status.rs
+++ b/bin/validator/src/server/validator_service/status.rs
@@ -13,14 +13,16 @@ impl grpc::server::validator_api::Status for ValidatorService {
         &self,
         _request: tonic::Request<()>,
     ) -> tonic::Result<grpc::validator::ValidatorStatus> {
-        // Reject requests while a backup subscription is streaming. Fails fast rather than blocking.
-        let _guard = self.serve_lock.try_read().map_err(|_| {
-            tonic::Status::resource_exhausted("validator is busy streaming a backup")
-        })?;
+        // Unlike the other RPCs, status stays available during a backup so operators can observe
+        // the validator. A failed read means a backup subscription holds the exclusive lock.
+        let status = match self.serve_lock.try_read() {
+            Ok(_guard) => "OK",
+            Err(_) => "BACKUP",
+        };
 
         Ok(grpc::validator::ValidatorStatus {
             version: env!("CARGO_PKG_VERSION").to_string(),
-            status: "OK".to_string(),
+            status: status.to_string(),
             chain_tip: self.committed_tip.borrow().as_u32(),
             validated_transactions_count: self.validated_transactions_count.load(Ordering::Relaxed),
             signed_blocks_count: self.signed_blocks_count.load(Ordering::Relaxed),

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -17,6 +17,12 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
     type Output = ();
 
     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
+        // Reject requests while a backup subscription is streaming.
+        let _guard = self
+            .serve_lock
+            .try_read()
+            .map_err(|_| Status::resource_exhausted("validator is busy streaming a backup"))?;
+
         tracing::Span::current().set_attribute("transaction.id", input.tx.id());
 
         // Validate the transaction.

--- a/bin/validator/src/server/validator_service/tests.rs
+++ b/bin/validator/src/server/validator_service/tests.rs
@@ -529,10 +529,11 @@ async fn validate_block_number_mismatch() {
     );
 }
 
-/// A block subscription replays the backed-up blocks from the requested height and then streams
-/// newly signed blocks as they arrive.
+/// A block subscription replays the backed-up blocks from the requested height. While the
+/// subscription is live it holds the exclusive backup lock, so signing is frozen for its duration
+/// and no further blocks can be produced or streamed.
 #[tokio::test]
-async fn block_subscription_replays_then_follows() {
+async fn block_subscription_replays_then_freezes_signing() {
     use std::time::Duration;
 
     use miden_protocol::block::SignedBlock;
@@ -558,16 +559,21 @@ async fn block_subscription_replays_then_follows() {
         assert_eq!(response.committed_chain_tip, 2);
     }
 
-    // Sign a new block and confirm it is streamed live to the existing subscriber.
-    tv.apply_empty_block().await;
-    let response = tokio::time::timeout(Duration::from_secs(5), stream.next())
+    // The live subscription holds the backup lock, so no new block can be signed while it is open.
+    // The validator therefore cannot produce a block to stream, and signing is rejected until the
+    // subscriber disconnects.
+    let proposed = tv.propose_empty_block();
+    let status = tv
+        .call_sign_block(&proposed)
         .await
-        .expect("live block should arrive promptly")
-        .expect("stream should not end")
-        .expect("stream item should not be an error");
-    let block = SignedBlock::read_from_bytes(&response.block).expect("valid signed block");
-    assert_eq!(block.header().block_num().as_u32(), 3);
-    assert_eq!(response.committed_chain_tip, 3);
+        .expect_err("sign_block must be rejected while a backup subscription is live");
+    assert_eq!(status.code(), tonic::Code::ResourceExhausted, "got: {status:?}");
+
+    // Once the subscriber disconnects, signing resumes.
+    drop(stream);
+    tv.call_sign_block(&proposed)
+        .await
+        .expect("sign_block should succeed once the subscription is dropped");
 }
 
 // SERVE LOCK TESTS

--- a/bin/validator/src/server/validator_service/tests.rs
+++ b/bin/validator/src/server/validator_service/tests.rs
@@ -62,11 +62,41 @@ impl TestValidator {
         &self,
         block_from: u32,
     ) -> <ValidatorService as proto::server::validator_api::BlockSubscription>::ItemStream {
-        let request =
-            tonic::Request::new(proto::validator::BlockSubscriptionRequest { block_from });
-        validator_api::BlockSubscription::full(&self.server, request)
+        self.try_call_block_subscription(block_from)
             .await
             .expect("subscription should open")
+    }
+
+    /// Opens a block subscription starting from `block_from`, returning the raw result so callers
+    /// can assert on rejection.
+    async fn try_call_block_subscription(
+        &self,
+        block_from: u32,
+    ) -> Result<
+        <ValidatorService as proto::server::validator_api::BlockSubscription>::ItemStream,
+        tonic::Status,
+    > {
+        let request =
+            tonic::Request::new(proto::validator::BlockSubscriptionRequest { block_from });
+        validator_api::BlockSubscription::full(&self.server, request).await
+    }
+
+    /// Calls the `status` endpoint on the validator server.
+    async fn call_status(&self) -> proto::validator::ValidatorStatus {
+        validator_api::Status::full(&self.server, tonic::Request::new(()))
+            .await
+            .expect("status should always be available")
+    }
+
+    /// Asserts that opening a backup subscription is rejected with `resource_exhausted`. The
+    /// success type ([`Self::ItemStream`]) is not `Debug`, so we match rather than `expect_err`.
+    async fn assert_backup_rejected(&self, block_from: u32) {
+        match self.try_call_block_subscription(block_from).await {
+            Ok(_) => panic!("backup subscription should have been rejected"),
+            Err(status) => {
+                assert_eq!(status.code(), tonic::Code::ResourceExhausted, "got: {status:?}");
+            },
+        }
     }
 
     /// Loads the current chain tip from the validator's database.
@@ -538,4 +568,114 @@ async fn block_subscription_replays_then_follows() {
     let block = SignedBlock::read_from_bytes(&response.block).expect("valid signed block");
     assert_eq!(block.header().block_num().as_u32(), 3);
     assert_eq!(response.committed_chain_tip, 3);
+}
+
+// SERVE LOCK TESTS
+// ================================================================================================
+//
+// A backup subscription holds the exclusive write side of `serve_lock` for the lifetime of the
+// returned stream; every other RPC takes the read side. The two are therefore mutually exclusive:
+// a backup cannot start while requests are in flight, and requests are rejected while a backup is
+// streaming. Both sides fail fast with `resource_exhausted` rather than blocking.
+
+/// While a backup subscription is streaming, `sign_block` is rejected, and it succeeds again once
+/// the subscription is dropped and the lock released.
+#[tokio::test]
+async fn backup_stream_blocks_sign_block_until_dropped() {
+    let mut tv = TestValidator::new().await;
+    tv.apply_empty_block().await;
+
+    // Open a backup subscription; the returned stream holds the exclusive lock.
+    let stream = tv.call_block_subscription(1).await;
+
+    let proposed = tv.propose_empty_block();
+    let status = tv
+        .call_sign_block(&proposed)
+        .await
+        .expect_err("sign_block must be rejected while a backup is streaming");
+    assert_eq!(status.code(), tonic::Code::ResourceExhausted, "got: {status:?}");
+
+    // Dropping the subscription releases the lock, so the same request now succeeds.
+    drop(stream);
+    tv.call_sign_block(&proposed)
+        .await
+        .expect("sign_block should succeed once the backup stream is dropped");
+}
+
+/// Unlike other RPCs, `status` stays available during a backup and reports `BACKUP` instead of
+/// `OK`, reverting to `OK` once the subscription is dropped.
+#[tokio::test]
+async fn status_reports_backup_while_streaming() {
+    let mut tv = TestValidator::new().await;
+    tv.apply_empty_block().await;
+
+    assert_eq!(tv.call_status().await.status, "OK");
+
+    let stream = tv.call_block_subscription(1).await;
+    assert_eq!(
+        tv.call_status().await.status,
+        "BACKUP",
+        "status must report BACKUP while a backup is streaming",
+    );
+
+    drop(stream);
+    assert_eq!(
+        tv.call_status().await.status,
+        "OK",
+        "status must revert to OK once the backup stream is dropped",
+    );
+}
+
+/// A backup subscription cannot start while another request holds the read side of the lock,
+/// modelling an in-flight RPC. Once that reader is released, the backup opens successfully.
+#[tokio::test]
+async fn in_flight_request_blocks_backup() {
+    let tv = TestValidator::new().await;
+
+    // Simulate an in-flight RPC by holding the read side of the lock, exactly as the RPC handlers
+    // do for their duration.
+    let read_guard = tv.server.serve_lock.try_read().expect("read side should be available");
+
+    tv.assert_backup_rejected(0).await;
+
+    // Releasing the reader lets a backup start.
+    drop(read_guard);
+    let _stream = tv.call_block_subscription(0).await;
+}
+
+/// Only one backup subscription can run at a time: opening a second while the first is live is
+/// rejected.
+#[tokio::test]
+async fn concurrent_backups_rejected() {
+    let tv = TestValidator::new().await;
+
+    let first = tv.call_block_subscription(0).await;
+
+    tv.assert_backup_rejected(0).await;
+
+    // The slot frees up once the first subscription is dropped.
+    drop(first);
+    let _stream = tv.call_block_subscription(0).await;
+}
+
+/// Ordinary requests share the read side of the lock and so run concurrently with one another; only
+/// a backup is exclusive.
+#[tokio::test]
+async fn requests_run_concurrently() {
+    let tv = TestValidator::new().await;
+
+    // Multiple readers may hold the lock at once, so requests are not serialized against each
+    // other.
+    let first = tv.server.serve_lock.try_read().expect("first reader should acquire");
+    let second = tv
+        .server
+        .serve_lock
+        .try_read()
+        .expect("second reader should acquire concurrently");
+
+    // A backup is still excluded while any reader is held.
+    tv.assert_backup_rejected(0).await;
+
+    drop(first);
+    drop(second);
 }


### PR DESCRIPTION
## Summary

Adds a RWLock to disable Validator RPCs when backup is occurring (and vice versa).

Status endpoint can still be used during backup.

Replaces #2283.
<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

```toml
[[entry]]
scope  = "validator"
impact = "changed"
description = "Disable API while recovery stream is active"
```
