### PR TITLE
fix(store): return error instead of asserting on unsupported nullifier prefix length

### DIFF
--- a/crates/store/src/db/models/queries/nullifiers.rs
+++ b/crates/store/src/db/models/queries/nullifiers.rs
@@ -73,7 +73,9 @@ pub(crate) fn select_nullifiers_by_prefix(
     pub const ROW_OVERHEAD_BYTES: usize = NULLIFIER_BYTES + BLOCK_NUM_BYTES; // 36 bytes
     pub const MAX_ROWS: usize = MAX_RESPONSE_PAYLOAD_BYTES / ROW_OVERHEAD_BYTES;
 
-    assert_eq!(prefix_len, 16, "Only 16-bit prefixes are supported");
+    if prefix_len != 16 {
+        return Err(DatabaseError::UnsupportedNullifierPrefixLength { prefix_len });
+    }
 
     if block_range.is_empty() {
         return Err(DatabaseError::InvalidBlockRange {

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -75,6 +75,8 @@ pub enum DatabaseError {
          use a stricter filter to reduce the number of transactions returned"
     )]
     TransactionPageExceedsPayloadLimit { block_num: BlockNumber },
+    #[error("unsupported nullifier prefix length {prefix_len}, only 16-bit prefixes are supported")]
+    UnsupportedNullifierPrefixLength { prefix_len: u8 },
     #[error("data corrupted: {0}")]
     DataCorrupted(String),
     #[error(transparent)]


### PR DESCRIPTION
## Summary

Closes #2290.

`select_nullifiers_by_prefix` at `crates/store/src/db/models/queries/nullifiers.rs` validated its `prefix_len` parameter with `assert_eq!(prefix_len, 16, ...)`, which panics in release builds when called with any other value. The RPC handler (`sync_nullifiers.rs`) already guards this with a `Status::invalid_argument`, but the store function itself panicked on invalid input rather than returning an error, so any future caller or test that skips the RPC guard would hit a panic.

## Change

- Added a `DatabaseError::UnsupportedNullifierPrefixLength { prefix_len }` variant.
- Replaced the `assert_eq!` with an early `return Err(...)`, matching the existing `InvalidBlockRange` validation in the same function.

## Testing

The store crate requires the RocksDB/libclang toolchain which isn't available in my local environment, so I'm relying on CI to compile. The change is a minimal, type-checked mirror of the adjacent `InvalidBlockRange` error path.

## Changelog

```toml
[[entry]]
scope       = "internal"
impact      = "fixed"
description = "Return an error instead of panicking on an unsupported nullifier prefix length in the store."
```