### PR TITLE
fix(db): return error instead of panicking on non-UTF-8 database path

### DIFF
--- a/crates/db/src/errors.rs
+++ b/crates/db/src/errors.rs
@@ -51,6 +51,8 @@ pub enum DatabaseError {
     SchemaVerification(#[from] SchemaVerificationError),
     #[error("I/O error")]
     Io(#[from] io::Error),
+    #[error("database file path is not valid UTF-8: {0}")]
+    NonUtf8Path(String),
     #[error("pool build error")]
     PoolBuild(#[from] deadpool::managed::BuildError),
     #[error("Setup deadpool connection pool failed")]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -42,7 +42,10 @@ impl Db {
         database_filepath: &Path,
         connection_pool_size: NonZeroUsize,
     ) -> Result<Self, DatabaseError> {
-        let manager = ConnectionManager::new(database_filepath.to_str().unwrap());
+        let path_str = database_filepath.to_str().ok_or_else(|| {
+            DatabaseError::NonUtf8Path(database_filepath.to_string_lossy().into_owned())
+        })?;
+        let manager = ConnectionManager::new(path_str);
         let pool = deadpool_diesel::Pool::builder(manager)
             .max_size(connection_pool_size.get())
             .build()?;


### PR DESCRIPTION
## Summary

Closes #2289.

`Db::new_with_pool_size` called `database_filepath.to_str().unwrap()` at `crates/db/src/lib.rs`. On Linux, file paths can contain arbitrary (non-UTF-8) bytes, for which `to_str()` returns `None`, so `unwrap()` panics at node startup if the configured data path is non-UTF-8.

## Change

- Added a `DatabaseError::NonUtf8Path(String)` variant.
- Replaced the `unwrap()` with an `ok_or_else(...)` that returns the new error, embedding the lossy path for context.

## Testing

`cargo build -p miden-node-db` passes locally. The `db` crate is SQLite/diesel-based so it builds without the RocksDB toolchain.

## Changelog

```toml
[[entry]]
scope       = "node"
impact      = "fixed"
description = "Return an error instead of panicking at startup when the database file path is not valid UTF-8."
```