### PR TITLE
Bump protocol to `0.16.0-alpha.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,7 +2931,6 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
- "futures",
  "miden-node-proto",
  "miden-node-utils",
  "miden-protocol",
@@ -2946,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c44c79026d461fcf55df1df045b47d9f47b55f65ab21f33db56afca2bfbae88"
+checksum = "616b8fa0652e25c5711bcd01f6f1f50e803a01db962e5af6b4a2bd7612dfde78"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -3549,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33405bc37bbde2273ad23a6787a4ce7ec74c93ec2a3812180a80905811f63f35"
+checksum = "8b5fd2fec04e0651a9ad7886541afc1bd6d8ee0de91a2850e9f4ead829c0fe3f"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3600,9 +3599,7 @@ version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
- "async-trait",
  "clap",
- "futures",
  "humantime",
  "miden-block-prover",
  "miden-node-proto",
@@ -3645,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20a8558525925bb9280c08ea64d57754775537e0a0c3c4992e08858054ff58b"
+checksum = "f431c2bcd8b63ee45d12155565a23a9abc78240663d275e0e95eb475c9ac6438"
 dependencies = [
  "bon",
  "fs-err",
@@ -3687,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0864c331305d2efc75d1832e5230db5e2c42356bd6ad128b1a366bd29c48233"
+checksum = "610ba28ab9d73da0fcde6aa2389b2029e096df0c7248fde558d7d44be67ec8f7"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3708,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354b495ae03dacc9fbebe1cef30ae66823a7115d888c18b8597be47e42d1148"
+checksum = "4eff35d682e8e4266bbe314e3b95f98ce5fea515bdc80573b907daaba937e8c1"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3721,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1630ad59c4ef5e9af2887be01667e18663ba5b204a6b5b246eee08fd6f591e"
+checksum = "a2bec9ae6f93ad985a86999e81cb90a7e11090a7ea25eed661f85e384bee2bb9"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.15.1
 miden-node-utils            = { path = "crates/utils", version = "0.15.1" }
 
 # miden-protocol dependencies. These should be updated in sync.
-miden-block-prover = { version = "=0.16.0-alpha.1" }
-miden-protocol     = { default-features = false, version = "=0.16.0-alpha.1" }
-miden-standards    = { version = "=0.16.0-alpha.1" }
-miden-testing      = { version = "=0.16.0-alpha.1" }
-miden-tx           = { default-features = false, version = "=0.16.0-alpha.1" }
-miden-tx-batch     = { version = "=0.16.0-alpha.1" }
+miden-block-prover = { version = "=0.16.0-alpha.2" }
+miden-protocol     = { default-features = false, version = "=0.16.0-alpha.2" }
+miden-standards    = { version = "=0.16.0-alpha.2" }
+miden-testing      = { version = "=0.16.0-alpha.2" }
+miden-tx           = { default-features = false, version = "=0.16.0-alpha.2" }
+miden-tx-batch     = { version = "=0.16.0-alpha.2" }
 
 # Other miden dependencies. These should align with those expected by miden-protocol.
 miden-crypto = { version = "0.28" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ miden-crypto = { version = "0.28" }
 # External dependencies
 anyhow            = { version = "1.0" }
 assert_matches    = { version = "1.5" }
-async-trait       = { version = "0.1" }
 backon            = { version = "1.6" }
 build-rs          = { version = "0.3" }
 clap              = { features = ["derive"], version = "4.5" }

--- a/bin/benchmark/Cargo.toml
+++ b/bin/benchmark/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 anyhow           = { workspace = true }
 clap             = { features = ["env", "string"], workspace = true }
 fs-err           = { workspace = true }
-futures          = { workspace = true }
 miden-node-proto = { workspace = true }
 miden-node-utils = { workspace = true }
 miden-protocol   = { features = ["std", "testing"], workspace = true }

--- a/bin/benchmark/src/prover.rs
+++ b/bin/benchmark/src/prover.rs
@@ -50,7 +50,7 @@ const RETRY_BACKOFF_SHIFT_CAP: u32 = 6;
 // ================================================================================================
 
 pub(crate) enum BenchmarkProver {
-    Local,
+    Local(LocalTransactionProver),
     Remote {
         prover: Box<RemoteTransactionProver>,
         limiter: Arc<RampingRateLimiter>,
@@ -60,7 +60,7 @@ pub(crate) enum BenchmarkProver {
 
 impl BenchmarkProver {
     pub(crate) fn local() -> Self {
-        Self::Local
+        Self::Local(LocalTransactionProver::default())
     }
 
     /// Whether proofs for this prover should be dispatched concurrently. The remote prover paces
@@ -89,12 +89,13 @@ impl BenchmarkProver {
         executed_tx: ExecutedTransaction,
     ) -> Result<ProvenTransaction> {
         match self {
-            Self::Local => spawn_blocking_in_current_span(move || {
-                LocalTransactionProver::default().prove(executed_tx)
-            })
-            .await
-            .map_err(|err| anyhow::anyhow!("local prover task panicked: {err}"))?
-            .map_err(|err| anyhow::anyhow!("local proving failed: {err}")),
+            Self::Local(prover) => {
+                let prover = prover.clone();
+                spawn_blocking_in_current_span(move || prover.prove(executed_tx))
+                    .await
+                    .context("local prover task panicked")?
+                    .context("local proving failed")
+            },
             Self::Remote { prover, limiter, permits } => {
                 let tx_inputs: TransactionInputs = executed_tx.into();
                 prove_remote_with_retry(prover, limiter, permits, &tx_inputs).await

--- a/bin/benchmark/src/prover.rs
+++ b/bin/benchmark/src/prover.rs
@@ -89,20 +89,12 @@ impl BenchmarkProver {
         executed_tx: ExecutedTransaction,
     ) -> Result<ProvenTransaction> {
         match self {
-            Self::Local => {
-                // The prover's future is not `Send` (the VM's execution tracer holds raw pointers
-                // across await points), so drive it to completion on a blocking thread. Proving is
-                // pure CPU work with no runtime dependency, so a plain executor drives it without
-                // needing a tokio handle.
-                spawn_blocking_in_current_span(move || {
-                    futures::executor::block_on(
-                        LocalTransactionProver::default().prove(executed_tx),
-                    )
-                })
-                .await
-                .map_err(|err| anyhow::anyhow!("local prover task panicked: {err}"))?
-                .map_err(|err| anyhow::anyhow!("local proving failed: {err}"))
-            },
+            Self::Local => spawn_blocking_in_current_span(move || {
+                LocalTransactionProver::default().prove(executed_tx)
+            })
+            .await
+            .map_err(|err| anyhow::anyhow!("local prover task panicked: {err}"))?
+            .map_err(|err| anyhow::anyhow!("local proving failed: {err}")),
             Self::Remote { prover, limiter, permits } => {
                 let tx_inputs: TransactionInputs = executed_tx.into();
                 prove_remote_with_retry(prover, limiter, permits, &tx_inputs).await

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -156,6 +156,7 @@ pub struct IncrementService {
     config: MonitorConfig,
     rpc_client: RpcClient,
     tx: TxBuilder,
+    prover: LocalTransactionProver,
     failures: FailureTracker,
     details: IncrementDetails,
     latency_state: Arc<Mutex<LatencyState>>,
@@ -175,6 +176,7 @@ impl IncrementService {
         wallet_account: Account,
         secret_key: SecretKey,
         counter_account: Account,
+        prover: LocalTransactionProver,
         accounts_sender: watch::Sender<TrackedAccounts>,
         latency_state: Arc<Mutex<LatencyState>>,
     ) -> Result<Self> {
@@ -187,6 +189,7 @@ impl IncrementService {
             config,
             rpc_client,
             tx,
+            prover,
             failures: FailureTracker::default(),
             details,
             latency_state,
@@ -273,7 +276,7 @@ impl IncrementService {
     )]
     async fn try_regenerate_accounts(&mut self) -> Result<()> {
         let (wallet_account, secret_key, counter_account) =
-            create_and_deploy_accounts(&self.config.rpc_url)
+            create_and_deploy_accounts(&self.config.rpc_url, &self.prover)
                 .await
                 .context("failed to regenerate accounts")?;
 
@@ -325,6 +328,7 @@ impl IncrementService {
         let counter_account = self.tx.counter_account.clone();
         let block_header = self.tx.block_header.clone();
         let secret_key = self.tx.secret_key.clone();
+        let prover = self.prover.clone();
         let (proven_tx, tx_inputs, account_patch) = spawn_blocking_in_current_span(move || {
             let account_id = wallet_account.id();
             let block_num = block_header.block_num();
@@ -348,9 +352,7 @@ impl IncrementService {
             // The patch captures the wallet's nonce bump and counter-slot write; the increment task
             // applies it to keep its local wallet copy in sync with chain.
             let account_patch = executed_tx.account_patch().clone();
-            let proven_tx =
-                futures::executor::block_on(LocalTransactionProver::default().prove(executed_tx))
-                    .context("Failed to prove transaction")?;
+            let proven_tx = prover.prove(executed_tx).context("failed to prove transaction")?;
 
             Ok::<_, anyhow::Error>((proven_tx, tx_inputs, account_patch))
         })

--- a/bin/network-monitor/src/deploy/mod.rs
+++ b/bin/network-monitor/src/deploy/mod.rs
@@ -248,9 +248,9 @@ pub async fn deploy_counter_account(
 
     let prover = prover.clone();
     let proven_tx = spawn_blocking_in_current_span(move || prover.prove(executed_tx))
-    .await
-    .context("prover task panicked")?
-    .context("Failed to prove transaction")?;
+        .await
+        .context("prover task panicked")?
+        .context("Failed to prove transaction")?;
 
     let request = ProvenTransaction {
         transaction: proven_tx.to_bytes(),

--- a/bin/network-monitor/src/deploy/mod.rs
+++ b/bin/network-monitor/src/deploy/mod.rs
@@ -145,13 +145,16 @@ pub async fn create_genesis_aware_rpc_client(
 /// Used both at startup and by the increment task when accounts are fundamentally outdated
 /// (e.g., after a network reset) and re-syncing from the RPC is not sufficient. The accounts
 /// are never persisted to disk; the monitor re-creates them on every restart.
-pub async fn create_and_deploy_accounts(rpc_url: &Url) -> Result<(Account, SecretKey, Account)> {
+pub async fn create_and_deploy_accounts(
+    rpc_url: &Url,
+    prover: &LocalTransactionProver,
+) -> Result<(Account, SecretKey, Account)> {
     tracing::info!(target: LOG_TARGET, "Creating fresh monitor accounts");
 
     let (wallet_account, secret_key) = create_wallet_account()?;
     let counter_account = create_counter_account(wallet_account.id())?;
 
-    deploy_counter_account(&counter_account, rpc_url).await?;
+    deploy_counter_account(&counter_account, rpc_url, prover).await?;
     tracing::info!(target: LOG_TARGET, "Successfully created and deployed accounts");
 
     Ok((wallet_account, secret_key, counter_account))
@@ -231,7 +234,11 @@ pub async fn build_probe_transaction_inputs(rpc_url: &Url) -> Result<Transaction
     skip_all,
     ret(level = "debug"),
 )]
-pub async fn deploy_counter_account(counter_account: &Account, rpc_url: &Url) -> Result<()> {
+pub async fn deploy_counter_account(
+    counter_account: &Account,
+    rpc_url: &Url,
+    prover: &LocalTransactionProver,
+) -> Result<()> {
     // Deploy counter account to the network using a genesis-aware RPC client.
     let mut rpc_client = create_genesis_aware_rpc_client(rpc_url, Duration::from_secs(10)).await?;
 
@@ -239,9 +246,8 @@ pub async fn deploy_counter_account(counter_account: &Account, rpc_url: &Url) ->
 
     let transaction_inputs = executed_tx.tx_inputs().to_bytes();
 
-    let proven_tx = spawn_blocking_in_current_span(move || {
-        futures::executor::block_on(LocalTransactionProver::default().prove(executed_tx))
-    })
+    let prover = prover.clone();
+    let proven_tx = spawn_blocking_in_current_span(move || prover.prove(executed_tx))
     .await
     .context("prover task panicked")?
     .context("Failed to prove transaction")?;

--- a/bin/network-monitor/src/monitor/tasks.rs
+++ b/bin/network-monitor/src/monitor/tasks.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use backon::{ExponentialBuilder, Retryable};
 use miden_node_proto::clients::RemoteProverClient;
 use miden_node_utils::tasks::Tasks as SupervisedTasks;
+use miden_tx::LocalTransactionProver;
 use tokio::sync::watch::Receiver;
 use tokio::sync::{Mutex, watch};
 use tracing::{debug, warn};
@@ -251,8 +252,9 @@ async fn run_ntx(
 async fn bootstrap_ntx(
     config: &MonitorConfig,
 ) -> Result<(IncrementService, CounterTrackingService)> {
+    let prover = LocalTransactionProver::default();
     let (wallet_account, secret_key, counter_account) =
-        create_and_deploy_accounts(&config.rpc_url).await?;
+        create_and_deploy_accounts(&config.rpc_url, &prover).await?;
 
     let (accounts_tx, accounts_rx) = watch::channel(TrackedAccounts {
         wallet: wallet_account.clone(),
@@ -266,6 +268,7 @@ async fn bootstrap_ntx(
         wallet_account,
         secret_key,
         counter_account,
+        prover,
         accounts_tx,
         latency_state.clone(),
     )

--- a/bin/ntx-builder/src/actor/execute.rs
+++ b/bin/ntx-builder/src/actor/execute.rs
@@ -437,8 +437,7 @@ impl NtxContext {
         .map_err(NtxError::Execution)
     }
 
-    /// Delegates the transaction proof to the remote prover if configured, otherwise performs the
-    /// proof locally.
+    /// Delegates the transaction proof to the configured remote prover.
     ///
     /// Transient transport failures against the remote prover are retried in-place; intrinsic
     /// proving errors (witness rejected, malformed inputs) escape on the first attempt.

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -16,9 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow                 = { workspace = true }
-async-trait            = { workspace = true }
 clap                   = { features = ["env"], workspace = true }
-futures                = { workspace = true }
 humantime              = { workspace = true }
 miden-block-prover     = { workspace = true }
 miden-node-proto       = { workspace = true }

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -1,4 +1,6 @@
 use miden_node_proto::generated as grpc;
+use miden_node_utils::ErrorReport;
+use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 
 use crate::COMPONENT;
@@ -35,12 +37,18 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
         //
         // We need to hold this until our request is processed to ensure that the queue capacity is
         // not exceeded.
-        let _permit = self.acquire_permit()?;
+        let permit = self.acquire_permit()?;
 
         // This mutex is fair and uses FIFO ordering.
         let prover = self.acquire_prover().await;
+        let task_panic_context = prover.task_panic_context();
 
-        prover.prove(request).await
+        spawn_blocking_in_current_span(move || {
+            let _permit = permit;
+            prover.prove(request)
+        })
+        .await
+        .map_err(|e| tonic::Status::internal(e.as_report_context(task_panic_context)))?
     }
 
     fn decode(request: grpc::remote_prover::ProofRequest) -> tonic::Result<Self::Input> {

--- a/bin/remote-prover/src/server/prover.rs
+++ b/bin/remote-prover/src/server/prover.rs
@@ -119,9 +119,9 @@ impl ProveRequest for LocalBatchProver {
     type Output = ProvenBatch;
 
     fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
-        let executed_batch = BatchExecutor::new().execute(input).map_err(|e| {
-            tonic::Status::internal(e.as_report_context("failed to execute batch"))
-        })?;
+        let executed_batch = BatchExecutor::new()
+            .execute(input)
+            .map_err(|e| tonic::Status::internal(e.as_report_context("failed to execute batch")))?;
         self.prove(executed_batch)
             .map_err(|e| tonic::Status::internal(e.as_report_context("failed to prove batch")))
     }

--- a/bin/remote-prover/src/server/prover.rs
+++ b/bin/remote-prover/src/server/prover.rs
@@ -2,15 +2,13 @@ use miden_block_prover::LocalBlockProver;
 use miden_node_proto::BlockProofRequest;
 use miden_node_proto::generated::remote_prover as proto;
 use miden_node_utils::ErrorReport;
-use miden_node_utils::spawn::spawn_blocking_in_current_span;
-use miden_node_utils::tracing::{ErrorSpanExt, miden_instrument};
+use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::MIN_PROOF_SECURITY_LEVEL;
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::block::BlockProof;
 use miden_protocol::transaction::{ProvenTransaction, TransactionInputs};
 use miden_tx::LocalTransactionProver;
 use miden_tx_batch::{BatchExecutor, LocalBatchProver};
-use tracing::Instrument;
 
 use crate::COMPONENT;
 use crate::server::proof_kind::ProofKind;
@@ -34,11 +32,20 @@ impl Prover {
 
     /// Proves a [`proto::ProofRequest`] using the appropriate prover implementation as specified
     /// during construction.
-    pub async fn prove(&self, request: proto::ProofRequest) -> Result<proto::Proof, tonic::Status> {
+    pub fn prove(&self, request: proto::ProofRequest) -> Result<proto::Proof, tonic::Status> {
         match self {
-            Prover::Transaction(prover) => prover.prove_request(request).await,
-            Prover::Batch(prover) => prover.prove_request(request).await,
-            Prover::Block(prover) => prover.prove_request(request).await,
+            Prover::Transaction(prover) => prover.prove_request(request),
+            Prover::Batch(prover) => prover.prove_request(request),
+            Prover::Block(prover) => prover.prove_request(request),
+        }
+    }
+
+    /// Returns the context attached to failures of the blocking task running this prover.
+    pub const fn task_panic_context(&self) -> &'static str {
+        match self {
+            Prover::Transaction(_) => "transaction prover task panicked",
+            Prover::Batch(_) => "batch prover task panicked",
+            Prover::Block(_) => "block prover task panicked",
         }
     }
 }
@@ -52,30 +59,24 @@ impl Prover {
 ///
 /// Implementations of this trait only need to provide the input and outputs types, as well as the
 /// proof implementation.
-#[async_trait::async_trait]
 trait ProveRequest: Send + Sync {
     type Input: miden_protocol::utils::serde::Deserializable + Send;
     type Output: miden_protocol::utils::serde::Serializable + Send;
 
-    async fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status>;
+    fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status>;
 
     /// Entry-point to the proof request handling.
     ///
     /// Decodes the request, proves it, and encodes the response.
-    async fn prove_request(
-        &self,
-        request: proto::ProofRequest,
-    ) -> Result<proto::Proof, tonic::Status> {
+    #[miden_instrument(
+        target=COMPONENT,
+        name="prove",
+        skip_all,
+        err,
+    )]
+    fn prove_request(&self, request: proto::ProofRequest) -> Result<proto::Proof, tonic::Status> {
         let input = Self::decode_request(request)?;
-
-        let prove_span = tracing::info_span!("prove", target = COMPONENT);
-        let result = self.prove(input).instrument(prove_span).await;
-
-        if let Err(e) = &result {
-            tracing::Span::current().set_error(e);
-        }
-
-        result.map(|output| Self::encode_response(output))
+        self.prove(input).map(|output| Self::encode_response(output))
     }
 
     #[miden_instrument(
@@ -102,60 +103,38 @@ trait ProveRequest: Send + Sync {
     }
 }
 
-#[async_trait::async_trait]
 impl ProveRequest for LocalTransactionProver {
     type Input = TransactionInputs;
     type Output = ProvenTransaction;
 
-    async fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
-        spawn_blocking_in_current_span(move || {
-            futures::executor::block_on(LocalTransactionProver::default().prove(input)).map_err(
-                |e| tonic::Status::internal(e.as_report_context("failed to prove transaction")),
-            )
+    fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
+        self.prove(input).map_err(|e| {
+            tonic::Status::internal(e.as_report_context("failed to prove transaction"))
         })
-        .await
-        .map_err(|e| {
-            tonic::Status::internal(e.as_report_context("transaction prover task panicked"))
-        })?
     }
 }
 
-#[async_trait::async_trait]
 impl ProveRequest for LocalBatchProver {
     type Input = ProposedBatch;
     type Output = ProvenBatch;
 
-    async fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
-        let prover = self.clone();
-
-        spawn_blocking_in_current_span(move || {
-            let executed_batch = BatchExecutor::new().execute(input).map_err(|e| {
-                tonic::Status::internal(e.as_report_context("failed to execute batch"))
-            })?;
-            prover
-                .prove(executed_batch)
-                .map_err(|e| tonic::Status::internal(e.as_report_context("failed to prove batch")))
-        })
-        .await
-        .map_err(|e| tonic::Status::internal(e.as_report_context("batch prover task panicked")))?
+    fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
+        let executed_batch = BatchExecutor::new().execute(input).map_err(|e| {
+            tonic::Status::internal(e.as_report_context("failed to execute batch"))
+        })?;
+        self.prove(executed_batch)
+            .map_err(|e| tonic::Status::internal(e.as_report_context("failed to prove batch")))
     }
 }
 
-#[async_trait::async_trait]
 impl ProveRequest for LocalBlockProver {
     type Input = BlockProofRequest;
     type Output = BlockProof;
 
-    async fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
-        let prover = self.clone();
+    fn prove(&self, input: Self::Input) -> Result<Self::Output, tonic::Status> {
         let BlockProofRequest { tx_batches, block_header, block_inputs } = input;
 
-        spawn_blocking_in_current_span(move || {
-            prover
-                .prove(tx_batches, &block_header, block_inputs)
-                .map_err(|e| tonic::Status::internal(e.as_report_context("failed to prove block")))
-        })
-        .await
-        .map_err(|e| tonic::Status::internal(e.as_report_context("block prover task panicked")))?
+        self.prove(tx_batches, &block_header, block_inputs)
+            .map_err(|e| tonic::Status::internal(e.as_report_context("failed to prove block")))
     }
 }

--- a/bin/remote-prover/src/server/service.rs
+++ b/bin/remote-prover/src/server/service.rs
@@ -1,22 +1,23 @@
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use miden_node_utils::tracing::miden_instrument;
-use tokio::sync::{Mutex, MutexGuard, SemaphorePermit};
+use tokio::sync::{Mutex, OwnedMutexGuard, OwnedSemaphorePermit, Semaphore};
 
 use crate::COMPONENT;
 use crate::server::proof_kind::ProofKind;
 use crate::server::prover::Prover;
 
 pub struct ProverService {
-    permits: tokio::sync::Semaphore,
-    prover: tokio::sync::Mutex<Prover>,
+    permits: Arc<Semaphore>,
+    prover: Arc<tokio::sync::Mutex<Prover>>,
     kind: ProofKind,
 }
 
 impl ProverService {
     pub fn with_capacity(kind: ProofKind, capacity: NonZeroUsize) -> Self {
-        let permits = tokio::sync::Semaphore::new(capacity.get());
-        let prover = Mutex::new(Prover::new(kind));
+        let permits = Arc::new(Semaphore::new(capacity.get()));
+        let prover = Arc::new(Mutex::new(Prover::new(kind)));
         Self { permits, prover, kind }
     }
 
@@ -29,9 +30,9 @@ impl ProverService {
         skip_all,
         err,
     )]
-    pub(super) fn acquire_permit(&self) -> Result<SemaphorePermit<'_>, tonic::Status> {
-        self.permits
-            .try_acquire()
+    pub(super) fn acquire_permit(&self) -> Result<OwnedSemaphorePermit, tonic::Status> {
+        Arc::clone(&self.permits)
+            .try_acquire_owned()
             .map_err(|_| tonic::Status::resource_exhausted("proof queue is full"))
     }
 
@@ -39,7 +40,7 @@ impl ProverService {
         target=COMPONENT,
         skip_all,
     )]
-    pub(super) async fn acquire_prover(&self) -> MutexGuard<'_, Prover> {
-        self.prover.lock().await
+    pub(super) async fn acquire_prover(&self) -> OwnedMutexGuard<Prover> {
+        Arc::clone(&self.prover).lock_owned().await
     }
 }

--- a/bin/remote-prover/src/server/tests.rs
+++ b/bin/remote-prover/src/server/tests.rs
@@ -132,7 +132,7 @@ impl ProofRequestExt for ProofRequest {
             .unwrap();
 
         let tx = Box::pin(tx.execute()).await.unwrap();
-        let tx = LocalTransactionProver::default().prove(tx.tx_inputs().clone()).await.unwrap();
+        let tx = LocalTransactionProver::default().prove(tx.tx_inputs().clone()).unwrap();
 
         ProposedBatch::new(
             vec![Arc::new(tx)],


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Title. Notably includes:

- `LocalTransactionProver::clone`
- `LocalTransactionProver::prove` is now sync

Closes #2335.
Closes #2324.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "protocol"
impact      = "changed"
description = "Upgrade to 0.16.0-alpha.2"
```
