### PR TITLE
fix(packaging): remove .env files from Debian packages

### DIFF
--- a/.github/actions/debian/action.yml
+++ b/.github/actions/debian/action.yml
@@ -87,6 +87,7 @@ runs:
           service_file="${service_file##*/}"
           svc="${service_file%.service}"
           git show "${TARGET_SHA}:packaging/${pkg_dir}/${service_file}" > "packaging/deb/${pkg}/lib/systemd/system/${service_file}"
+          touch "packaging/deb/${pkg}/lib/systemd/system/${svc}.env"
         done < <(find "packaging/${pkg_dir}" -maxdepth 1 -name '*.service' -print)
         chmod 0775 "packaging/deb/${pkg}/DEBIAN/postinst"
         chmod 0775 "packaging/deb/${pkg}/DEBIAN/postrm"

--- a/.github/actions/debian/action.yml
+++ b/.github/actions/debian/action.yml
@@ -87,7 +87,6 @@ runs:
           service_file="${service_file##*/}"
           svc="${service_file%.service}"
           git show "${TARGET_SHA}:packaging/${pkg_dir}/${service_file}" > "packaging/deb/${pkg}/lib/systemd/system/${service_file}"
-          git show "${TARGET_SHA}:bin/${crate}/.env"                    > "packaging/deb/${pkg}/lib/systemd/system/${svc}.env"
         done < <(find "packaging/${pkg_dir}" -maxdepth 1 -name '*.service' -print)
         chmod 0775 "packaging/deb/${pkg}/DEBIAN/postinst"
         chmod 0775 "packaging/deb/${pkg}/DEBIAN/postrm"

--- a/.github/actions/debian/action.yml
+++ b/.github/actions/debian/action.yml
@@ -87,7 +87,6 @@ runs:
           service_file="${service_file##*/}"
           svc="${service_file%.service}"
           git show "${TARGET_SHA}:packaging/${pkg_dir}/${service_file}" > "packaging/deb/${pkg}/lib/systemd/system/${service_file}"
-          touch "packaging/deb/${pkg}/lib/systemd/system/${svc}.env"
         done < <(find "packaging/${pkg_dir}" -maxdepth 1 -name '*.service' -print)
         chmod 0775 "packaging/deb/${pkg}/DEBIAN/postinst"
         chmod 0775 "packaging/deb/${pkg}/DEBIAN/postrm"

--- a/packaging/network-monitor/miden-network-monitor.service
+++ b/packaging/network-monitor/miden-network-monitor.service
@@ -7,7 +7,6 @@ WantedBy=multi-user.target
 
 [Service]
 Type=exec
-EnvironmentFile=/lib/systemd/system/miden-network-monitor.env
 ExecStart=/usr/bin/miden-network-monitor start
 WorkingDirectory=/opt/miden-network-monitor
 User=miden-network-monitor

--- a/packaging/node/miden-node.service
+++ b/packaging/node/miden-node.service
@@ -8,7 +8,6 @@ WantedBy=multi-user.target
 [Service]
 Type=exec
 Environment="OTEL_SERVICE_NAME=miden-node"
-EnvironmentFile=/lib/systemd/system/miden-node.env
 ExecStart=/usr/bin/miden-node bundled start
 WorkingDirectory=/opt/miden-node
 User=miden-node

--- a/packaging/ntx-builder/miden-ntx-builder.service
+++ b/packaging/ntx-builder/miden-ntx-builder.service
@@ -8,7 +8,6 @@ WantedBy=multi-user.target
 [Service]
 Type=exec
 Environment="OTEL_SERVICE_NAME=miden-ntx-builder"
-EnvironmentFile=/lib/systemd/system/miden-ntx-builder.env
 ExecStart=/usr/bin/miden-ntx-builder start
 WorkingDirectory=/opt/miden-ntx-builder
 User=miden-ntx-builder

--- a/packaging/prover/miden-prover.service
+++ b/packaging/prover/miden-prover.service
@@ -8,7 +8,6 @@ WantedBy=multi-user.target
 [Service]
 Type=exec
 Environment="OTEL_SERVICE_NAME=miden-prover"
-EnvironmentFile=/lib/systemd/system/miden-prover.env
 ExecStart=/usr/bin/miden-remote-prover
 User=miden-prover
 RestartSec=5

--- a/packaging/validator/miden-validator.service
+++ b/packaging/validator/miden-validator.service
@@ -8,7 +8,6 @@ WantedBy=multi-user.target
 [Service]
 Type=exec
 Environment="OTEL_SERVICE_NAME=miden-validator"
-EnvironmentFile=/lib/systemd/system/miden-validator.env
 ExecStart=/usr/bin/miden-validator start
 WorkingDirectory=/opt/miden-validator
 User=miden-validator


### PR DESCRIPTION
## Summary

`.env` files required by the Debian package workflow have been removed from the repository, so that Debian packages are now failing to build.

This PR:

- Removes copying of the (deleted) `.env` files into the package (and is adding temporary empty files instead). This is a temporary solution so that we can build 0.15.1 packages that still have `.service` files that require these files to be present.
- Removes the `EnvironmentFile` references from `.service` files so that the services don't depend on the environment files anymore.

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```
