### PR TITLE
fix(rpc): fix RPC connection timeout panics by configuring a max connection age grace period

### DIFF
--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -37,6 +37,7 @@ impl RpcOptions {
         GrpcOptionsExternal {
             request_timeout: self.grpc.timeout,
             max_connection_age: self.grpc.max_connection_age,
+            max_connection_age_grace: self.grpc.max_connection_age_grace,
             burst_size: self.rate_limit.burst_size,
             replenish_n_per_second_per_ip: self.rate_limit.replenish_per_second,
             max_concurrent_connections: self.rate_limit.max_concurrent_connections,
@@ -78,6 +79,17 @@ pub struct GrpcOptions {
         help_heading = super::section::RPC_CONFIGURATION_HELP_HEADING
     )]
     pub max_connection_age: Duration,
+
+    /// Grace period for an RPC connection to shut down after reaching its maximum age.
+    #[arg(
+        long = "rpc.grpc.max-connection-age-grace",
+        env = "MIDEN_NODE_RPC_GRPC_MAX_CONNECTION_AGE_GRACE",
+        default_value = duration_to_human_readable_string(Duration::from_secs(10)),
+        value_parser = humantime::parse_duration,
+        value_name = "DURATION",
+        help_heading = super::section::RPC_CONFIGURATION_HELP_HEADING
+    )]
+    pub max_connection_age_grace: Duration,
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -175,6 +175,7 @@ impl Rpc {
         let rpc = tonic::transport::Server::builder()
             .accept_http1(true)
             .max_connection_age(self.grpc_options.max_connection_age)
+            .max_connection_age_grace(self.grpc_options.max_connection_age_grace)
             .timeout(self.grpc_options.request_timeout)
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
             .layer(

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -275,6 +275,51 @@ async fn rpc_rate_limits_per_ip() {
 }
 
 #[tokio::test]
+async fn rpc_connection_timeout_grace_does_not_panic() {
+    let tonic_timeout_panics = Arc::new(AtomicUsize::new(0));
+    let tonic_timeout_panics_hook = Arc::clone(&tonic_timeout_panics);
+    let default_panic_hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |info| {
+        let panic_payload = info
+            .payload()
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str));
+
+        if panic_payload
+            .is_some_and(|payload| payload.contains("async fn resumed after completion"))
+        {
+            tonic_timeout_panics_hook.fetch_add(1, Ordering::SeqCst);
+        }
+    }));
+
+    let grpc_options = GrpcOptionsExternal {
+        max_connection_age: Duration::from_millis(20),
+        max_connection_age_grace: Duration::from_millis(20),
+        ..GrpcOptionsExternal::test()
+    };
+    let (mut rpc_client, rpc_addr, _store) = start_rpc_with_options(grpc_options).await;
+
+    let initial_response = send_request(&mut rpc_client).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let url = Url::parse(&format!("http://{rpc_addr}")).unwrap();
+    let mut fresh_rpc_client = connect_rpc(url, None).await;
+    let fresh_response = send_request(&mut fresh_rpc_client).await;
+
+    std::panic::set_hook(default_panic_hook);
+    initial_response.expect("initial RPC request should succeed");
+    fresh_response
+        .expect("RPC server should keep serving fresh connections after timing out an old one");
+    assert_eq!(
+        tonic_timeout_panics.load(Ordering::SeqCst),
+        0,
+        "tonic connection timeout should not panic after max_connection_age"
+    );
+}
+
+#[tokio::test]
 async fn rpc_server_accepts_requests_with_accept_header() {
     // Start the RPC.
     let (mut rpc_client, _, _store) = start_rpc().await;

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -11,6 +11,7 @@ pub use rocksdb::*;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const TEST_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_MAX_CONNECTION_AGE: Duration = Duration::from_mins(30);
+const DEFAULT_MAX_CONNECTION_AGE_GRACE: Duration = Duration::from_secs(10);
 const DEFAULT_REPLENISH_N_PER_SECOND_PER_IP: NonZeroU64 = NonZeroU64::new(16).unwrap();
 const DEFAULT_BURST_SIZE: NonZeroU32 = NonZeroU32::new(128).unwrap();
 const DEFAULT_MAX_CONCURRENT_CONNECTIONS: u64 = 1_000;
@@ -80,6 +81,16 @@ pub struct GrpcOptionsExternal {
     )]
     pub max_connection_age: Duration,
 
+    /// Maximum duration for a connection to shut down gracefully after reaching the maximum age
+    /// before the server forcefully closes it.
+    #[arg(
+        long = "grpc.max_connection_age_grace",
+        default_value = duration_to_human_readable_string(DEFAULT_MAX_CONNECTION_AGE_GRACE),
+        value_parser = humantime::parse_duration,
+        value_name = "MAX_CONNECTION_AGE_GRACE"
+    )]
+    pub max_connection_age_grace: Duration,
+
     /// Number of connections to be served before the "API tokens" need to be replenished per IP
     /// address.
     #[arg(
@@ -111,6 +122,7 @@ impl Default for GrpcOptionsExternal {
         Self {
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
             max_connection_age: DEFAULT_MAX_CONNECTION_AGE,
+            max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
             burst_size: DEFAULT_BURST_SIZE,
             replenish_n_per_second_per_ip: DEFAULT_REPLENISH_N_PER_SECOND_PER_IP,
             max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
@@ -131,6 +143,7 @@ impl GrpcOptionsExternal {
         Self {
             request_timeout: Duration::from_hours(24),
             max_connection_age: Duration::from_hours(24),
+            max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
             burst_size: NonZeroU32::new(100_000).unwrap(),
             replenish_n_per_second_per_ip: NonZeroU64::new(100_000).unwrap(),
             max_concurrent_connections: u64::MAX,


### PR DESCRIPTION
## Summary

This PR adds a `max_connection_age_grace` setting for external RPC gRPC configuration and wires it into the public RPC tonic server via `.max_connection_age_grace(...)`.

Without a grace period, tonic 0.14.x can panic when a connection reaches max_connection_age, because the graceful shutdown timeout future completes and is polled again. Setting a grace period moves tonic onto the forceful-shutdown path after the grace window, avoiding the completed-future re-poll.

Changes:

  - Added `max_connection_age_grace` to `GrpcOptionsExternal`.
  - Added CLI/env support through `--rpc.grpc.max-connection-age-grace` and `MIDEN_NODE_RPC_GRPC_MAX_CONNECTION_AGE_GRACE`.
  - Applied the grace period to the public RPC server builder.
  - Added a regression test covering connection timeout without the tonic panic.

Closes #2336 

## Changelog

```toml
[[entry]]
scope       = "rpc"
impact      = "fixed"
description = "Tokio worker threads no longer panic when connections reach maximum age."
```
