### PR TITLE
Switch to trusted crate publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -2,6 +2,7 @@ name: Publish crates
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   release:
@@ -61,9 +62,13 @@ jobs:
       - name: Rustup
         run: rustup toolchain install --no-self-update
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish unpublished crates
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

This switches the publishing workflow from using an auth token (github secret) to the trusted publishing model, where short lived auth token is requested on each run.

The required admin changes on `crates.io` should already be enabled.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "internal"
impact      = "changed"
description = "Crates are now published using trusted publishing"
```
