### PR TITLE
Bump version to `0.16.0-alpha.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "miden-benchmark"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "clap",
  "fs-err",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-tracing-macro"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "backon",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "backon",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7080,7 +7080,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.16.0-alpha.1"
+version = "0.16.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.96.1"
-version      = "0.16.0-alpha.1"
+version      = "0.16.0-alpha.2"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]
@@ -42,16 +42,16 @@ debug = true
 
 [workspace.dependencies]
 # Workspace crates.
-miden-node-block-producer   = { path = "crates/block-producer", version = "0.16.0-alpha.1" }
-miden-node-db               = { path = "crates/db", version = "0.16.0-alpha.1" }
-miden-node-grpc-error-macro = { path = "crates/grpc-error-macro", version = "0.16.0-alpha.1" }
-miden-node-proto            = { path = "crates/proto", version = "0.16.0-alpha.1" }
-miden-node-proto-build      = { path = "proto", version = "0.16.0-alpha.1" }
-miden-node-rpc              = { path = "crates/rpc", version = "0.16.0-alpha.1" }
-miden-node-store            = { path = "crates/store", version = "0.16.0-alpha.1" }
+miden-node-block-producer   = { path = "crates/block-producer", version = "0.16.0-alpha.2" }
+miden-node-db               = { path = "crates/db", version = "0.16.0-alpha.2" }
+miden-node-grpc-error-macro = { path = "crates/grpc-error-macro", version = "0.16.0-alpha.2" }
+miden-node-proto            = { path = "crates/proto", version = "0.16.0-alpha.2" }
+miden-node-proto-build      = { path = "proto", version = "0.16.0-alpha.2" }
+miden-node-rpc              = { path = "crates/rpc", version = "0.16.0-alpha.2" }
+miden-node-store            = { path = "crates/store", version = "0.16.0-alpha.2" }
 miden-node-test-macro       = { path = "crates/test-macro" }
-miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.16.0-alpha.1" }
-miden-node-utils            = { path = "crates/utils", version = "0.16.0-alpha.1" }
+miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.16.0-alpha.2" }
+miden-node-utils            = { path = "crates/utils", version = "0.16.0-alpha.2" }
 
 # miden-protocol dependencies. These should be updated in sync.
 miden-block-prover = { version = "=0.16.0-alpha.2" }


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

The primary goal is deploying the monitor fix so the devnet status page can go green(er).

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```