### PR TITLE
feat: add graceful shutdown to node services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,6 +3427,7 @@ dependencies = [
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tonic",
  "tower",
  "tower-http",
@@ -6117,6 +6118,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ tempfile           = { version = "3.12" }
 thiserror          = { default-features = false, version = "2.0" }
 tokio              = { default-features = false, version = "1.46" }
 tokio-stream       = { version = "0.1" }
+tokio-util         = { features = ["rt"], version = "0.7" }
 toml               = { version = "1.0" }
 tonic              = { default-features = false, version = "0.14" }
 tonic-health       = { version = "0.14" }

--- a/bin/node/src/commands/mod.rs
+++ b/bin/node/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod store;
 use clap::Subcommand;
 pub use lifecycle::{BootstrapCommand, MigrateCommand};
 use miden_node_utils::logging::OpenTelemetry;
+use miden_node_utils::shutdown::CancellationToken;
 pub use modes::{FullNodeCommand, SequencerCommand};
 pub use recover::RecoverCommand;
 
@@ -80,12 +81,12 @@ impl Command {
         }
     }
 
-    pub(crate) async fn execute(self) -> anyhow::Result<()> {
+    pub(crate) async fn execute(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         match self {
             Command::Bootstrap(bootstrap_command) => bootstrap_command.handle().await,
             Command::Migrate(migrate_command) => migrate_command.handle(),
-            Command::Sequencer(sequencer_command) => sequencer_command.handle().await,
-            Command::Full(full_node_command) => full_node_command.handle().await,
+            Command::Sequencer(sequencer_command) => sequencer_command.handle(shutdown).await,
+            Command::Full(full_node_command) => full_node_command.handle(shutdown).await,
             Command::Recover(recover_command) => recover_command.handle().await,
         }
     }

--- a/bin/node/src/commands/modes.rs
+++ b/bin/node/src/commands/modes.rs
@@ -14,6 +14,7 @@ use miden_node_proto::clients::{
 use miden_node_rpc::{Rpc, RpcMode, SequencerInternal};
 use miden_node_store::State;
 use miden_node_utils::clap::{GrpcOptionsInternal, duration_to_human_readable_string};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use tokio::net::TcpListener;
 use url::Url;
@@ -50,12 +51,12 @@ pub struct SequencerCommand {
 }
 
 impl SequencerCommand {
-    pub async fn handle(self) -> anyhow::Result<()> {
+    pub async fn handle(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         let runtime = self.runtime.runtime_config(&self.store);
         self.block_producer.validate()?;
         let network_tx_auth = self.runtime.rpc.network_tx_auth()?;
         let state = load_state(&runtime).await?;
-        let _disk_monitor = state.spawn_disk_monitor();
+        let _disk_monitor = state.spawn_disk_monitor(shutdown.clone());
 
         let sequencer = Sequencer {
             store: Arc::clone(&state),
@@ -71,7 +72,7 @@ impl SequencerCommand {
             mempool_tx_capacity: self.block_producer.mempool.tx_capacity,
             batch_workers: self.block_producer.batch.workers,
         }
-        .spawn()
+        .spawn(shutdown.clone())
         .await
         .context("failed to spawn sequencer")?;
         let block_producer = sequencer.api();
@@ -89,17 +90,17 @@ impl SequencerCommand {
         };
         let mut tasks = Tasks::new();
         tasks.spawn("sequencer", sequencer.wait());
-        tasks.spawn("RPC server", rpc.serve());
+        tasks.spawn("RPC server", rpc.serve(shutdown.clone()));
         if let Some(internal_listen) = self.internal {
             let sequencer_internal = SequencerInternal {
                 listener: bind_rpc(internal_listen).await?,
                 block_producer,
                 grpc_options: GrpcOptionsInternal::from(runtime.external_grpc_options),
             };
-            tasks.spawn("sequencer internal server", sequencer_internal.serve());
+            tasks.spawn("sequencer internal server", sequencer_internal.serve(shutdown.clone()));
         }
 
-        tasks.join_next_as_error().await
+        tasks.join_next_or_cancelled(shutdown).await
     }
 }
 
@@ -180,14 +181,14 @@ pub struct FullNodeCommand {
 }
 
 impl FullNodeCommand {
-    pub async fn handle(self) -> anyhow::Result<()> {
+    pub async fn handle(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         let runtime = self.runtime.runtime_config(&self.store);
         let source_rpc = self.sync.source_rpc_client()?;
         let validator_client = self.validator_client();
         let sequencer_client = self.sequencer_client();
         let network_tx_auth = self.runtime.rpc.network_tx_auth()?;
         let state = load_state(&runtime).await?;
-        let _disk_monitor = state.spawn_disk_monitor();
+        let _disk_monitor = state.spawn_disk_monitor(shutdown.clone());
 
         let rpc = Rpc {
             listener: bind_rpc(runtime.rpc_listen).await?,
@@ -203,9 +204,9 @@ impl FullNodeCommand {
             network_tx_auth,
         };
         let mut tasks = Tasks::new();
-        tasks.spawn("RPC server", rpc.serve());
+        tasks.spawn("RPC server", rpc.serve(shutdown.clone()));
 
-        tasks.join_next_as_error().await
+        tasks.join_next_or_cancelled(shutdown).await
     }
 
     fn sequencer_client(&self) -> Option<SequencerClient> {

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -43,5 +43,5 @@ async fn main() -> anyhow::Result<()> {
     // Configure tracing with optional OpenTelemetry exporting support.
     let _otel_guard = miden_node_utils::logging::setup_tracing(cli.command.open_telemetry())?;
 
-    cli.command.execute().await
+    miden_node_utils::shutdown::run_with_shutdown(|shutdown| cli.command.execute(shutdown)).await
 }

--- a/bin/ntx-builder/src/actor/mod.rs
+++ b/bin/ntx-builder/src/actor/mod.rs
@@ -12,6 +12,7 @@ use candidate::TransactionCandidate;
 use futures::FutureExt;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::Word;
 use miden_protocol::account::{Account, AccountDelta, AccountId};
@@ -284,7 +285,11 @@ impl AccountActor {
     ///
     /// - `Ok(())`: intentional shutdown (idle timeout).
     /// - `Err(_)`: crash (database error, semaphore failure, or any other bug).
-    pub async fn run(self, semaphore: Arc<Semaphore>) -> anyhow::Result<()> {
+    pub async fn run(
+        self,
+        semaphore: Arc<Semaphore>,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<()> {
         let account_id = self.account_id;
 
         // Load the account once and keep it in memory for the actor's lifetime, advancing it from
@@ -334,6 +339,7 @@ impl AccountActor {
             };
 
             tokio::select! {
+                () = shutdown.cancelled() => return Ok(()),
                 // A committed block touched this account (or the coordinator woke everyone): the
                 // submission may have landed (advancing the in-memory account by its own delta),
                 // the submission may have expired, or new notes may be available.
@@ -809,7 +815,7 @@ mod tests {
         let notify = Arc::new(Notify::new());
         let actor = AccountActor::new(account_id, &ctx, notify.clone());
         let semaphore = Arc::new(Semaphore::new(1));
-        let handle = tokio::spawn(actor.run(semaphore));
+        let handle = tokio::spawn(actor.run(semaphore, CancellationToken::new()));
 
         // Wake the actor far more often than the idle timeout, and keep doing so for longer than
         // the test's deadline. With a per-iteration `sleep(idle_timeout)` every wake would restart

--- a/bin/ntx-builder/src/builder.rs
+++ b/bin/ntx-builder/src/builder.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use futures::Stream;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::{BlockNumber, SignedBlock};
@@ -26,6 +27,7 @@ enum SteadyStateAction {
     Block(Box<Option<Result<(SignedBlock, BlockNumber), RpcError>>>),
     Request(Option<ActorRequest>),
     Respawn(Option<miden_protocol::account::AccountId>),
+    Shutdown,
 }
 
 // NETWORK TRANSACTION BUILDER
@@ -101,23 +103,31 @@ impl NetworkTransactionBuilder {
     }
 
     /// Runs the network transaction builder event loop until a fatal error occurs.
-    pub async fn run(self, listener: TcpListener) -> anyhow::Result<()> {
+    pub async fn run(
+        self,
+        listener: TcpListener,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<()> {
         let mut tasks = Tasks::new();
 
         // Start the gRPC server.
         let server = NtxBuilderRpcServer::new(self.db.clone(), self.config.max_note_attempts);
+        let server_shutdown = shutdown.clone();
         tasks.spawn("grpc-server", async move {
-            server.serve(listener).await.context("ntx-builder gRPC server failed")
+            server
+                .serve(listener, server_shutdown)
+                .await
+                .context("ntx-builder gRPC server failed")
         });
 
-        tasks.spawn("event-loop", self.run_event_loop());
+        tasks.spawn("event-loop", self.run_event_loop(shutdown.clone()));
 
         // Wait for either the event loop or the gRPC server to complete. Any completion is treated
         // as fatal.
-        tasks.join_next_as_error().await.context("ntx-builder task failed")
+        tasks.join_next_or_cancelled(shutdown).await.context("ntx-builder task failed")
     }
 
-    async fn run_event_loop(mut self) -> anyhow::Result<()> {
+    async fn run_event_loop(mut self, shutdown: CancellationToken) -> anyhow::Result<()> {
         // Pin a dedicated connection for the loop's DB writes so block application is never starved
         // by the account actors competing for the shared pool.
         let loop_db = self
@@ -128,7 +138,10 @@ impl NetworkTransactionBuilder {
 
         // Phase 1: catch-up.
         loop {
-            let (block, committed_tip) = self.next_block().await?;
+            let (block, committed_tip) = tokio::select! {
+                () = shutdown.cancelled() => return Ok(()),
+                result = self.next_block() => result?,
+            };
             let local_tip = block.header().block_num();
             self.apply_committed_block(&loop_db, block, committed_tip).await?;
 
@@ -169,6 +182,7 @@ impl NetworkTransactionBuilder {
                 let coordinator = &mut self.coordinator;
 
                 tokio::select! {
+                    () = shutdown.cancelled() => SteadyStateAction::Shutdown,
                     block = block_stream.next() => SteadyStateAction::Block(Box::new(block)),
                     request = actor_request_rx.recv() => SteadyStateAction::Request(request),
                     respawn = coordinator.next() => SteadyStateAction::Respawn(respawn?),
@@ -199,6 +213,10 @@ impl NetworkTransactionBuilder {
                         );
                         self.coordinator.spawn_actor(account_id);
                     }
+                },
+                SteadyStateAction::Shutdown => {
+                    self.coordinator.shutdown().await?;
+                    return Ok(());
                 },
             }
         }

--- a/bin/ntx-builder/src/commands/mod.rs
+++ b/bin/ntx-builder/src/commands/mod.rs
@@ -13,6 +13,7 @@ use miden_node_utils::genesis::{
     read_signed_genesis_block,
 };
 use miden_node_utils::logging::OpenTelemetry;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_protocol::block::SignedBlock;
 use tokio::net::TcpListener;
 use tonic::metadata::AsciiMetadataValue;
@@ -162,9 +163,9 @@ pub enum NtxBuilderCommand {
 }
 
 impl NtxBuilderCommand {
-    pub async fn handle(self) -> anyhow::Result<()> {
+    pub async fn handle(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         match self {
-            Self::Start { .. } => self.start().await,
+            Self::Start { .. } => self.start(shutdown).await,
             Self::Bootstrap {
                 data_directory,
                 genesis_block_file,
@@ -185,7 +186,7 @@ impl NtxBuilderCommand {
         }
     }
 
-    async fn start(self) -> anyhow::Result<()> {
+    async fn start(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         let Self::Start {
             listen,
             rpc_url,
@@ -223,10 +224,10 @@ impl NtxBuilderCommand {
         };
 
         config
-            .build()
+            .build(shutdown.clone())
             .await
             .context("failed to initialize ntx builder")?
-            .run(listener)
+            .run(listener, shutdown)
             .await
             .context("failed while running ntx builder component")
     }

--- a/bin/ntx-builder/src/coordinator.rs
+++ b/bin/ntx-builder/src/coordinator.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Context;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::account::AccountId;
 use miden_standards::note::AccountTargetNetworkNote;
@@ -102,6 +103,9 @@ pub struct Coordinator {
     /// Their actor spawn is deferred until a committed block carries the account's creation, at
     /// which point [`Coordinator::handle_committed_block`] promotes them to a real actor.
     pending_spawns: HashSet<AccountId>,
+
+    /// Cancellation signal shared by all actors spawned by this coordinator.
+    shutdown: CancellationToken,
 }
 
 impl Coordinator {
@@ -111,6 +115,7 @@ impl Coordinator {
         max_inflight_transactions: usize,
         max_account_crashes: usize,
         actor_context: AccountActorContext,
+        shutdown: CancellationToken,
     ) -> Self {
         Self {
             actor_registry: HashMap::new(),
@@ -120,6 +125,7 @@ impl Coordinator {
             crash_counts: HashMap::new(),
             max_account_crashes,
             pending_spawns: HashSet::new(),
+            shutdown,
         }
     }
 
@@ -158,8 +164,9 @@ impl Coordinator {
         let handle = ActorHandle::new(notify);
 
         let semaphore = self.semaphore.clone();
+        let shutdown = self.shutdown.clone();
         self.actor_join_set
-            .spawn(Box::pin(async move { (account_id, actor.run(semaphore).await) }));
+            .spawn(Box::pin(async move { (account_id, actor.run(semaphore, shutdown).await) }));
 
         self.actor_registry.insert(account_id, handle);
         tracing::debug!(
@@ -276,6 +283,24 @@ impl Coordinator {
             },
         }
     }
+
+    /// Waits for all currently running actors to exit after cancellation.
+    pub async fn shutdown(&mut self) -> anyhow::Result<()> {
+        while let Some(result) = self.actor_join_set.join_next().await {
+            match result {
+                Ok((_account_id, Ok(()))) => {},
+                Ok((account_id, Err(err))) => {
+                    return Err(err).with_context(|| {
+                        format!("account actor {account_id} failed during shutdown")
+                    });
+                },
+                Err(err) if err.is_cancelled() => {},
+                Err(err) => return Err(err).context("account actor failed to join"),
+            }
+        }
+        self.actor_registry.clear();
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -291,7 +316,7 @@ impl Coordinator {
         let (tx, rx) = tokio::sync::mpsc::channel(8);
         let mut actor_context = AccountActorContext::test(&db);
         actor_context.request_tx = tx;
-        (Self::new(4, 10, actor_context), dir, rx)
+        (Self::new(4, 10, actor_context, CancellationToken::new()), dir, rx)
     }
 }
 

--- a/bin/ntx-builder/src/lib.rs
+++ b/bin/ntx-builder/src/lib.rs
@@ -10,6 +10,7 @@ use clients::RpcClient;
 use db::Db;
 use miden_node_utils::ErrorReport;
 use miden_node_utils::lru_cache::LruCache;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_protocol::block::{BlockNumber, SignedBlock};
 use miden_remote_prover_client::RemoteTransactionProver;
 use tokio::sync::mpsc;
@@ -364,7 +365,10 @@ impl NtxBuilderConfig {
     /// - The DB cannot be opened or the schema verification fails
     /// - The DB has not been bootstrapped (no persisted chain state)
     /// - The RPC connection fails (after retries)
-    pub async fn build(self) -> anyhow::Result<NetworkTransactionBuilder> {
+    pub async fn build(
+        self,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<NetworkTransactionBuilder> {
         // The event loop pins one connection for itself (so block application is never starved by
         // the account actors), leaving the rest of the pool for actors and the gRPC server. That
         // requires at least two connections.
@@ -426,7 +430,7 @@ impl NtxBuilderConfig {
         let chain = Arc::new(SharedChainState::new(header, mmr));
 
         let (coordinator, actor_request_rx) =
-            self.build_coordinator(rpc, db.clone(), chain.clone())?;
+            self.build_coordinator(rpc, db.clone(), chain.clone(), shutdown)?;
 
         Ok(NetworkTransactionBuilder::new(
             self,
@@ -449,6 +453,7 @@ impl NtxBuilderConfig {
         rpc: RpcClient,
         db: Db,
         chain: Arc<SharedChainState>,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<(Coordinator, mpsc::Receiver<actor::ActorRequest>)> {
         let (request_tx, actor_request_rx) = mpsc::channel(self.account_channel_capacity);
         let actor_context = AccountActorContext {
@@ -474,8 +479,12 @@ impl NtxBuilderConfig {
             },
             request_tx,
         };
-        let coordinator =
-            Coordinator::new(self.max_concurrent_txs, self.max_account_crashes, actor_context);
+        let coordinator = Coordinator::new(
+            self.max_concurrent_txs,
+            self.max_account_crashes,
+            actor_context,
+            shutdown,
+        );
 
         Ok((coordinator, actor_request_rx))
     }

--- a/bin/ntx-builder/src/main.rs
+++ b/bin/ntx-builder/src/main.rs
@@ -7,5 +7,5 @@ async fn main() -> anyhow::Result<()> {
 
     let _otel_guard = miden_node_utils::logging::setup_tracing(command.open_telemetry())?;
 
-    command.handle().await
+    miden_node_utils::shutdown::run_with_shutdown(|shutdown| command.handle(shutdown)).await
 }

--- a/bin/ntx-builder/src/server.rs
+++ b/bin/ntx-builder/src/server.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use miden_node_proto::server::ntx_builder_api;
 use miden_node_proto_build::ntx_builder_api_descriptor;
 use miden_node_utils::panic::{CatchPanicLayer, catch_panic_layer_fn};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -31,7 +32,11 @@ impl NtxBuilderRpcServer {
     }
 
     /// Starts the gRPC server on the given listener.
-    pub async fn serve(self, listener: TcpListener) -> anyhow::Result<()> {
+    pub async fn serve(
+        self,
+        listener: TcpListener,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<()> {
         let api_service = ntx_builder_api::service(self);
         let reflection_service = server::Builder::configure()
             .register_file_descriptor_set(ntx_builder_api_descriptor())
@@ -49,7 +54,10 @@ impl NtxBuilderRpcServer {
             .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
             .add_service(api_service)
             .add_service(reflection_service)
-            .serve_with_incoming(TcpListenerStream::new(listener))
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                shutdown.cancelled_owned(),
+            )
             .await
             .context("failed to serve NTX builder gRPC API")
     }

--- a/bin/remote-prover/src/main.rs
+++ b/bin/remote-prover/src/main.rs
@@ -14,7 +14,10 @@ async fn main() -> anyhow::Result<()> {
     let _otel_guard = miden_node_utils::logging::setup_tracing(server.open_telemetry())?;
     info!(target: LOG_TARGET, "Tracing initialized");
 
-    let (handle, _port) = server.spawn().await.context("failed to spawn server")?;
+    miden_node_utils::shutdown::run_with_shutdown(|shutdown| async move {
+        let (handle, _port) = server.spawn(shutdown).await.context("failed to spawn server")?;
 
-    handle.await.context("proof server panicked").flatten()
+        handle.await.context("proof server panicked").flatten()
+    })
+    .await
 }

--- a/bin/remote-prover/src/server/mod.rs
+++ b/bin/remote-prover/src/server/mod.rs
@@ -5,6 +5,7 @@ use miden_node_proto::server::{remote_prover_api, remote_prover_worker_status_ap
 use miden_node_utils::cors::cors_for_grpc_web_layer;
 use miden_node_utils::logging::OpenTelemetry;
 use miden_node_utils::panic::catch_panic_layer_fn;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
 use proof_kind::ProofKind;
 use tokio::net::TcpListener;
@@ -55,7 +56,10 @@ impl Server {
     }
 
     /// Spawns the prover server, returning its handle and the port it is listening on.
-    pub async fn spawn(&self) -> anyhow::Result<(JoinHandle<anyhow::Result<()>>, u16)> {
+    pub async fn spawn(
+        &self,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<(JoinHandle<anyhow::Result<()>>, u16)> {
         let listener = TcpListener::bind(format!("0.0.0.0:{}", self.port))
             .await
             .context("failed to bind to gRPC port")?;
@@ -108,7 +112,10 @@ impl Server {
             .add_service(status_service)
             .add_service(health_service)
             .add_service(reflection_service)
-            .serve_with_incoming(TcpListenerStream::new(listener));
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                shutdown.cancelled_owned(),
+            );
 
         let server =
             tokio::spawn(async move { server.await.context("failed while serving proof server") });

--- a/bin/remote-prover/src/server/tests.rs
+++ b/bin/remote-prover/src/server/tests.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use assert_matches::assert_matches;
 use miden_node_proto::generated::remote_prover::api_client::ApiClient;
 use miden_node_proto::generated::remote_prover::{Proof, ProofRequest, ProofType};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::asset::{Asset, FungibleAsset};
@@ -190,7 +191,7 @@ impl Server {
 async fn legacy_behaviour_with_capacity_1() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Transaction)
         .with_capacity(1)
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 
@@ -225,7 +226,7 @@ async fn legacy_behaviour_with_capacity_1() {
 async fn capacity_is_respected() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Transaction)
         .with_capacity(2)
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 
@@ -267,7 +268,7 @@ async fn capacity_is_respected() {
 async fn timeout_is_respected() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Transaction)
         .with_timeout(Duration::from_nanos(10))
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 
@@ -298,7 +299,7 @@ async fn timeout_is_respected() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_proof_kind_is_rejected() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Transaction)
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 
@@ -325,7 +326,7 @@ async fn invalid_proof_kind_is_rejected() {
 #[tokio::test(flavor = "multi_thread")]
 async fn unsupported_proof_kind_is_rejected() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Batch)
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 
@@ -348,7 +349,7 @@ async fn unsupported_proof_kind_is_rejected() {
 #[serial]
 async fn transaction_proof_is_correct() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Transaction)
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 
@@ -373,7 +374,7 @@ async fn transaction_proof_is_correct() {
 #[serial]
 async fn batch_proof_is_correct() {
     let (server, port) = Server::with_arbitrary_port(ProofKind::Batch)
-        .spawn()
+        .spawn(CancellationToken::new())
         .await
         .expect("server should spawn");
 

--- a/bin/validator/src/commands/mod.rs
+++ b/bin/validator/src/commands/mod.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use clap::Parser;
 use miden_node_utils::clap::GrpcOptionsInternal;
 use miden_node_utils::logging::OpenTelemetry;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey;
 use miden_protocol::utils::serde::Deserializable;
 use miden_validator::{DataDirectory, ValidatorSigner};
@@ -119,7 +120,7 @@ pub enum ValidatorCommand {
 }
 
 impl ValidatorCommand {
-    pub async fn handle(self) -> anyhow::Result<()> {
+    pub async fn handle(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         match self {
             Self::Bootstrap {
                 genesis_block_directory,
@@ -165,6 +166,7 @@ impl ValidatorCommand {
                         signer,
                         data_directory,
                         sqlite_connection_pool_size,
+                        shutdown,
                     )
                     .await
                 } else {
@@ -176,6 +178,7 @@ impl ValidatorCommand {
                         signer,
                         data_directory,
                         sqlite_connection_pool_size,
+                        shutdown,
                     )
                     .await
                 }

--- a/bin/validator/src/commands/start.rs
+++ b/bin/validator/src/commands/start.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use miden_node_utils::clap::GrpcOptionsInternal;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_validator::{DataDirectory, ValidatorServer, ValidatorSigner};
 
 // Starts the validator component.
@@ -13,6 +14,7 @@ pub async fn start(
     signer: ValidatorSigner,
     data_directory: PathBuf,
     sqlite_connection_pool_size: NonZeroUsize,
+    shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     let data_directory = DataDirectory::load_server(data_directory)
         .context("failed to load validator data directory")?;
@@ -23,7 +25,7 @@ pub async fn start(
         data_directory,
         sqlite_connection_pool_size,
     }
-    .serve()
+    .serve(shutdown)
     .await
     .context("failed while serving validator component")
 }

--- a/bin/validator/src/main.rs
+++ b/bin/validator/src/main.rs
@@ -10,5 +10,5 @@ async fn main() -> anyhow::Result<()> {
 
     let _otel_guard = miden_node_utils::logging::setup_tracing(command.open_telemetry())?;
 
-    command.handle().await
+    miden_node_utils::shutdown::run_with_shutdown(|shutdown| command.handle(shutdown)).await
 }

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -7,6 +7,7 @@ use miden_node_proto_build::validator_api_descriptor;
 use miden_node_store::BlockStore;
 use miden_node_utils::clap::GrpcOptionsInternal;
 use miden_node_utils::panic::catch_panic_layer_fn;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -54,7 +55,7 @@ impl ValidatorServer {
     ///
     /// Executes in place (i.e. not spawned) and will run indefinitely until a fatal error is
     /// encountered.
-    pub async fn serve(self) -> anyhow::Result<()> {
+    pub async fn serve(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         tracing::info!(target: LOG_TARGET, endpoint=?self.address, "Initializing server");
 
         // Initialize database connection.
@@ -107,7 +108,10 @@ impl ValidatorServer {
                 .context("failed to initialize validator server")?,
             ))
             .add_service(reflection_service)
-            .serve_with_incoming(TcpListenerStream::new(listener))
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(listener),
+                shutdown.cancelled_owned(),
+            )
             .await
             .context("failed to serve validator API")
     }

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use futures::TryFutureExt;
 use miden_node_proto::domain::batch::BatchInputs;
 use miden_node_store::state::State;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{ErrorSpanExt, miden_instrument, miden_span_record};
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
@@ -96,7 +97,11 @@ impl BatchBuilder {
     ///
     /// Full batches are spawned on each check and job completion. A batch of any size is attempted
     /// when no batch has been spawned for the maximum batch interval.
-    pub async fn run(mut self, mempool: SharedMempool) -> anyhow::Result<()> {
+    pub async fn run(
+        mut self,
+        mempool: SharedMempool,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<()> {
         let mut last_spawn = Instant::now();
         let mut full_batch_check = tokio::time::interval(self.intervals.full_batch_check_interval);
         full_batch_check.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -108,6 +113,12 @@ impl BatchBuilder {
             let has_active_job = !self.active_jobs.is_empty();
 
             tokio::select! {
+                () = shutdown.cancelled() => {
+                    while let Some(result) = self.active_jobs.join_next().await {
+                        Self::handle_job_result(result)?;
+                    }
+                    return Ok(());
+                },
                 _ = force_at => {
                     last_spawn = Instant::now();
                     if has_available_worker {

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use miden_node_store::state::State;
 use miden_node_utils::formatting::format_array;
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{ErrorSpanExt, miden_instrument, miden_span_record};
 use miden_protocol::batch::{OrderedBatches, ProvenBatch};
@@ -52,7 +53,11 @@ impl BlockBuilder {
     ///   2. Compiling these batches into the next block
     ///   3. Proving the block (this is simulated using random sleeps)
     ///   4. Committing the block to the store
-    pub async fn run(self, mempool: SharedMempool) -> anyhow::Result<()> {
+    pub async fn run(
+        self,
+        mempool: SharedMempool,
+        shutdown: CancellationToken,
+    ) -> anyhow::Result<()> {
         let mut interval = tokio::time::interval(self.block_interval);
         // We set the interval's missed tick behaviour to burst. This means we'll catch up missed
         // blocks as fast as possible. In other words, we try our best to keep the desired block
@@ -60,7 +65,10 @@ impl BlockBuilder {
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Burst);
 
         loop {
-            interval.tick().await;
+            tokio::select! {
+                () = shutdown.cancelled() => return Ok(()),
+                _ = interval.tick() => {},
+            }
 
             // Exit if a fatal error occurred.
             //

--- a/crates/block-producer/src/proof_scheduler.rs
+++ b/crates/block-producer/src/proof_scheduler.rs
@@ -62,8 +62,8 @@ impl ProofTaskJoinSet {
         self.0.len()
     }
 
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
+    fn abort_all(&mut self) {
+        self.0.abort_all();
     }
 
     /// Spawns a new task to prove a block.
@@ -136,10 +136,7 @@ pub(crate) async fn run(
         // Wait for either a job to complete or the chain tip to advance.
         tokio::select! {
             () = shutdown.cancelled() => {
-                while !proving_tasks.is_empty() {
-                    let (block_num, proof_bytes) = proving_tasks.join_next().await?;
-                    pending.insert(block_num, proof_bytes);
-                }
+                proving_tasks.abort_all();
                 return Ok(());
             },
             // Proving a block has completed - cache and commit the proof.
@@ -296,5 +293,30 @@ impl ProveBlockError {
             },
             _ => Self::Transient(err.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn abort_all_cancels_inflight_proof_tasks_without_waiting_for_completion() {
+        let mut tasks = ProofTaskJoinSet::new();
+        tasks
+            .0
+            .spawn(async { pending::<anyhow::Result<(BlockNumber, Vec<u8>)>>().await });
+
+        tasks.abort_all();
+
+        let result = tokio::time::timeout(Duration::from_millis(100), tasks.0.join_next())
+            .await
+            .expect("aborted proof task should be joinable immediately")
+            .expect("join set should contain the aborted proof task");
+
+        assert!(result.is_err_and(|err| err.is_cancelled()));
     }
 }

--- a/crates/block-producer/src/proof_scheduler.rs
+++ b/crates/block-producer/src/proof_scheduler.rs
@@ -20,6 +20,7 @@ use anyhow::Context;
 use miden_node_proto::BlockProofRequest;
 use miden_node_store::state::{Finality, State};
 use miden_node_utils::retry::{self, Retryable};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::{BlockNumber, BlockProof};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
@@ -59,6 +60,10 @@ impl ProofTaskJoinSet {
 
     fn len(&self) -> usize {
         self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     /// Spawns a new task to prove a block.
@@ -106,6 +111,7 @@ pub(crate) async fn run(
     state: Arc<State>,
     mut chain_tip_rx: watch::Receiver<BlockNumber>,
     max_concurrent_proofs: NonZeroUsize,
+    shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     info!(target: LOG_TARGET, "Proof scheduler started");
 
@@ -129,6 +135,13 @@ pub(crate) async fn run(
 
         // Wait for either a job to complete or the chain tip to advance.
         tokio::select! {
+            () = shutdown.cancelled() => {
+                while !proving_tasks.is_empty() {
+                    let (block_num, proof_bytes) = proving_tasks.join_next().await?;
+                    pending.insert(block_num, proof_bytes);
+                }
+                return Ok(());
+            },
             // Proving a block has completed - cache and commit the proof.
             proving_result = proving_tasks.join_next() => {
                 let (block_num, proof_bytes) = proving_result?;

--- a/crates/block-producer/src/rpc_sync.rs
+++ b/crates/block-producer/src/rpc_sync.rs
@@ -6,6 +6,7 @@ use miden_node_proto::clients::RpcClient;
 use miden_node_proto::generated::rpc::{BlockSubscriptionRequest, ProofSubscriptionRequest};
 use miden_node_store::state::{Finality, State};
 use miden_node_utils::retry::{self, Retryable};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::{BlockNumber, SignedBlock};
@@ -62,7 +63,7 @@ pub struct RpcSync {
 
 impl RpcSync {
     /// Runs the block and proof synchronization loops until one exits unexpectedly.
-    pub async fn run(self) -> anyhow::Result<()> {
+    pub async fn run(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         let mut tasks = Tasks::new();
         let block_sync = BlockSync {
             state: Arc::clone(&self.state),
@@ -74,10 +75,10 @@ impl RpcSync {
             source_rpc: self.source_rpc,
         };
 
-        tasks.spawn("block-sync", block_sync.run());
-        tasks.spawn("proof-sync", proof_sync.run());
+        tasks.spawn("block-sync", block_sync.run(shutdown.clone()));
+        tasks.spawn("proof-sync", proof_sync.run(shutdown.clone()));
 
-        tasks.join_next_as_error().await
+        tasks.join_next_or_cancelled(shutdown).await
     }
 }
 
@@ -91,9 +92,9 @@ struct BlockSync {
 }
 
 impl BlockSync {
-    async fn run(self) -> anyhow::Result<()> {
-        (|| async {
-            self.sync()
+    async fn run(self, shutdown: CancellationToken) -> anyhow::Result<()> {
+        let retry = (|| async {
+            self.sync(shutdown.clone())
                 .await
                 .and_then(|()| Err(anyhow::anyhow!("unexpected end of stream")))
         })
@@ -105,8 +106,12 @@ impl BlockSync {
                 retry.delay = %RECONNECT_DELAY.as_secs(),
                 "Block sync failed, retrying",
             );
-        })
-        .await
+        });
+
+        tokio::select! {
+            result = retry => result,
+            () = shutdown.cancelled() => Ok(()),
+        }
     }
 
     #[miden_instrument(
@@ -114,7 +119,7 @@ impl BlockSync {
         skip_all,
         err,
     )]
-    async fn sync(&self) -> anyhow::Result<()> {
+    async fn sync(&self, shutdown: CancellationToken) -> anyhow::Result<()> {
         let block_from = self.state.chain_tip(Finality::Committed).await.child().as_u32();
         info!(target: LOG_TARGET, block_from, "Connecting to upstream RPC for blocks");
 
@@ -124,7 +129,14 @@ impl BlockSync {
             .await?
             .into_inner();
 
-        while let Some(result) = stream.next().await {
+        loop {
+            let result = tokio::select! {
+                () = shutdown.cancelled() => return Ok(()),
+                result = stream.next() => result,
+            };
+            let Some(result) = result else {
+                return Ok(());
+            };
             let event = result?;
             let upstream_tip = BlockNumber::from(event.committed_chain_tip);
             let block = SignedBlock::read_from_bytes(&event.block)
@@ -134,8 +146,6 @@ impl BlockSync {
             let local_tip = self.state.chain_tip(Finality::Committed).await;
             self.readiness.update(upstream_tip, local_tip).await;
         }
-
-        Ok(())
     }
 }
 
@@ -151,9 +161,9 @@ impl ProofSync {
     /// once its block has been committed locally. This means proof sync can stall if block sync falls
     /// behind, but that is acceptable — there is no value in streaming proofs for blocks that have not
     /// yet been applied.
-    async fn run(self) -> anyhow::Result<()> {
-        (|| async {
-            self.sync()
+    async fn run(self, shutdown: CancellationToken) -> anyhow::Result<()> {
+        let retry = (|| async {
+            self.sync(shutdown.clone())
                 .await
                 .and_then(|()| Err(anyhow::anyhow!("unexpected end of stream")))
         })
@@ -165,11 +175,15 @@ impl ProofSync {
                 retry.delay = %RECONNECT_DELAY.as_secs(),
                 "Proof sync failed, retrying",
             );
-        })
-        .await
+        });
+
+        tokio::select! {
+            result = retry => result,
+            () = shutdown.cancelled() => Ok(()),
+        }
     }
 
-    async fn sync(&self) -> anyhow::Result<()> {
+    async fn sync(&self, shutdown: CancellationToken) -> anyhow::Result<()> {
         // Subscribe from next proven tip.
         let starting_block = self.state.chain_tip(Finality::Proven).await.child();
         info!(
@@ -185,7 +199,14 @@ impl ProofSync {
 
         let mut expected = starting_block;
         let mut committed_tip_rx = self.state.subscribe_committed_tip();
-        while let Some(result) = stream.next().await {
+        loop {
+            let result = tokio::select! {
+                () = shutdown.cancelled() => return Ok(()),
+                result = stream.next() => result,
+            };
+            let Some(result) = result else {
+                return Ok(());
+            };
             let event = result?;
             let block_num = BlockNumber::from(event.block_num);
 
@@ -196,16 +217,16 @@ impl ProofSync {
 
             // Ensure the block is committed before applying its proof so that proven tip never
             // exceeds committed tip.
-            committed_tip_rx
-                .wait_for(|committed_tip| *committed_tip >= block_num)
-                .await
-                .context("committed tip channel closed")?;
+            tokio::select! {
+                () = shutdown.cancelled() => return Ok(()),
+                result = committed_tip_rx.wait_for(|committed_tip| *committed_tip >= block_num) => {
+                    result.context("committed tip channel closed")?;
+                },
+            }
 
             self.state.apply_proof(block_num, event.proof).await?;
 
             expected = expected.child();
         }
-
-        Ok(())
     }
 }

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use miden_node_store::state::{Finality, State};
 use miden_node_utils::formatting::{format_input_notes, format_output_notes};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::batch::ProposedBatch;
@@ -101,7 +102,7 @@ pub struct Sequencer {
 
 impl Sequencer {
     /// Spawns the sequencer tasks and returns its in-process API.
-    pub async fn spawn(self) -> Result<SequencerHandle> {
+    pub async fn spawn(self, shutdown: CancellationToken) -> Result<SequencerHandle> {
         tracing::info!(target: LOG_TARGET, "Initializing sequencer");
         let store = self.store;
         let validator =
@@ -124,7 +125,7 @@ impl Sequencer {
             mempool_tx_capacity: self.mempool_tx_capacity,
         };
         let mempool = Mempool::shared(chain_tip, api_config.mempool_config());
-        let api = BlockProducerApi::from_shared_mempool(mempool.clone(), store);
+        let api = BlockProducerApi::from_shared_mempool(mempool.clone(), store, shutdown.clone());
         let block_prover = if let Some(url) = self.block_prover_url {
             Arc::new(BlockProver::remote(url))
         } else {
@@ -141,20 +142,29 @@ impl Sequencer {
 
         tasks.spawn("batch-builder", {
             let mempool = mempool.clone();
-            async { batch_builder.run(mempool).await }
+            let shutdown = shutdown.clone();
+            async { batch_builder.run(mempool, shutdown).await }
         });
         tasks.spawn("block-builder", {
             let mempool = mempool.clone();
-            async { block_builder.run(mempool).await }
+            let shutdown = shutdown.clone();
+            async { block_builder.run(mempool, shutdown).await }
         });
         tasks.spawn("proof-scheduler", {
             let store = Arc::clone(&api.store);
+            let shutdown = shutdown.clone();
             async move {
-                proof_scheduler::run(block_prover, store, chain_tip_rx, self.max_concurrent_proofs)
-                    .await
+                proof_scheduler::run(
+                    block_prover,
+                    store,
+                    chain_tip_rx,
+                    self.max_concurrent_proofs,
+                    shutdown,
+                )
+                .await
             }
         });
-        let task = tokio::spawn(async move { tasks.join_next_as_error().await });
+        let task = tokio::spawn(async move { tasks.join_next_or_cancelled(shutdown).await });
 
         Ok(SequencerHandle { api, task })
     }
@@ -164,7 +174,7 @@ impl Sequencer {
     /// Executes in place (i.e. not spawned) and will run indefinitely until a fatal error is
     /// encountered.
     pub async fn serve(self) -> anyhow::Result<()> {
-        self.spawn().await?.wait().await
+        self.spawn(CancellationToken::new()).await?.wait().await
     }
 }
 
@@ -229,10 +239,18 @@ pub struct BlockProducerStatus {
 impl BlockProducerApi {
     /// Creates an API backed by a fresh mempool.
     pub fn new(store: Arc<State>, chain_tip: BlockNumber, config: BlockProducerApiConfig) -> Self {
-        Self::from_shared_mempool(Mempool::shared(chain_tip, config.mempool_config()), store)
+        Self::from_shared_mempool(
+            Mempool::shared(chain_tip, config.mempool_config()),
+            store,
+            CancellationToken::new(),
+        )
     }
 
-    fn from_shared_mempool(mempool: SharedMempool, store: Arc<State>) -> Self {
+    fn from_shared_mempool(
+        mempool: SharedMempool,
+        store: Arc<State>,
+        shutdown: CancellationToken,
+    ) -> Self {
         let cached_mempool_stats = mempool
             .lock()
             .map(|mempool| MempoolStats::from_mempool(&mempool))
@@ -242,14 +260,14 @@ impl BlockProducerApi {
             store,
             cached_mempool_stats: Arc::new(RwLock::new(cached_mempool_stats)),
         };
-        api.spawn_mempool_stats_updater();
+        api.spawn_mempool_stats_updater(shutdown);
         api
     }
 
     /// Starts a background task that periodically updates the cached mempool statistics.
     ///
     /// This prevents the need to lock the mempool for each status request.
-    fn spawn_mempool_stats_updater(&self) {
+    fn spawn_mempool_stats_updater(&self, shutdown: CancellationToken) {
         let cached_mempool_stats = Arc::clone(&self.cached_mempool_stats);
         let mempool = Arc::clone(&self.mempool);
 
@@ -262,7 +280,10 @@ impl BlockProducerApi {
             let mut interval = tokio::time::interval(CACHED_MEMPOOL_STATS_UPDATE_INTERVAL);
 
             loop {
-                interval.tick().await;
+                tokio::select! {
+                    () = shutdown.cancelled() => return,
+                    _ = interval.tick() => {},
+                }
 
                 let stats = {
                     let Ok(mempool) = mempool.lock() else {

--- a/crates/block-producer/src/server/tests.rs
+++ b/crates/block-producer/src/server/tests.rs
@@ -39,7 +39,7 @@ async fn block_producer_starts_with_store_state() {
         mempool_tx_capacity: NonZeroUsize::new(100).unwrap(),
         batch_workers: DEFAULT_BATCH_WORKERS,
     }
-    .spawn()
+    .spawn(miden_node_utils::shutdown::CancellationToken::new())
     .await
     .unwrap();
 

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -17,6 +17,7 @@ use miden_node_utils::clap::{GrpcOptionsExternal, GrpcOptionsInternal};
 use miden_node_utils::cors::cors_for_grpc_web_layer;
 use miden_node_utils::grpc;
 use miden_node_utils::panic::{CatchPanicLayer, catch_panic_layer_fn};
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
 use tokio::net::TcpListener;
@@ -108,7 +109,7 @@ impl Rpc {
     ///
     /// Note: Executes in place (i.e. not spawned) and will run indefinitely until
     ///       a fatal error is encountered.
-    pub async fn serve(self) -> anyhow::Result<()> {
+    pub async fn serve(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         let mut api = api::RpcService::new(
             self.store.clone(),
             self.mode.clone(),
@@ -156,7 +157,7 @@ impl Rpc {
                         source_rpc: *source_rpc,
                         readiness,
                     }
-                    .run(),
+                    .run(shutdown.clone()),
                 );
             },
         }
@@ -209,10 +210,13 @@ impl Rpc {
             .add_service(health_service)
             // Enables gRPC reflection service.
             .add_service(reflection_service)
-            .serve_with_incoming(TcpListenerStream::new(self.listener));
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(self.listener),
+                shutdown.clone().cancelled_owned(),
+            );
         tasks.spawn("RPC server", async move { rpc.await.map_err(|e| anyhow::anyhow!(e)) });
 
-        tasks.join_next_as_error().await
+        tasks.join_next_or_cancelled(shutdown).await
     }
 }
 
@@ -241,7 +245,7 @@ impl SequencerInternal {
     ///
     /// Executes in place (i.e. not spawned) and will run indefinitely until a fatal error is
     /// encountered.
-    pub async fn serve(self) -> anyhow::Result<()> {
+    pub async fn serve(self, shutdown: CancellationToken) -> anyhow::Result<()> {
         info!(target: COMPONENT, endpoint = ?self.listener, "Internal sequencer server initialized");
 
         let service = SequencerInternalService { block_producer: self.block_producer };
@@ -253,7 +257,10 @@ impl SequencerInternal {
             .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
             .timeout(self.grpc_options.request_timeout)
             .add_service(sequencer_api::service(service))
-            .serve_with_incoming(TcpListenerStream::new(self.listener))
+            .serve_with_incoming_shutdown(
+                TcpListenerStream::new(self.listener),
+                shutdown.cancelled_owned(),
+            )
             .await
             .context("failed to serve internal sequencer API")
     }

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -796,7 +796,7 @@ async fn start_rpc_with_options(
             grpc_options,
             network_tx_auth: None,
         }
-        .serve()
+        .serve(miden_node_utils::shutdown::CancellationToken::new())
         .await
         .expect("Failed to start serving store");
     });

--- a/crates/store/src/state/disk_monitor.rs
+++ b/crates/store/src/state/disk_monitor.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 
@@ -10,13 +11,16 @@ use crate::state::State;
 impl State {
     /// Spawns a background task that periodically records the on-disk size of every store data path
     /// as `OTel` span attributes.
-    pub fn spawn_disk_monitor(&self) -> tokio::task::JoinHandle<()> {
+    pub fn spawn_disk_monitor(&self, shutdown: CancellationToken) -> tokio::task::JoinHandle<()> {
         let data_directory = self.data_directory.clone();
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_mins(5));
             loop {
-                interval.tick().await;
+                tokio::select! {
+                    () = shutdown.cancelled() => return,
+                    _ = interval.tick() => {},
+                }
                 let _ = measure_disk_space_usage(data_directory.clone()).await;
             }
         })

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -42,7 +42,8 @@ opentelemetry_sdk        = { features = ["rt-tokio", "testing"], version = "0.31
 rand                     = { workspace = true }
 reqwest                  = { workspace = true }
 thiserror                = { workspace = true }
-tokio                    = { workspace = true }
+tokio                    = { features = ["macros", "rt", "signal", "time"], workspace = true }
+tokio-util               = { workspace = true }
 tonic                    = { default-features = true, workspace = true }
 tower                    = { features = ["limit"], workspace = true }
 tower-http               = { features = ["catch-panic"], workspace = true }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod lru_cache;
 pub mod panic;
 pub mod retry;
+pub mod shutdown;
 pub mod spawn;
 pub mod tasks;
 pub mod tracing;

--- a/crates/utils/src/shutdown.rs
+++ b/crates/utils/src/shutdown.rs
@@ -1,0 +1,64 @@
+use std::future::Future;
+use std::time::Duration;
+
+use anyhow::Context;
+pub use tokio_util::sync::CancellationToken;
+
+/// Time allowed for services to finish after a shutdown signal before the process exits.
+pub const GRACE_PERIOD: Duration = Duration::from_secs(10);
+
+/// Runs a service future until it completes or a shutdown signal is received.
+///
+/// On `SIGTERM` or Ctrl-C, the provided root cancellation token is cancelled and the service future
+/// is given [`GRACE_PERIOD`] to complete. If it does not, the process exits immediately so
+/// blocking work cannot hold the Tokio runtime alive indefinitely.
+pub async fn run_with_shutdown<F, Fut>(run: F) -> anyhow::Result<()>
+where
+    F: FnOnce(CancellationToken) -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    let token = CancellationToken::new();
+    let service = run(token.clone());
+    tokio::pin!(service);
+
+    tokio::select! {
+        result = &mut service => result,
+        result = shutdown_signal() => {
+            result?;
+            tracing::info!("Shutdown signal received; cancelling service tasks");
+            token.cancel();
+
+            let Ok(result) = tokio::time::timeout(GRACE_PERIOD, &mut service).await else {
+                tracing::error!(
+                    grace_period = ?GRACE_PERIOD,
+                    "Graceful shutdown timed out; exiting process",
+                );
+                std::process::exit(0);
+            };
+
+            result
+        },
+    }
+}
+
+/// Waits for SIGTERM or Ctrl-C.
+pub async fn shutdown_signal() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .context("failed to install SIGTERM handler")?;
+
+        tokio::select! {
+            _ = terminate.recv() => Ok(()),
+            result = tokio::signal::ctrl_c() => {
+                result.context("failed to install Ctrl-C handler")
+            },
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await.context("failed to install Ctrl-C handler")
+    }
+}

--- a/crates/utils/src/tasks.rs
+++ b/crates/utils/src/tasks.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use anyhow::Context;
 use tokio::task::{Id, JoinError, JoinSet};
 
+use crate::shutdown::CancellationToken;
+
 /// A named task set for supervising concurrently-running Tokio tasks.
 ///
 /// Dropping a task set aborts all tasks that are still running.
@@ -81,10 +83,125 @@ impl Tasks {
             anyhow::bail!("task set is empty");
         };
 
+        Self::unexpected_completion(&task, result)
+    }
+
+    /// Waits for either an unexpected task completion or a shutdown request.
+    ///
+    /// Before shutdown, any task completion is treated as fatal because this type supervises
+    /// long-running tasks. Once `token` is cancelled, clean task exits are accepted and this method
+    /// waits for all tracked tasks to finish.
+    pub async fn join_next_or_cancelled(&mut self, token: CancellationToken) -> anyhow::Result<()> {
+        while !token.is_cancelled() {
+            tokio::select! {
+                biased;
+                () = token.cancelled() => break,
+                result = self.join_next() => {
+                    let Some((task, result)) = result else {
+                        anyhow::bail!("task set is empty");
+                    };
+                    Self::unexpected_completion(&task, result)?;
+                },
+            }
+        }
+
+        while let Some((task, result)) = self.join_next().await {
+            Self::shutdown_completion(&task, result)?;
+        }
+
+        Ok(())
+    }
+
+    fn unexpected_completion(
+        task: &str,
+        result: Result<anyhow::Result<()>, JoinError>,
+    ) -> anyhow::Result<()> {
         match result {
             Ok(Ok(())) => anyhow::bail!("task {task} completed unexpectedly"),
             Ok(Err(err)) => Err(err).with_context(|| format!("task {task} failed")),
             Err(err) => Err(err).with_context(|| format!("task {task} failed to join")),
         }
+    }
+
+    fn shutdown_completion(
+        task: &str,
+        result: Result<anyhow::Result<()>, JoinError>,
+    ) -> anyhow::Result<()> {
+        match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(err)) => Err(err).with_context(|| format!("task {task} failed during shutdown")),
+            Err(err) if err.is_cancelled() => Ok(()),
+            Err(err) => Err(err).with_context(|| format!("task {task} failed to join")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn join_next_or_cancelled_accepts_clean_task_completion_after_cancellation() {
+        let token = crate::shutdown::CancellationToken::new();
+        let mut tasks = Tasks::new();
+        tasks.spawn("worker", {
+            let token = token.clone();
+            async move {
+                token.cancelled().await;
+                Ok(())
+            }
+        });
+
+        token.cancel();
+
+        tasks
+            .join_next_or_cancelled(token)
+            .await
+            .expect("clean shutdown should not be treated as an error");
+    }
+
+    #[tokio::test]
+    async fn join_next_or_cancelled_treats_task_completion_before_cancellation_as_error() {
+        let token = crate::shutdown::CancellationToken::new();
+        let mut tasks = Tasks::new();
+        tasks.spawn("worker", async { Ok(()) });
+
+        let err = tasks
+            .join_next_or_cancelled(token)
+            .await
+            .expect_err("unexpected task completion should fail before shutdown");
+
+        assert_eq!(err.to_string(), "task worker completed unexpectedly");
+    }
+
+    #[tokio::test]
+    async fn join_next_or_cancelled_waits_for_all_tasks_to_complete_after_cancellation() {
+        let token = crate::shutdown::CancellationToken::new();
+        let mut tasks = Tasks::new();
+        tasks.spawn("worker-a", {
+            let token = token.clone();
+            async move {
+                token.cancelled().await;
+                Ok(())
+            }
+        });
+        tasks.spawn("worker-b", {
+            let token = token.clone();
+            async move {
+                token.cancelled().await;
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok(())
+            }
+        });
+
+        token.cancel();
+
+        tasks
+            .join_next_or_cancelled(token)
+            .await
+            .expect("shutdown should wait for all clean task exits");
+        assert!(tasks.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This PR implements graceful shutdown for all node services:

  - Adds shared shutdown utilities using `CancellationToken`, handling `SIGTERM` and `Ctrl-C` (`SIGINT`) with a 10s grace period before forced process exit.
  - Extends task supervision so long-running task groups can exit cleanly after cancellation while still treating unexpected pre-shutdown exits as fatal.
  - Wires cancellation through standalone services: sequencer/full node, ntx-builder, validator, and remote prover.
  - Converts tonic gRPC servers to `serve_with_incoming_shutdown(...)`.
  - Makes sequencer internals, full-node sync loops, ntx-builder event loop/account actors, and store disk monitor respond to cancellation.
  - Adds focused tests for shutdown-aware task supervision and updates affected test helpers.

Closes #91 

## Changelog

```toml
[[entry]]
scope       = "general"
impact      = "added"
description = "Node services now shut down cleanly upon receiving a SIGTERM or SIGINT signal."
```
