### PR TITLE
refactor(rpc): gRPC codegen should pass request metadata to `handle()`

### DIFF
--- a/bin/ntx-builder/src/server/get_network_note_status.rs
+++ b/bin/ntx-builder/src/server/get_network_note_status.rs
@@ -29,7 +29,11 @@ impl grpc::server::ntx_builder_api::GetNetworkNoteStatus for NtxBuilderRpcServer
         ),
         err,
     )]
-    async fn handle(&self, note_id: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        note_id: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         let row = self.db.get_note_status(note_id).await.map_err(|err| {
             tracing::error!(target: LOG_TARGET, error = %err, "Failed to query note status from DB");
             tonic::Status::internal("database error")

--- a/bin/ntx-builder/src/server/get_network_note_status.rs
+++ b/bin/ntx-builder/src/server/get_network_note_status.rs
@@ -31,8 +31,9 @@ impl grpc::server::ntx_builder_api::GetNetworkNoteStatus for NtxBuilderRpcServer
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         note_id: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         let row = self.db.get_note_status(note_id).await.map_err(|err| {
             tracing::error!(target: LOG_TARGET, error = %err, "Failed to query note status from DB");

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -16,7 +16,11 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
         skip_all,
         err,
     )]
-    async fn handle(&self, (proof_kind, request): Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        (proof_kind, request): Self::Input,
+    ) -> tonic::Result<Self::Output> {
         miden_span_record!(
             request.kind = %proof_kind,
         );

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -18,8 +18,9 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         (proof_kind, request): Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         miden_span_record!(
             request.kind = %proof_kind,

--- a/bin/remote-prover/src/server/status.rs
+++ b/bin/remote-prover/src/server/status.rs
@@ -17,7 +17,11 @@ impl grpc::server::remote_prover_worker_status_api::Status for StatusService {
     type Input = ();
     type Output = grpc::remote_prover::WorkerStatus;
 
-    async fn handle(&self, _input: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        _input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         Ok(grpc::remote_prover::WorkerStatus {
             version: env!("CARGO_PKG_VERSION").to_string(),
             supported_proof_type: self.kind as i32,

--- a/bin/remote-prover/src/server/status.rs
+++ b/bin/remote-prover/src/server/status.rs
@@ -19,8 +19,9 @@ impl grpc::server::remote_prover_worker_status_api::Status for StatusService {
 
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         _input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         Ok(grpc::remote_prover::WorkerStatus {
             version: env!("CARGO_PKG_VERSION").to_string(),

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -51,7 +51,11 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::ItemStream> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::ItemStream> {
         miden_span_record!(block.from = request.block_from,);
 
         let committed_tip = *self.committed_tip.borrow();

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -53,8 +53,9 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::ItemStream> {
         miden_span_record!(block.from = request.block_from,);
 

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -31,7 +31,11 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
         })
     }
 
-    async fn handle(&self, proposed_block: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        proposed_block: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         // Reject requests while a backup subscription is streaming.
         let _guard = self.serve_lock.try_read().map_err(|_| {
             tonic::Status::resource_exhausted("validator is busy streaming a backup")

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -33,8 +33,9 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
 
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         proposed_block: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         // Reject requests while a backup subscription is streaming.
         let _guard = self.serve_lock.try_read().map_err(|_| {

--- a/bin/validator/src/server/validator_service/status.rs
+++ b/bin/validator/src/server/validator_service/status.rs
@@ -29,7 +29,11 @@ impl grpc::server::validator_api::Status for ValidatorService {
         })
     }
 
-    async fn handle(&self, _input: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        _input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         unimplemented!()
     }
 

--- a/bin/validator/src/server/validator_service/status.rs
+++ b/bin/validator/src/server/validator_service/status.rs
@@ -31,8 +31,9 @@ impl grpc::server::validator_api::Status for ValidatorService {
 
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         _input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         unimplemented!()
     }

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -23,7 +23,11 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
         skip_all,
         err,
     )]
-    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         // Reject requests while a backup subscription is streaming.
         let _guard = self
             .serve_lock

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -25,8 +25,9 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         // Reject requests while a backup subscription is streaming.
         let _guard = self

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -432,14 +432,20 @@ impl UnaryMethod {
     ///
     ///     fn decode(request: <Method::request>) -> tonic::Result<Self::Input>;
     ///     fn encode(output: Self::Output) -> tonic::Result<Method::response>;
-    ///     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output>;
+    ///     async fn handle(
+    ///         &self,
+    ///         request: &tonic::Request<()>,
+    ///         input: Self::Input,
+    ///     ) -> tonic::Result<Self::Output>;
     ///
     ///     async fn full(
     ///         &self,
     ///         request: tonic::Request<<Method::Request>>,
     ///     ) -> tonic::Result<<Method::response>> {
-    ///         let input = Self::decode(request.into_inner())?;
-    ///         let output = self.handle(input).await?;
+    ///         let (metadata, extensions, message) = request.into_parts();
+    ///         let request = tonic::Request::from_parts(metadata, extensions, ());
+    ///         let input = Self::decode(message)?;
+    ///         let output = self.handle(&request, input).await?;
     ///         Self::encode(output)
     ///     }
     /// }
@@ -462,6 +468,7 @@ impl UnaryMethod {
         ret.new_fn("handle")
             .set_async(true)
             .arg_ref_self()
+            .arg("request", "&tonic::Request<()>")
             .arg("input", "Self::Input")
             .ret("tonic::Result<Self::Output>");
 
@@ -470,8 +477,10 @@ impl UnaryMethod {
             .arg_ref_self()
             .arg("request", format!("tonic::Request<{}>", &self.request))
             .ret(format!("tonic::Result<{}>", &self.response))
-            .line("let input = Self::decode(request.into_inner())?;")
-            .line("let output = self.handle(input).await?;")
+            .line("let (metadata, extensions, message) = request.into_parts();")
+            .line("let request = tonic::Request::from_parts(metadata, extensions, ());")
+            .line("let input = Self::decode(message)?;")
+            .line("let output = self.handle(&request, input).await?;")
             .line("Self::encode(output)");
 
         ret
@@ -498,13 +507,19 @@ impl ServerStream {
     ///
     ///     fn decode(request: <Method::request>) -> tonic::Result<Self::Input>;
     ///     fn encode(item: Self::Item) -> tonic::Result<Method::response>;
-    ///     async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream>;
+    ///     async fn handle(
+    ///         &self,
+    ///         request: &tonic::Request<()>,
+    ///         input: Self::Input,
+    ///     ) -> tonic::Result<Self::ItemStream>;
     ///
     ///     async fn full(&self, request: tonic::Request<<Method::request>>) -> tonic::Result<Pin<Box<dyn Stream<...>>>> {
     ///         use tokio_stream::StreamExt as _;
-    ///         let input = Self::decode(request.into_inner())?;
-    ///         let stream = self.handle(input).await?;
-    ///         Ok(Box::pin(stream.map(|item| item.and_then(|i| Self::encode(i)))))
+    ///         let (metadata, extensions, message) = request.into_parts();
+    ///         let request = tonic::Request::from_parts(metadata, extensions, ());
+    ///         let input = Self::decode(message)?;
+    ///         let stream = self.handle(&request, input).await?;
+    ///         Ok(Box::pin(stream.map(|item| item.and_then(Self::encode))))
     ///     }
     /// }
     /// ```
@@ -537,6 +552,7 @@ impl ServerStream {
         ret.new_fn("handle")
             .set_async(true)
             .arg_ref_self()
+            .arg("request", "&tonic::Request<()>")
             .arg("input", "Self::Input")
             .ret("tonic::Result<Self::ItemStream>");
 
@@ -546,9 +562,11 @@ impl ServerStream {
             .arg("request", format!("tonic::Request<{}>", &self.request))
             .ret(format!("tonic::Result<{boxed_stream}>"))
             .line("use tonic::codegen::tokio_stream::StreamExt as _;")
-            .line("let input = Self::decode(request.into_inner())?;")
-            .line("let stream = self.handle(input).await?;")
-            .line("Ok(Box::pin(stream.map(|item| item.and_then(|i| Self::encode(i)))))");
+            .line("let (metadata, extensions, message) = request.into_parts();")
+            .line("let request = tonic::Request::from_parts(metadata, extensions, ());")
+            .line("let input = Self::decode(message)?;")
+            .line("let stream = self.handle(&request, input).await?;")
+            .line("Ok(Box::pin(stream.map(|item| item.and_then(Self::encode))))");
 
         ret
     }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -434,8 +434,9 @@ impl UnaryMethod {
     ///     fn encode(output: Self::Output) -> tonic::Result<Method::response>;
     ///     async fn handle(
     ///         &self,
-    ///         request: &tonic::Request<()>,
     ///         input: Self::Input,
+    ///         metadata: &tonic::metadata::MetadataMap,
+    ///         extensions: &tonic::codegen::http::Extensions,
     ///     ) -> tonic::Result<Self::Output>;
     ///
     ///     async fn full(
@@ -443,9 +444,8 @@ impl UnaryMethod {
     ///         request: tonic::Request<<Method::Request>>,
     ///     ) -> tonic::Result<<Method::response>> {
     ///         let (metadata, extensions, message) = request.into_parts();
-    ///         let request = tonic::Request::from_parts(metadata, extensions, ());
     ///         let input = Self::decode(message)?;
-    ///         let output = self.handle(&request, input).await?;
+    ///         let output = self.handle(input, &metadata, &extensions).await?;
     ///         Self::encode(output)
     ///     }
     /// }
@@ -468,8 +468,9 @@ impl UnaryMethod {
         ret.new_fn("handle")
             .set_async(true)
             .arg_ref_self()
-            .arg("request", "&tonic::Request<()>")
             .arg("input", "Self::Input")
+            .arg("metadata", "&tonic::metadata::MetadataMap")
+            .arg("extensions", "&tonic::codegen::http::Extensions")
             .ret("tonic::Result<Self::Output>");
 
         ret.new_fn("full")
@@ -478,9 +479,8 @@ impl UnaryMethod {
             .arg("request", format!("tonic::Request<{}>", &self.request))
             .ret(format!("tonic::Result<{}>", &self.response))
             .line("let (metadata, extensions, message) = request.into_parts();")
-            .line("let request = tonic::Request::from_parts(metadata, extensions, ());")
             .line("let input = Self::decode(message)?;")
-            .line("let output = self.handle(&request, input).await?;")
+            .line("let output = self.handle(input, &metadata, &extensions).await?;")
             .line("Self::encode(output)");
 
         ret
@@ -509,16 +509,16 @@ impl ServerStream {
     ///     fn encode(item: Self::Item) -> tonic::Result<Method::response>;
     ///     async fn handle(
     ///         &self,
-    ///         request: &tonic::Request<()>,
     ///         input: Self::Input,
+    ///         metadata: &tonic::metadata::MetadataMap,
+    ///         extensions: &tonic::codegen::http::Extensions,
     ///     ) -> tonic::Result<Self::ItemStream>;
     ///
     ///     async fn full(&self, request: tonic::Request<<Method::request>>) -> tonic::Result<Pin<Box<dyn Stream<...>>>> {
     ///         use tokio_stream::StreamExt as _;
     ///         let (metadata, extensions, message) = request.into_parts();
-    ///         let request = tonic::Request::from_parts(metadata, extensions, ());
     ///         let input = Self::decode(message)?;
-    ///         let stream = self.handle(&request, input).await?;
+    ///         let stream = self.handle(input, &metadata, &extensions).await?;
     ///         Ok(Box::pin(stream.map(|item| item.and_then(Self::encode))))
     ///     }
     /// }
@@ -552,8 +552,9 @@ impl ServerStream {
         ret.new_fn("handle")
             .set_async(true)
             .arg_ref_self()
-            .arg("request", "&tonic::Request<()>")
             .arg("input", "Self::Input")
+            .arg("metadata", "&tonic::metadata::MetadataMap")
+            .arg("extensions", "&tonic::codegen::http::Extensions")
             .ret("tonic::Result<Self::ItemStream>");
 
         ret.new_fn("full")
@@ -563,9 +564,8 @@ impl ServerStream {
             .ret(format!("tonic::Result<{boxed_stream}>"))
             .line("use tonic::codegen::tokio_stream::StreamExt as _;")
             .line("let (metadata, extensions, message) = request.into_parts();")
-            .line("let request = tonic::Request::from_parts(metadata, extensions, ());")
             .line("let input = Self::decode(message)?;")
-            .line("let stream = self.handle(&request, input).await?;")
+            .line("let stream = self.handle(input, &metadata, &extensions).await?;")
             .line("Ok(Box::pin(stream.map(|item| item.and_then(Self::encode))))");
 
         ret

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -37,8 +37,9 @@ impl proto::server::rpc_api::GetAccount for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         miden_span_record!(
             account.id = %request.account_id,

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -35,7 +35,11 @@ impl proto::server::rpc_api::GetAccount for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         miden_span_record!(
             account.id = %request.account_id,
         );

--- a/crates/rpc/src/server/api/get_block_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_by_number.rs
@@ -30,8 +30,9 @@ impl proto::server::rpc_api::GetBlockByNumber for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, ?request, "Getting block by number");
 

--- a/crates/rpc/src/server/api/get_block_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_by_number.rs
@@ -28,7 +28,11 @@ impl proto::server::rpc_api::GetBlockByNumber for RpcService {
         ),
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, ?request, "Getting block by number");
 
         let block_num = BlockNumber::from(request.block_num);

--- a/crates/rpc/src/server/api/get_block_header_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_header_by_number.rs
@@ -30,8 +30,9 @@ impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, ?request, "Getting block header by number");
 

--- a/crates/rpc/src/server/api/get_block_header_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_header_by_number.rs
@@ -28,7 +28,11 @@ impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
         ),
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, ?request, "Getting block header by number");
 
         let block_num = request.block_num.map(BlockNumber::from);

--- a/crates/rpc/src/server/api/get_limits.rs
+++ b/crates/rpc/src/server/api/get_limits.rs
@@ -26,8 +26,9 @@ impl proto::server::rpc_api::GetLimits for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         _input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, "Getting limits");
 

--- a/crates/rpc/src/server/api/get_limits.rs
+++ b/crates/rpc/src/server/api/get_limits.rs
@@ -24,7 +24,11 @@ impl proto::server::rpc_api::GetLimits for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, _request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        _input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, "Getting limits");
 
         Ok(RPC_LIMITS.clone())

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -2,7 +2,6 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 use miden_protocol::Word;
 use tonic::Request;
-use tonic::metadata::{Ascii, MetadataValue};
 use tracing::debug;
 
 use super::{RpcMode, RpcService};
@@ -10,7 +9,6 @@ use crate::{COMPONENT, LOG_TARGET};
 
 pub struct GetNetworkNoteStatusInput {
     request: proto::note::NoteId,
-    original_accept_header: Option<MetadataValue<Ascii>>,
 }
 
 #[tonic::async_trait]
@@ -19,20 +17,11 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
     type Output = proto::rpc::GetNetworkNoteStatusResponse;
 
     fn decode(request: proto::note::NoteId) -> tonic::Result<Self::Input> {
-        Ok(GetNetworkNoteStatusInput { request, original_accept_header: None })
+        Ok(GetNetworkNoteStatusInput { request })
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::rpc::GetNetworkNoteStatusResponse> {
         Ok(output)
-    }
-
-    async fn full(&self, request: Request<proto::note::NoteId>) -> tonic::Result<Self::Output> {
-        let original_accept_header = request.metadata().get(http::header::ACCEPT.as_str()).cloned();
-        let mut input = Self::decode(request.into_inner())?;
-        input.original_accept_header = original_accept_header;
-
-        let output = self.handle(input).await?;
-        Self::encode(output)
     }
 
     #[miden_instrument(
@@ -41,8 +30,14 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
-        let GetNetworkNoteStatusInput { request, original_accept_header } = request;
+    async fn handle(
+        &self,
+        request_context: &Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
+        let GetNetworkNoteStatusInput { request } = request;
+        let original_accept_header =
+            request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
 
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -28,11 +28,11 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
     )]
     async fn handle(
         &self,
-        request_context: &Request<()>,
         request: Self::Input,
+        metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
-        let original_accept_header =
-            request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
+        let original_accept_header = metadata.get(http::header::ACCEPT.as_str()).cloned();
 
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -7,17 +7,13 @@ use tracing::debug;
 use super::{RpcMode, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
-pub struct GetNetworkNoteStatusInput {
-    request: proto::note::NoteId,
-}
-
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
-    type Input = GetNetworkNoteStatusInput;
+    type Input = proto::note::NoteId;
     type Output = proto::rpc::GetNetworkNoteStatusResponse;
 
     fn decode(request: proto::note::NoteId) -> tonic::Result<Self::Input> {
-        Ok(GetNetworkNoteStatusInput { request })
+        Ok(request)
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::rpc::GetNetworkNoteStatusResponse> {
@@ -35,7 +31,6 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
         request_context: &Request<()>,
         request: Self::Input,
     ) -> tonic::Result<Self::Output> {
-        let GetNetworkNoteStatusInput { request } = request;
         let original_accept_header =
             request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
 

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -9,11 +9,17 @@ use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
-    type Input = proto::note::NoteId;
+    type Input = miden_protocol::note::NoteId;
     type Output = proto::rpc::GetNetworkNoteStatusResponse;
 
     fn decode(request: proto::note::NoteId) -> tonic::Result<Self::Input> {
-        Ok(request)
+        let note_id_digest: Word = request
+            .id
+            .as_ref()
+            .ok_or_else(|| tonic::Status::invalid_argument("missing note ID digest"))?
+            .try_into()
+            .map_err(|_| tonic::Status::invalid_argument("invalid note ID digest"))?;
+        Ok(miden_protocol::note::NoteId::from_raw(note_id_digest))
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::rpc::GetNetworkNoteStatusResponse> {
@@ -36,20 +42,14 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
 
         tracing::trace!(target: LOG_TARGET, ?request);
 
-        let note_id_digest: Word = request
-            .id
-            .as_ref()
-            .ok_or_else(|| tonic::Status::invalid_argument("missing note ID digest"))?
-            .try_into()
-            .map_err(|_| tonic::Status::invalid_argument("invalid note ID digest"))?;
-        let note_id = miden_protocol::note::NoteId::from_raw(note_id_digest);
+        let note_id = request;
         miden_span_record!(
             note.id = %note_id,
         );
 
         debug!(target: LOG_TARGET, "Getting network note status");
 
-        let mut forwarded_request = Request::new(request);
+        let mut forwarded_request = Request::new(note_id.as_word().into());
         if let Some(accept) = original_accept_header {
             forwarded_request.metadata_mut().insert(http::header::ACCEPT.as_str(), accept);
         }

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -29,8 +29,9 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -27,7 +27,11 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let root = read_root::<Status>(request.root, "NoteScriptRoot")?;

--- a/crates/rpc/src/server/api/get_notes_by_id.rs
+++ b/crates/rpc/src/server/api/get_notes_by_id.rs
@@ -31,7 +31,11 @@ impl proto::server::rpc_api::GetNotesById for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         check::<QueryParamNoteIdLimit>(request.ids.len())?;

--- a/crates/rpc/src/server/api/get_notes_by_id.rs
+++ b/crates/rpc/src/server/api/get_notes_by_id.rs
@@ -33,8 +33,9 @@ impl proto::server::rpc_api::GetNotesById for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -27,8 +27,9 @@ impl proto::server::rpc_api::Status for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         _input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         let block_producer_status = match &self.mode {
             RpcMode::Sequencer { block_producer, .. } => {

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -25,7 +25,11 @@ impl proto::server::rpc_api::Status for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, _request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        _input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         let block_producer_status = match &self.mode {
             RpcMode::Sequencer { block_producer, .. } => {
                 Some(block_producer_status_to_proto(block_producer.status().await))

--- a/crates/rpc/src/server/api/submit_auth_tx.rs
+++ b/crates/rpc/src/server/api/submit_auth_tx.rs
@@ -23,8 +23,9 @@ impl sequencer_api::SubmitAuthenticatedTx for SequencerInternalService {
 
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         tx: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         self.block_producer
             .submit_authenticated_tx(tx)

--- a/crates/rpc/src/server/api/submit_auth_tx.rs
+++ b/crates/rpc/src/server/api/submit_auth_tx.rs
@@ -21,7 +21,11 @@ impl sequencer_api::SubmitAuthenticatedTx for SequencerInternalService {
         Ok(output)
     }
 
-    async fn handle(&self, tx: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        tx: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         self.block_producer
             .submit_authenticated_tx(tx)
             .await

--- a/crates/rpc/src/server/api/submit_auth_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_auth_tx_batch.rs
@@ -44,7 +44,11 @@ impl sequencer_api::SubmitAuthenticatedTxBatch for SequencerInternalService {
         Ok(output)
     }
 
-    async fn handle(&self, (batch, inputs): Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        (batch, inputs): Self::Input,
+    ) -> tonic::Result<Self::Output> {
         self.block_producer
             .submit_authenticated_tx_batch(batch, inputs)
             .await

--- a/crates/rpc/src/server/api/submit_auth_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_auth_tx_batch.rs
@@ -46,8 +46,9 @@ impl sequencer_api::SubmitAuthenticatedTxBatch for SequencerInternalService {
 
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         (batch, inputs): Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         self.block_producer
             .submit_authenticated_tx_batch(batch, inputs)

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -14,7 +14,6 @@ use miden_protocol::transaction::{
 };
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx::TransactionVerifier;
-use tonic::metadata::{Ascii, MetadataValue};
 use tonic::{Request, Status};
 use tracing::debug;
 
@@ -23,8 +22,6 @@ use crate::LOG_TARGET;
 
 pub struct SubmitProvenTxInput {
     request: proto::transaction::ProvenTransaction,
-    is_authorized_network_tx: bool,
-    original_accept_header: Option<MetadataValue<Ascii>>,
 }
 
 #[tonic::async_trait]
@@ -33,31 +30,11 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
     type Output = proto::blockchain::BlockNumber;
 
     fn decode(request: proto::transaction::ProvenTransaction) -> tonic::Result<Self::Input> {
-        Ok(SubmitProvenTxInput {
-            request,
-            is_authorized_network_tx: false,
-            original_accept_header: None,
-        })
+        Ok(SubmitProvenTxInput { request })
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::blockchain::BlockNumber> {
         Ok(output)
-    }
-
-    async fn full(
-        &self,
-        request: Request<proto::transaction::ProvenTransaction>,
-    ) -> tonic::Result<proto::blockchain::BlockNumber> {
-        let is_authorized_network_tx = self.is_authorized_network_tx(request.metadata());
-        let original_accept_header = request.metadata().get(http::header::ACCEPT.as_str()).cloned();
-
-        let mut input = Self::decode(request.into_inner())?;
-
-        input.is_authorized_network_tx = is_authorized_network_tx;
-        input.original_accept_header = original_accept_header;
-
-        let output = self.handle(input).await?;
-        Self::encode(output)
     }
 
     #[miden_instrument(
@@ -66,12 +43,15 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
-        let SubmitProvenTxInput {
-            mut request,
-            is_authorized_network_tx,
-            original_accept_header,
-        } = input;
+    async fn handle(
+        &self,
+        request_context: &Request<()>,
+        input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
+        let SubmitProvenTxInput { mut request } = input;
+        let is_authorized_network_tx = self.is_authorized_network_tx(request_context.metadata());
+        let original_accept_header =
+            request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
 
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -41,13 +41,13 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
     )]
     async fn handle(
         &self,
-        request_context: &Request<()>,
         input: Self::Input,
+        metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         let mut request = input;
-        let is_authorized_network_tx = self.is_authorized_network_tx(request_context.metadata());
-        let original_accept_header =
-            request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
+        let is_authorized_network_tx = self.is_authorized_network_tx(metadata);
+        let original_accept_header = metadata.get(http::header::ACCEPT.as_str()).cloned();
 
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -20,17 +20,13 @@ use tracing::debug;
 use super::{COMPONENT, RpcMode, RpcService};
 use crate::LOG_TARGET;
 
-pub struct SubmitProvenTxInput {
-    request: proto::transaction::ProvenTransaction,
-}
-
 #[tonic::async_trait]
 impl proto::server::rpc_api::SubmitProvenTx for RpcService {
-    type Input = SubmitProvenTxInput;
+    type Input = proto::transaction::ProvenTransaction;
     type Output = proto::blockchain::BlockNumber;
 
     fn decode(request: proto::transaction::ProvenTransaction) -> tonic::Result<Self::Input> {
-        Ok(SubmitProvenTxInput { request })
+        Ok(request)
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::blockchain::BlockNumber> {
@@ -48,7 +44,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
         request_context: &Request<()>,
         input: Self::Input,
     ) -> tonic::Result<Self::Output> {
-        let SubmitProvenTxInput { mut request } = input;
+        let mut request = input;
         let is_authorized_network_tx = self.is_authorized_network_tx(request_context.metadata());
         let original_accept_header =
             request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -13,17 +13,13 @@ use tonic::{Request, Status};
 use super::{RpcMode, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
-pub struct SubmitProvenTxBatchInput {
-    request: proto::transaction::TransactionBatch,
-}
-
 #[tonic::async_trait]
 impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
-    type Input = SubmitProvenTxBatchInput;
+    type Input = proto::transaction::TransactionBatch;
     type Output = proto::blockchain::BlockNumber;
 
     fn decode(request: proto::transaction::TransactionBatch) -> tonic::Result<Self::Input> {
-        Ok(SubmitProvenTxBatchInput { request })
+        Ok(request)
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::blockchain::BlockNumber> {
@@ -41,7 +37,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         request_context: &Request<()>,
         input: Self::Input,
     ) -> tonic::Result<Self::Output> {
-        let SubmitProvenTxBatchInput { request } = input;
+        let request = input;
         let is_authorized_network_tx = self.is_authorized_network_tx(request_context.metadata());
         let original_accept_header =
             request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -8,7 +8,6 @@ use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx_batch_prover::LocalBatchProver;
-use tonic::metadata::{Ascii, MetadataValue};
 use tonic::{Request, Status};
 
 use super::{RpcMode, RpcService};
@@ -16,8 +15,6 @@ use crate::{COMPONENT, LOG_TARGET};
 
 pub struct SubmitProvenTxBatchInput {
     request: proto::transaction::TransactionBatch,
-    is_authorized_network_tx: bool,
-    original_accept_header: Option<MetadataValue<Ascii>>,
 }
 
 #[tonic::async_trait]
@@ -26,30 +23,11 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
     type Output = proto::blockchain::BlockNumber;
 
     fn decode(request: proto::transaction::TransactionBatch) -> tonic::Result<Self::Input> {
-        Ok(SubmitProvenTxBatchInput {
-            request,
-            is_authorized_network_tx: false,
-            original_accept_header: None,
-        })
+        Ok(SubmitProvenTxBatchInput { request })
     }
 
     fn encode(output: Self::Output) -> tonic::Result<proto::blockchain::BlockNumber> {
         Ok(output)
-    }
-
-    async fn full(
-        &self,
-        request: Request<proto::transaction::TransactionBatch>,
-    ) -> tonic::Result<proto::blockchain::BlockNumber> {
-        let is_authorized_network_tx = self.is_authorized_network_tx(request.metadata());
-        let original_accept_header = request.metadata().get(http::header::ACCEPT.as_str()).cloned();
-
-        let mut input = Self::decode(request.into_inner())?;
-        input.is_authorized_network_tx = is_authorized_network_tx;
-        input.original_accept_header = original_accept_header;
-
-        let output = self.handle(input).await?;
-        Self::encode(output)
     }
 
     #[miden_instrument(
@@ -58,12 +36,15 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::Output> {
-        let SubmitProvenTxBatchInput {
-            request,
-            is_authorized_network_tx,
-            original_accept_header,
-        } = input;
+    async fn handle(
+        &self,
+        request_context: &Request<()>,
+        input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
+        let SubmitProvenTxBatchInput { request } = input;
+        let is_authorized_network_tx = self.is_authorized_network_tx(request_context.metadata());
+        let original_accept_header =
+            request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
 
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -34,13 +34,13 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
     )]
     async fn handle(
         &self,
-        request_context: &Request<()>,
         input: Self::Input,
+        metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         let request = input;
-        let is_authorized_network_tx = self.is_authorized_network_tx(request_context.metadata());
-        let original_accept_header =
-            request_context.metadata().get(http::header::ACCEPT.as_str()).cloned();
+        let is_authorized_network_tx = self.is_authorized_network_tx(metadata);
+        let original_accept_header = metadata.get(http::header::ACCEPT.as_str()).cloned();
 
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -1,11 +1,8 @@
-use std::net::IpAddr;
-
-use futures::StreamExt;
 use miden_node_proto::generated as proto;
 use miden_node_utils::grpc::ClientIp;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::BlockNumber;
-use tonic::{Request, Status};
+use tonic::Request;
 use tracing::debug;
 
 use super::super::{COMPONENT, RpcService};
@@ -14,7 +11,6 @@ use crate::LOG_TARGET;
 
 pub struct BlockSubscriptionInput {
     request: proto::rpc::BlockSubscriptionRequest,
-    client_ip: Option<IpAddr>,
 }
 
 #[tonic::async_trait]
@@ -24,7 +20,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
     type ItemStream = SubscriptionStream;
 
     fn decode(request: proto::rpc::BlockSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(BlockSubscriptionInput { request, client_ip: None })
+        Ok(BlockSubscriptionInput { request })
     }
 
     fn encode(event: Self::Item) -> tonic::Result<proto::rpc::BlockSubscriptionResponse> {
@@ -32,17 +28,6 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
             block: event.data,
             committed_chain_tip: event.tip.as_u32(),
         })
-    }
-
-    async fn full(
-        &self,
-        request: Request<proto::rpc::BlockSubscriptionRequest>,
-    ) -> tonic::Result<BlockSubscriptionResponseStream> {
-        let client_ip = ClientIp::from_request(&request);
-        let mut input = Self::decode(request.into_inner())?;
-        input.client_ip = client_ip;
-        let stream = self.handle(input).await?;
-        Ok(Box::pin(stream.map(|item| item.and_then(Self::encode))))
     }
 
     #[miden_instrument(
@@ -54,8 +39,13 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         ),
         err,
     )]
-    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream> {
-        let BlockSubscriptionInput { request, client_ip } = input;
+    async fn handle(
+        &self,
+        request_context: &Request<()>,
+        input: Self::Input,
+    ) -> tonic::Result<Self::ItemStream> {
+        let BlockSubscriptionInput { request } = input;
+        let client_ip = ClientIp::from_request(request_context);
 
         debug!(target: LOG_TARGET, "Subscribing to blocks");
 
@@ -63,12 +53,3 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         SubscriptionStream::blocks(self, from, client_ip)
     }
 }
-
-type BlockSubscriptionResponseStream = std::pin::Pin<
-    Box<
-        dyn tonic::codegen::tokio_stream::Stream<
-                Item = Result<proto::rpc::BlockSubscriptionResponse, Status>,
-            > + Send
-            + 'static,
-    >,
->;

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -10,12 +10,12 @@ use crate::LOG_TARGET;
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::BlockSubscription for RpcService {
-    type Input = proto::rpc::BlockSubscriptionRequest;
+    type Input = BlockNumber;
     type Item = StreamItem;
     type ItemStream = SubscriptionStream;
 
     fn decode(request: proto::rpc::BlockSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(request)
+        Ok(BlockNumber::from(request.block_from))
     }
 
     fn encode(event: Self::Item) -> tonic::Result<proto::rpc::BlockSubscriptionResponse> {
@@ -30,7 +30,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         name = "block_subscription",
         skip_all,
         fields(
-            block.from = %input.block_from,
+            block.from = %input,
         ),
         err,
     )]
@@ -40,12 +40,11 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         _metadata: &tonic::metadata::MetadataMap,
         extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::ItemStream> {
-        let request = input;
         let client_ip = ClientIp::from_extensions(extensions);
 
         debug!(target: LOG_TARGET, "Subscribing to blocks");
 
-        let from = BlockNumber::from(request.block_from);
+        let from = input;
         SubscriptionStream::blocks(self, from, client_ip)
     }
 }

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -2,7 +2,6 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::grpc::ClientIp;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::BlockNumber;
-use tonic::Request;
 use tracing::debug;
 
 use super::super::{COMPONENT, RpcService};
@@ -37,11 +36,12 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
     )]
     async fn handle(
         &self,
-        request_context: &Request<()>,
         input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::ItemStream> {
         let request = input;
-        let client_ip = ClientIp::from_request(request_context);
+        let client_ip = ClientIp::from_extensions(extensions);
 
         debug!(target: LOG_TARGET, "Subscribing to blocks");
 

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -9,18 +9,14 @@ use super::super::{COMPONENT, RpcService};
 use super::stream::{StreamItem, SubscriptionStream};
 use crate::LOG_TARGET;
 
-pub struct BlockSubscriptionInput {
-    request: proto::rpc::BlockSubscriptionRequest,
-}
-
 #[tonic::async_trait]
 impl proto::server::rpc_api::BlockSubscription for RpcService {
-    type Input = BlockSubscriptionInput;
+    type Input = proto::rpc::BlockSubscriptionRequest;
     type Item = StreamItem;
     type ItemStream = SubscriptionStream;
 
     fn decode(request: proto::rpc::BlockSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(BlockSubscriptionInput { request })
+        Ok(request)
     }
 
     fn encode(event: Self::Item) -> tonic::Result<proto::rpc::BlockSubscriptionResponse> {
@@ -35,7 +31,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         name = "block_subscription",
         skip_all,
         fields(
-            block.from = %input.request.block_from,
+            block.from = %input.block_from,
         ),
         err,
     )]
@@ -44,7 +40,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         request_context: &Request<()>,
         input: Self::Input,
     ) -> tonic::Result<Self::ItemStream> {
-        let BlockSubscriptionInput { request } = input;
+        let request = input;
         let client_ip = ClientIp::from_request(request_context);
 
         debug!(target: LOG_TARGET, "Subscribing to blocks");

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -2,7 +2,6 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::grpc::ClientIp;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::BlockNumber;
-use tonic::Request;
 use tracing::debug;
 
 use super::super::{COMPONENT, RpcService};
@@ -38,11 +37,12 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
     )]
     async fn handle(
         &self,
-        request_context: &Request<()>,
         input: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::ItemStream> {
         let request = input;
-        let client_ip = ClientIp::from_request(request_context);
+        let client_ip = ClientIp::from_extensions(extensions);
 
         debug!(target: LOG_TARGET, "Subscribing to block proofs");
 

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -1,12 +1,8 @@
-use std::net::IpAddr;
-use std::pin::Pin;
-
-use futures::StreamExt;
 use miden_node_proto::generated as proto;
 use miden_node_utils::grpc::ClientIp;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::block::BlockNumber;
-use tonic::{Request, Status};
+use tonic::Request;
 use tracing::debug;
 
 use super::super::{COMPONENT, RpcService};
@@ -15,7 +11,6 @@ use crate::LOG_TARGET;
 
 pub struct ProofSubscriptionInput {
     request: proto::rpc::ProofSubscriptionRequest,
-    client_ip: Option<IpAddr>,
 }
 
 #[tonic::async_trait]
@@ -25,7 +20,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
     type ItemStream = SubscriptionStream;
 
     fn decode(request: proto::rpc::ProofSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(ProofSubscriptionInput { request, client_ip: None })
+        Ok(ProofSubscriptionInput { request })
     }
 
     fn encode(event: Self::Item) -> tonic::Result<proto::rpc::ProofSubscriptionResponse> {
@@ -34,17 +29,6 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
             proof: event.data,
             proven_chain_tip: event.tip.as_u32(),
         })
-    }
-
-    async fn full(
-        &self,
-        request: Request<proto::rpc::ProofSubscriptionRequest>,
-    ) -> tonic::Result<ProofSubscriptionResponseStream> {
-        let client_ip = ClientIp::from_request(&request);
-        let mut input = Self::decode(request.into_inner())?;
-        input.client_ip = client_ip;
-        let stream = self.handle(input).await?;
-        Ok(Box::pin(stream.map(|item| item.and_then(Self::encode))))
     }
 
     #[miden_instrument(
@@ -56,8 +40,13 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         ),
         err,
     )]
-    async fn handle(&self, input: Self::Input) -> tonic::Result<Self::ItemStream> {
-        let ProofSubscriptionInput { request, client_ip } = input;
+    async fn handle(
+        &self,
+        request_context: &Request<()>,
+        input: Self::Input,
+    ) -> tonic::Result<Self::ItemStream> {
+        let ProofSubscriptionInput { request } = input;
+        let client_ip = ClientIp::from_request(request_context);
 
         debug!(target: LOG_TARGET, "Subscribing to block proofs");
 
@@ -66,12 +55,3 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         SubscriptionStream::proofs(self, from, client_ip)
     }
 }
-
-type ProofSubscriptionResponseStream = Pin<
-    Box<
-        dyn tonic::codegen::tokio_stream::Stream<
-                Item = Result<proto::rpc::ProofSubscriptionResponse, Status>,
-            > + Send
-            + 'static,
-    >,
->;

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -10,12 +10,12 @@ use crate::LOG_TARGET;
 
 #[tonic::async_trait]
 impl proto::server::rpc_api::ProofSubscription for RpcService {
-    type Input = proto::rpc::ProofSubscriptionRequest;
+    type Input = BlockNumber;
     type Item = StreamItem;
     type ItemStream = SubscriptionStream;
 
     fn decode(request: proto::rpc::ProofSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(request)
+        Ok(BlockNumber::from(request.block_from))
     }
 
     fn encode(event: Self::Item) -> tonic::Result<proto::rpc::ProofSubscriptionResponse> {
@@ -31,7 +31,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         name = "proof_subscription",
         skip_all,
         fields(
-            block.from = %input.block_from,
+            block.from = %input,
         ),
         err,
     )]
@@ -41,13 +41,11 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         _metadata: &tonic::metadata::MetadataMap,
         extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::ItemStream> {
-        let request = input;
         let client_ip = ClientIp::from_extensions(extensions);
 
         debug!(target: LOG_TARGET, "Subscribing to block proofs");
 
-        let from = BlockNumber::from(request.block_from);
-
+        let from = input;
         SubscriptionStream::proofs(self, from, client_ip)
     }
 }

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -9,18 +9,14 @@ use super::super::{COMPONENT, RpcService};
 use super::stream::{StreamItem, SubscriptionStream};
 use crate::LOG_TARGET;
 
-pub struct ProofSubscriptionInput {
-    request: proto::rpc::ProofSubscriptionRequest,
-}
-
 #[tonic::async_trait]
 impl proto::server::rpc_api::ProofSubscription for RpcService {
-    type Input = ProofSubscriptionInput;
+    type Input = proto::rpc::ProofSubscriptionRequest;
     type Item = StreamItem;
     type ItemStream = SubscriptionStream;
 
     fn decode(request: proto::rpc::ProofSubscriptionRequest) -> tonic::Result<Self::Input> {
-        Ok(ProofSubscriptionInput { request })
+        Ok(request)
     }
 
     fn encode(event: Self::Item) -> tonic::Result<proto::rpc::ProofSubscriptionResponse> {
@@ -36,7 +32,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         name = "proof_subscription",
         skip_all,
         fields(
-            block.from = %input.request.block_from,
+            block.from = %input.block_from,
         ),
         err,
     )]
@@ -45,7 +41,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         request_context: &Request<()>,
         input: Self::Input,
     ) -> tonic::Result<Self::ItemStream> {
-        let ProofSubscriptionInput { request } = input;
+        let request = input;
         let client_ip = ClientIp::from_request(request_context);
 
         debug!(target: LOG_TARGET, "Subscribing to block proofs");

--- a/crates/rpc/src/server/api/sync_account_storage_maps.rs
+++ b/crates/rpc/src/server/api/sync_account_storage_maps.rs
@@ -32,8 +32,9 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/sync_account_storage_maps.rs
+++ b/crates/rpc/src/server/api/sync_account_storage_maps.rs
@@ -30,7 +30,11 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let account_id = read_account_id::<proto::rpc::SyncAccountStorageMapsRequest, Status>(

--- a/crates/rpc/src/server/api/sync_account_vault.rs
+++ b/crates/rpc/src/server/api/sync_account_vault.rs
@@ -31,7 +31,11 @@ impl proto::server::rpc_api::SyncAccountVault for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let account_id = read_account_id::<proto::rpc::SyncAccountVaultRequest, Status>(

--- a/crates/rpc/src/server/api/sync_account_vault.rs
+++ b/crates/rpc/src/server/api/sync_account_vault.rs
@@ -33,8 +33,9 @@ impl proto::server::rpc_api::SyncAccountVault for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/sync_chain_mmr.rs
+++ b/crates/rpc/src/server/api/sync_chain_mmr.rs
@@ -32,8 +32,9 @@ impl proto::server::rpc_api::SyncChainMmr for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, "Syncing chain MMR");
 

--- a/crates/rpc/src/server/api/sync_chain_mmr.rs
+++ b/crates/rpc/src/server/api/sync_chain_mmr.rs
@@ -30,7 +30,11 @@ impl proto::server::rpc_api::SyncChainMmr for RpcService {
         ),
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         debug!(target: LOG_TARGET, "Syncing chain MMR");
 
         let current_client_block_height = BlockNumber::from(request.current_client_block_height);

--- a/crates/rpc/src/server/api/sync_notes.rs
+++ b/crates/rpc/src/server/api/sync_notes.rs
@@ -28,7 +28,11 @@ impl proto::server::rpc_api::SyncNotes for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let range = read_block_range::<Status>(request.block_range, "SyncNotesRequest")?;

--- a/crates/rpc/src/server/api/sync_notes.rs
+++ b/crates/rpc/src/server/api/sync_notes.rs
@@ -30,8 +30,9 @@ impl proto::server::rpc_api::SyncNotes for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -33,7 +33,11 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let range = read_block_range::<Status>(request.block_range, "SyncNullifiersRequest")?;

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -35,8 +35,9 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/sync_transactions.rs
+++ b/crates/rpc/src/server/api/sync_transactions.rs
@@ -37,8 +37,9 @@ impl proto::server::rpc_api::SyncTransactions for RpcService {
     )]
     async fn handle(
         &self,
-        _request: &tonic::Request<()>,
         request: Self::Input,
+        _metadata: &tonic::metadata::MetadataMap,
+        _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 

--- a/crates/rpc/src/server/api/sync_transactions.rs
+++ b/crates/rpc/src/server/api/sync_transactions.rs
@@ -35,7 +35,11 @@ impl proto::server::rpc_api::SyncTransactions for RpcService {
         skip_all,
         err,
     )]
-    async fn handle(&self, request: Self::Input) -> tonic::Result<Self::Output> {
+    async fn handle(
+        &self,
+        _request: &tonic::Request<()>,
+        request: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let range = read_block_range::<Status>(request.block_range, "SyncTransactionsRequest")?;

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use http::header::{ACCEPT, CONTENT_TYPE};
-use http::{HeaderMap, HeaderValue};
+use http::{Extensions, HeaderMap, HeaderValue};
 use miden_node_block_producer::{BlockProducerApi, BlockProducerApiConfig};
 use miden_node_proto::clients::{
     Builder,
@@ -53,6 +53,7 @@ use tokio::net::TcpListener;
 use tokio::task;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::Request;
+use tonic::metadata::MetadataMap;
 use url::Url;
 
 use crate::server::api::RpcService;
@@ -518,12 +519,12 @@ impl ntx_builder_api::GetNetworkNoteStatus for FixedNtxBuilder {
 
     async fn handle(
         &self,
-        request: &Request<()>,
         _input: Self::Input,
+        metadata: &MetadataMap,
+        _extensions: &Extensions,
     ) -> tonic::Result<Self::Output> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
-        let accept = request
-            .metadata()
+        let accept = metadata
             .get(ACCEPT.as_str())
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -516,14 +516,11 @@ impl ntx_builder_api::GetNetworkNoteStatus for FixedNtxBuilder {
         Ok(output)
     }
 
-    async fn handle(&self, _input: Self::Input) -> tonic::Result<Self::Output> {
-        Ok(self.response.clone())
-    }
-
-    async fn full(
+    async fn handle(
         &self,
-        request: Request<proto::note::NoteId>,
-    ) -> tonic::Result<proto::rpc::GetNetworkNoteStatusResponse> {
+        request: &Request<()>,
+        _input: Self::Input,
+    ) -> tonic::Result<Self::Output> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
         let accept = request
             .metadata()
@@ -531,7 +528,8 @@ impl ntx_builder_api::GetNetworkNoteStatus for FixedNtxBuilder {
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);
         *self.last_accept.lock().expect("last_accept mutex should not be poisoned") = accept;
-        self.handle(request.into_inner()).await.and_then(Self::encode)
+
+        Ok(self.response.clone())
     }
 }
 

--- a/crates/utils/src/grpc/layers.rs
+++ b/crates/utils/src/grpc/layers.rs
@@ -58,16 +58,16 @@ pub fn rate_limit_per_ip(
 /// The originating client IP, resolved by [`ResolveClientIpLayer`] and stored in a request's
 /// extensions.
 ///
-/// gRPC handlers can read this via `request.extensions().get::<ClientIp>()` to obtain the
+/// gRPC handlers can read this via `ClientIp::from_extensions(request.extensions())` to obtain the
 /// load-balancer-aware client address without re-implementing IP extraction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClientIp(pub IpAddr);
 
 impl ClientIp {
-    /// Returns the client IP resolved for `request` by [`ResolveClientIpLayer`], or `None` if it
-    /// could not be determined.
-    pub fn from_request<T>(request: &tonic::Request<T>) -> Option<IpAddr> {
-        request.extensions().get::<Self>().map(|ip| ip.0)
+    /// Returns the client IP resolved into `extensions` by [`ResolveClientIpLayer`], or `None` if
+    /// it could not be determined.
+    pub fn from_extensions(extensions: &http::Extensions) -> Option<IpAddr> {
+        extensions.get::<Self>().map(|ip| ip.0)
     }
 }
 


### PR DESCRIPTION
## Summary

As described in issue #2302 we now have quite a few gRPC method implementations where we're overriding the generated `full()` method just so that we have access to request metadata (client IP address, header values, etc.).

This PR changes the gRPC codegen so that the `handle()` method gets passed the gRPC request metadata (in addition to the decoded request).

Closes #2302 

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```
