### PR TITLE
Bump to protocol `v0.16.0-alpha.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,9 +1520,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.22"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
  "digest 0.11.3",
@@ -2579,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905d38bdbb43bb506efa0a428b3e969ff244549832a86b18591492f503adfe37"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
  "ecdsa",
@@ -2847,9 +2847,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e483bbe648544b9c365fa55010cdf026d063d63edea2687a72e533b4f18b61d"
+checksum = "b96b70c94b9dbb4a5dd9b03c52bf59d2fae254eb3fee4d9338889d8b5b82b9d9"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2858,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09255753cdbc4e4578480ab5471a825d3cecb5b0e5bece14c597c1bb4a839c2"
+checksum = "1f1fc5bffab96b788524758d72c3457726357d1397874fac5ea841c6753b28e9"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
@@ -2873,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c54976047487532ae9fc700c9fe2fac9e101a4809c5fb1d4f79df94b7e56222"
+checksum = "0d08306e2cc2fe3fa50aef600d434ad67a780807374cbda60fe4450ca4dad37e"
 dependencies = [
  "env_logger",
  "log",
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d29b8a98292705318af772b7f15af987847cfe457747fba27b2948748886a12"
+checksum = "2609e82bffb5d9e0d37591db837d659224dec4e82e13575daa6203280ba6c14f"
 dependencies = [
  "env_logger",
  "log",
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8973568357991baf3852c5e1af80b49217048a4e1c16b5aa405fde96e96b67c9"
+checksum = "b442514653b58191f4ed0fd9ed14853d977bd44702cf04064e0eca7cc5c77b79"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -2946,8 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0"
-source = "git+https://github.com/0xMiden/protocol.git?branch=next#f69d8cfe9759a9b0a2cd85ae246d1a3b8d601639"
+version = "0.16.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c44c79026d461fcf55df1df045b47d9f47b55f65ab21f33db56afca2bfbae88"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -2955,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22c961a81f922e15cf9cc74e9a6808cb6060510a318bd5d688267a3ba0ea73b"
+checksum = "93203254d349bb0d7b4302853331c57b66a38bb4289fd2f56bee0c624b05e1a1"
 dependencies = [
  "derive_more",
  "log",
@@ -2974,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72338a14fe81175fe89b7cfab452cd8c06dcc333f2c79534491e0f5f99935f"
+checksum = "7d062b282d71d2f847bf372a070929f8238c5199b9756e36d4d11f22acd58ad1"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -2993,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb57a3fbdf2bdc51bd024050719c65929d0545f4cca225000f99678f62935f02"
+checksum = "afd70d37ade91ce0f37a0ad7b9f1709391657243857d5d209ec62a100e358d4d"
 dependencies = [
  "blake3",
  "cc",
@@ -3036,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee301b99abeeb640f9f5eaa7c11f731bab5b2e7671cbaebed606da5ff1a4a2b"
+checksum = "9197f2837af387b5a9b60ef3c30670cf34a453c3a8e81f9cf68df84ca3122253"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -3046,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bc37da0644866859da3a7d7a438d3b698a2e009ca6e9a1f71fb3462b509ba8"
+checksum = "0f75a72da10ddadeb9a56542b675431b9cb93f5f25ea180ff8f0c311aafee922"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -3065,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06741437192077e3fec0a0685ef05ea883aa3823bc0722ae56b178233db2812f"
+checksum = "45929f2e6b18f6535cfa25a55f5dac8be556410a4fc5c7e003a147b678af9e18"
 dependencies = [
  "miden-serde-utils",
  "num-bigint",
@@ -3093,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf4dca41a33d65992ad877746539b48fbc367101d2ed3161d3b727140af3aaf"
+checksum = "320d7e0f1ac4a668682146cce69585ddc8dfe1fdf6ba5dac1986233e3e48d4df"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -3107,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7087fe7fa147cd443848844afdf54ffa8be697bd8d7b8304662fd6b252a01aa2"
+checksum = "8075f037bb02eb763223bc2f762a55c793f3795677f88fc06e58641091fd69e0"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -3130,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f51dca2756f7cb71c45adf591d15718900e5d8a7bbb9aca4c465cd415f77cd9"
+checksum = "942d744f2606ad9d146fc9d817fccc5913d9cc8b8b9e53666779f6c415a174ce"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -3496,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cfd769e4fea024bcef5d7c1d5315cbe82742e92018eac8be77832d228f4d84"
+checksum = "01202970e634f258502ed082d776c906289b6394eb5ac6b8067be0d7261a55a3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -3512,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ac8de1ee9b1c2af84cb71696c7268e2f5ab3e6b3e7a75a79c92996a595c7d5"
+checksum = "d2e4776a16e18c5317ae31cfb149f30a5b454a25b6e6fefd3ccee943227514db"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -3531,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e84c111ceabba22f7769bbc7acf446500886579d817fc0ff6cc1a3eb7adbd3"
+checksum = "7de67303b1f197ad49f023fad38ca1c4be8fb55ef6098c95f254b09a8ad6b040"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -3548,8 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0"
-source = "git+https://github.com/0xMiden/protocol.git?branch=next#f69d8cfe9759a9b0a2cd85ae246d1a3b8d601639"
+version = "0.16.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33405bc37bbde2273ad23a6787a4ce7ec74c93ec2a3812180a80905811f63f35"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3578,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e213f372baa1f98f7ef68845908e567c636e960b0a2657f8780de6288fc58aab"
+checksum = "a18511f219eeb6decc384f8a39d1428ed6d3eb313b3ff778a988635f61b84ece"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -3633,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a89e64d3ccd5b51b0ef08cdfc36e1bbd1402448275520eb0208de740125509"
+checksum = "6bf6872ac0f2de384ac65968e9bdc24656b31c487ea3bb1665871095c10f11ee"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -3643,8 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0"
-source = "git+https://github.com/0xMiden/protocol.git?branch=next#f69d8cfe9759a9b0a2cd85ae246d1a3b8d601639"
+version = "0.16.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d20a8558525925bb9280c08ea64d57754775537e0a0c3c4992e08858054ff58b"
 dependencies = [
  "bon",
  "fs-err",
@@ -3662,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca940751e1ca7abc33a9b8eaaad4cdd6f153613380ad2c3626134bab6aafb91"
+checksum = "13f2f5cc37a6b24ef2ab4c8d4dfb874a8f55add5147bfad47fde901f03165a51"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -3674,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc3510d500d4ce676652ef24539e2be4f04ae63d0bf8299799ca16d79b66a9d"
+checksum = "93a95d46e93b94d82e0fcc6cec67ea362a548c1b6209bfdd1211433537314b83"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -3684,8 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0"
-source = "git+https://github.com/0xMiden/protocol.git?branch=next#f69d8cfe9759a9b0a2cd85ae246d1a3b8d601639"
+version = "0.16.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0864c331305d2efc75d1832e5230db5e2c42356bd6ad128b1a366bd29c48233"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3704,8 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0"
-source = "git+https://github.com/0xMiden/protocol.git?branch=next#f69d8cfe9759a9b0a2cd85ae246d1a3b8d601639"
+version = "0.16.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354b495ae03dacc9fbebe1cef30ae66823a7115d888c18b8597be47e42d1148"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3716,8 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0"
-source = "git+https://github.com/0xMiden/protocol.git?branch=next#f69d8cfe9759a9b0a2cd85ae246d1a3b8d601639"
+version = "0.16.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1630ad59c4ef5e9af2887be01667e18663ba5b204a6b5b246eee08fd6f591e"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3728,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9acfad9d3087359def17ee4f9bf0c6704d084834a4d9ea79c41e4cadc4283d3"
+checksum = "dd084f8c9b3fbd173536a794850e1f29789eaeaff0f87e7852505f0fa9aa8556"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3739,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9145af29088953f3a55dd1a5c8e2981e1bb91b95d0689e40d29b46d5e4644c"
+checksum = "048bbc18d446d1bc29b5e3ceac69000f1488a0ea1b15b18f48a0c702c2c1e706"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -3750,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38d3babbd60b4d4f74b32872ff873bfbaf439829e3d46d97a5534c35c2ed744"
+checksum = "98a713931678d5cdc23ab388cda048cc055079767780799b1d56f35b14ae6957"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -3762,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec080d36e3663bda1550c981bfa0870f06d3e37a1f286f02fa8212d9f478fb10"
+checksum = "0a7fe110d6c5a90a27747d051c6d20cbbbc2d425c4276e96ce7bf82270d23cc3"
 dependencies = [
  "lock_api",
  "loom",
@@ -3803,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7297bdb9e1a24acbf62f4083cb187fb2e7001ec9a882b16e95f3cc66d06054"
+checksum = "c5bbb6c5af707266e4844460f5b55fc3c80d96a6a80b5e2a479d3cc95ad6d483"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -3819,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8e411205251d07ec902559d80f097e66fedb644e0c35dc4cad431c10b99a4d"
+checksum = "f67fe32b429d499d0ae713e044b593d866b1ab51540de6ca8881413aba42e858"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",
@@ -4533,13 +4539,14 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "primefield",
  "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -5055,11 +5062,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.6.0-pre.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "ctutils",
+ "crypto-bigint",
  "hmac",
 ]
 
@@ -5426,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wincode"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a62dfa6ae65cb073dfe001fb076eaf827fd4267fcba7eb3be2fee4f1e69ccb5"
+checksum = "9aa9d3a86c66cf10ce79df36f555a5a4c8d72a82515d9ea8ca420e02c925c30f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6789,9 +6796,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -7042,9 +7049,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0-rc.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86421f2a70c9e6cab8d84c99fb62d8761d355bd1285443a7e7ccad15aa515f2"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
  "ff",
  "group",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,15 +54,15 @@ miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.15.1
 miden-node-utils            = { path = "crates/utils", version = "0.15.1" }
 
 # miden-protocol dependencies. These should be updated in sync.
-miden-block-prover = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
-miden-protocol     = { branch = "next", default-features = false, git = "https://github.com/0xMiden/protocol.git" }
-miden-standards    = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
-miden-testing      = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
-miden-tx           = { branch = "next", default-features = false, git = "https://github.com/0xMiden/protocol.git" }
-miden-tx-batch     = { branch = "next", git = "https://github.com/0xMiden/protocol.git" }
+miden-block-prover = { version = "=0.16.0-alpha.1" }
+miden-protocol     = { default-features = false, version = "=0.16.0-alpha.1" }
+miden-standards    = { version = "=0.16.0-alpha.1" }
+miden-testing      = { version = "=0.16.0-alpha.1" }
+miden-tx           = { default-features = false, version = "=0.16.0-alpha.1" }
+miden-tx-batch     = { version = "=0.16.0-alpha.1" }
 
 # Other miden dependencies. These should align with those expected by miden-protocol.
-miden-crypto = { version = "0.27" }
+miden-crypto = { version = "0.28" }
 
 # External dependencies
 anyhow            = { version = "1.0" }

--- a/bin/network-monitor/src/assets/counter_program.masm
+++ b/bin/network-monitor/src/assets/counter_program.masm
@@ -25,7 +25,7 @@ pub proc increment
     exec.active_note::get_sender
     # => [sender_suffix, sender_prefix, owner_suffix, owner_prefix, 0, 0]
 
-    exec.account_id::is_equal
+    exec.account_id::eq
     # => [are_equal, 0, 0]
 
     assert.err="Note sender not authorized" drop drop


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Title, only minor actual code changes since we had already migrated the painful stuff.

Also bumped `crypto` to match protocol.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "protocol"
impact      = "changed"
description = "Upgraded protocol crates to `0.16.0-alpha.1`"

[[entry]]
scope       = "protocol"
impact      = "changed"
description = "Upgraded `miden-crypto` to `0.28`"
```
