### PR TITLE
fix: create monitor increment note via the account context

### DIFF
--- a/bin/network-monitor/src/assets/wallet_counter_program.masm
+++ b/bin/network-monitor/src/assets/wallet_counter_program.masm
@@ -1,9 +1,9 @@
-# Wallet self-counter component for the network monitor.
+# Wallet self-counter + note-creation component for the network monitor.
 #
-# The wallet increments this counter in the same transaction that emits an increment note to the
-# counter account, so the slot is an on-chain, atomically-committed count of *committed* increment
-# requests (the authoritative `expected` value). Unlike the counter contract, no note-sender
-# authorization is needed: the wallet increments its own storage from its own (signed) transaction.
+# A single account procedure atomically (a) creates the increment network note and (b) bumps the
+# wallet's own counter slot. Because both effects happen in one account procedure, a transaction can
+# never do one without the other, so the emitted note and the authoritative `expected` counter can
+# never diverge.
 #
 # Storage layout:
 # - COUNTER_SLOT: counter value (u64)
@@ -11,24 +11,35 @@
 use miden::core::sys
 use miden::protocol::active_account
 use miden::protocol::native_account
+use miden::protocol::output_note
 
 const COUNTER_SLOT = word("miden::monitor::wallet_contract::counter")
 
-# Increment the wallet's own counter slot.
-# => []
+# Create the increment network note and bump the wallet's own counter slot, atomically.
+#
+# Inputs:  [tag, note_type, RECIPIENT, pad(10)]
+# Outputs: [note_idx, pad(15)]
+#
+# Invocation: call
 @account_procedure
-pub proc increment
+pub proc increment_and_create_note
+    # Create the output note. `output_note::create` is only callable from the account context, so it
+    # must run here inside an account procedure.
+    exec.output_note::create
+    # => [note_idx, pad(15)]
+
+    # Bump the wallet's own counter slot. These ops are self-contained and leave note_idx on top.
     push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count, 0, 0, 0]
+    # => [count, 0, 0, 0, note_idx, pad(...)]
 
     push.1 add
-    # => [count+1, 0, 0, 0]
+    # => [count+1, 0, 0, 0, note_idx, pad(...)]
 
     push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => [OLD_VALUE]
+    # => [OLD_VALUE, note_idx, pad(...)]
 
     dropw
-    # => []
+    # => [note_idx, pad(15)]
 end
 
 # Read the wallet's own counter slot (no auth required).

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -1123,10 +1123,8 @@ pub(crate) fn create_increment_script() -> Result<NoteScript> {
 /// complete, non-composable script. Keep it in sync with `miden-standards` on version bumps; the
 /// `wallet_self_increment_tx` test exercises it end-to-end.
 fn create_increment_tx_script(network_note: &Note) -> Result<TransactionScript> {
-    let wallet_program = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/src/assets/wallet_counter_program.masm"
-    ));
+    let wallet_component = crate::deploy::wallet::wallet_counter_component_code()
+        .context("failed to compile wallet counter component code")?;
 
     let partial: PartialNote = network_note.clone().into();
     let recipient = partial.recipient_digest();
@@ -1135,44 +1133,53 @@ fn create_increment_tx_script(network_note: &Note) -> Result<TransactionScript> 
 
     let mut note_section = format!(
         "
+        padw padw push.0.0
         push.{recipient}
         push.{note_type}
         push.{tag}
-        # => [tag, note_type, RECIPIENT, pad(16)]
-        exec.::miden::protocol::output_note::create
-        # => [note_idx, pad(16)]
+        # => [tag, note_type, RECIPIENT, pad(10)]
+        call.::miden::standards::note::note_creator::create_note
+        # => [note_idx, pad(15)]
+        movdn.15 dropw dropw dropw drop drop drop
+        # => [note_idx]
         "
     );
     for attachment in partial.attachments().iter() {
         let scheme = attachment.attachment_scheme().as_u16();
         let commitment = attachment.content().to_commitment();
+        // `add_attachment` consumes `[attachment_scheme, ATTACHMENT_COMMITMENT, note_idx]`, so dup
+        // the note index for it to consume and keep our own copy for the next attachment / drop.
         write!(
             note_section,
             "
         dup
         push.{commitment}
         push.{scheme}
+        # => [attachment_scheme, ATTACHMENT_COMMITMENT, note_idx, note_idx]
         exec.::miden::protocol::output_note::add_attachment
-        # => [note_idx, pad(16)]
+        # => [note_idx]
         "
         )
         .expect("writing to a String cannot fail");
     }
     note_section.push_str("        drop\n");
 
-    let script_src = format!(
-        "use external_contract::wallet_counter
+    // Absolute path to the wallet's registered `increment` account procedure (e.g.
+    // `::wallet::program::increment`), matching the component path the account was built under.
+    let increment_path =
+        format!("::{}::increment", crate::deploy::wallet::WALLET_COUNTER_COMPONENT_PATH);
 
-        @transaction_script
+    let script_src = format!(
+        "@transaction_script
         pub proc main
-            call.wallet_counter::increment
+            call.{increment_path}
 {note_section}
         end"
     );
 
     let mut code_builder = CodeBuilder::new()
-        .with_linked_module("external_contract::wallet_counter", wallet_program)
-        .context("Failed to link wallet counter module")?;
+        .with_dynamically_linked_library(&wallet_component)
+        .context("Failed to dynamically link wallet counter component")?;
 
     // The note's attachments (e.g. the network-account target) are resolved at runtime from the
     // advice map keyed by their commitment, matching `build_send_notes_script`.

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -1114,14 +1114,14 @@ pub(crate) fn create_increment_script() -> Result<NoteScript> {
 
 /// Build the transaction script for one increment.
 ///
-/// The script does two things atomically in the wallet's transaction:
-/// 1. `call`s the wallet's own `increment` procedure, bumping the wallet's on-chain counter slot
-/// 2. Emits the network note that targets the counter account (the `observed` value).
+/// The whole transaction is a single `call` into the wallet's `increment_and_create_note` account
+/// procedure, which atomically (1) creates the network note targeting the counter account (the
+/// `observed` value) and (2) bumps the wallet's own on-chain counter slot (the authoritative
+/// `expected` value).
 ///
-/// The note-emission section mirrors `miden_standards`' `build_send_notes_script` for an
-/// asset-less note with attachments; it is not reused directly because that builder produces a
-/// complete, non-composable script. Keep it in sync with `miden-standards` on version bumps; the
-/// `wallet_self_increment_tx` test exercises it end-to-end.
+/// The note attachments (the `NetworkAccountTarget`) are added afterwards with
+/// `output_note::add_attachment`, which is not account-restricted, mirroring `miden_standards`'
+/// `SendNotesTransactionScript`. The `wallet_self_increment_tx` test exercises this end-to-end.
 fn create_increment_tx_script(network_note: &Note) -> Result<TransactionScript> {
     let wallet_component = crate::deploy::wallet::wallet_counter_component_code()
         .context("failed to compile wallet counter component code")?;
@@ -1131,6 +1131,17 @@ fn create_increment_tx_script(network_note: &Note) -> Result<TransactionScript> 
     let note_type = Felt::from(partial.metadata().note_type());
     let tag = Felt::from(partial.metadata().tag());
 
+    // The wallet's own account procedure creates the note *and* bumps the counter atomically, so
+    // the whole transaction is a single `call` into the wallet component.
+    // `increment_and_create_note` shares `create_note`'s stack contract: it consumes `[tag,
+    // note_type, RECIPIENT, pad(10)]` and returns `[note_idx, pad(15)]`. We build the padded input
+    // explicitly and reduce the trailing pads back to `[note_idx]`, otherwise the extra pads
+    // survive on the overflow stack and `main` returns with the wrong depth ("stack depth must be
+    // 16, but was 21").
+    let increment_and_create_note = format!(
+        "::{}::increment_and_create_note",
+        crate::deploy::wallet::WALLET_COUNTER_COMPONENT_PATH
+    );
     let mut note_section = format!(
         "
         padw padw push.0.0
@@ -1138,7 +1149,7 @@ fn create_increment_tx_script(network_note: &Note) -> Result<TransactionScript> 
         push.{note_type}
         push.{tag}
         # => [tag, note_type, RECIPIENT, pad(10)]
-        call.::miden::standards::note::note_creator::create_note
+        call.{increment_and_create_note}
         # => [note_idx, pad(15)]
         movdn.15 dropw dropw dropw drop drop drop
         # => [note_idx]
@@ -1164,15 +1175,9 @@ fn create_increment_tx_script(network_note: &Note) -> Result<TransactionScript> 
     }
     note_section.push_str("        drop\n");
 
-    // Absolute path to the wallet's registered `increment` account procedure (e.g.
-    // `::wallet::program::increment`), matching the component path the account was built under.
-    let increment_path =
-        format!("::{}::increment", crate::deploy::wallet::WALLET_COUNTER_COMPONENT_PATH);
-
     let script_src = format!(
         "@transaction_script
         pub proc main
-            call.{increment_path}
 {note_section}
         end"
     );

--- a/bin/network-monitor/src/deploy/wallet.rs
+++ b/bin/network-monitor/src/deploy/wallet.rs
@@ -10,6 +10,7 @@ use miden_protocol::account::{
     Account,
     AccountBuilder,
     AccountComponent,
+    AccountComponentCode,
     AccountComponentMetadata,
     AccountType,
     StorageSlot,
@@ -35,6 +36,29 @@ pub static WALLET_COUNTER_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|
         .expect("storage slot name should be valid")
 });
 
+/// Module path under which the wallet's self-counter component is compiled.
+///
+/// The increment transaction script must reference `increment` under this exact path (via a
+/// dynamically-linked copy of [`wallet_counter_component_code`]) so the `call` resolves to the
+/// procedure root registered in the account.
+pub const WALLET_COUNTER_COMPONENT_PATH: &str = "wallet::program";
+
+/// The wallet self-counter component source (bumps [`WALLET_COUNTER_SLOT_NAME`]).
+const WALLET_COUNTER_PROGRAM: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/assets/wallet_counter_program.masm"));
+
+/// Compiles the wallet's self-counter [`AccountComponentCode`].
+///
+/// This is the single source of truth for the component: [`create_wallet_account`] builds the
+/// account from it, and the increment transaction-script builder dynamically links it so
+/// `call.::wallet::program::increment` resolves to the same procedure root the account registered.
+/// Compilation is deterministic, so both sites obtain identical code and roots.
+pub fn wallet_counter_component_code() -> Result<AccountComponentCode> {
+    CodeBuilder::default()
+        .compile_component_code(WALLET_COUNTER_COMPONENT_PATH, WALLET_COUNTER_PROGRAM)
+        .context("failed to compile wallet counter component code")
+}
+
 /// Create a wallet account with `RpoFalcon512` authentication and a self-counter component.
 ///
 /// Returns the created account and the secret key for authentication.
@@ -56,12 +80,7 @@ pub fn create_wallet_account() -> Result<(Account, SecretKey)> {
 
     // The wallet carries its own counter component so it can increment a storage slot in the same
     // transaction that emits the increment note. See `WALLET_COUNTER_SLOT_NAME`.
-    let script = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/src/assets/wallet_counter_program.masm"
-    ));
-    let component_code =
-        CodeBuilder::default().compile_component_code("wallet::program", script)?;
+    let component_code = wallet_counter_component_code()?;
 
     let counter_slot = StorageSlot::with_value(WALLET_COUNTER_SLOT_NAME.clone(), Word::empty());
     let metadata = AccountComponentMetadata::new("wallet::program");

--- a/bin/network-monitor/src/deploy/wallet.rs
+++ b/bin/network-monitor/src/deploy/wallet.rs
@@ -18,7 +18,6 @@ use miden_protocol::account::{
 };
 use miden_protocol::crypto::dsa::falcon512_poseidon2::SecretKey;
 use miden_standards::account::auth::{Approver, AuthSingleSig};
-use miden_standards::account::wallets::BasicWallet;
 use miden_standards::code_builder::CodeBuilder;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -78,8 +77,8 @@ pub fn create_wallet_account() -> Result<(Account, SecretKey)> {
     .into();
     let init_seed: [u8; 32] = rng.random();
 
-    // The wallet carries its own counter component so it can increment a storage slot in the same
-    // transaction that emits the increment note. See `WALLET_COUNTER_SLOT_NAME`.
+    // The wallet carries a single custom component that both bumps its counter slot and creates the
+    // increment note in one account procedure (see `wallet_counter_program.masm`).
     let component_code = wallet_counter_component_code()?;
 
     let counter_slot = StorageSlot::with_value(WALLET_COUNTER_SLOT_NAME.clone(), Word::empty());
@@ -89,7 +88,6 @@ pub fn create_wallet_account() -> Result<(Account, SecretKey)> {
     let account = AccountBuilder::new(init_seed)
         .account_type(AccountType::Public)
         .with_auth_component(auth_component)
-        .with_component(BasicWallet)
         .with_component(counter_component)
         .build()
         .context("failed to build wallet account")?;


### PR DESCRIPTION
## Summary

The network monitor's counter flow was broken on next: every increment transaction failed during execution with:
```
failed to execute transaction kernel program:
  x error during processing of event 'miden::protocol::account::push_procedure_index'
  `-> account procedure with procedure root 0x… is not in the account procedure index map
```

The monitor's increment transaction script was written to mirror miden-standards 0.15's `build_send_notes_script`, which created output notes by executing `output_note::create` directly from the transaction-script context. After migrating to 0.16, the kernel makes note creation account-context only.

I changed it to create the note through the standard `note_creator::create_note` account procedure via call (switching into the account context)

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "network-monitor"
impact      = "fixed"
description = "Fixed network monitor increment transactions failing under the 0.16 transaction kernel by creating notes through the account context"
```
