### PR TITLE
chore: make docker-build should build monitor image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ local-network-logs: ## Follows logs for the local development network
 	docker compose $(COMPOSE_FILES) logs -f
 
 .PHONY: docker-build
-docker-build: docker-build-node docker-build-validator docker-build-ntx-builder docker-build-monitor docker-build-remote-prover ## Builds all Docker images
+docker-build: docker-build-node docker-build-validator docker-build-ntx-builder docker-build-monitor docker-build-remote-prover docker-build-monitor ## Builds all Docker images
 
 .PHONY: docker-build-node
 docker-build-node: ## Builds the Miden node using Docker


### PR DESCRIPTION
## Summary

Otherwise `make local-network-up` fails because the monitor image is not present, even after running `make local-network-build`.

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```
