### PR TITLE
feat(logging): add account, note, storage, and mempool lifecycle events

### DIFF
--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -118,7 +118,7 @@ impl BlockBuilder {
         miden_span_record!(
             block.number = %telemetry.block_number,
             block.batches.count = telemetry.batches_count,
-            block.batch.ids = ?telemetry.batch_ids,
+            block.batch.ids = %format_array(telemetry.batch_ids),
             block.transactions.ids = ?telemetry.transaction_ids,
             block.transactions.count = telemetry.transactions_count,
         );

--- a/crates/block-producer/src/mempool/graph/mod.rs
+++ b/crates/block-producer/src/mempool/graph/mod.rs
@@ -7,3 +7,4 @@ mod transaction;
 
 pub use batch::BatchGraph;
 pub use transaction::TransactionGraph;
+pub(super) use transaction::TransactionRemoval;

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -96,6 +96,36 @@ pub struct TransactionGraph {
     user_batches: BatchTxMap,
 }
 
+/// Transactions removed by a single lifecycle transition.
+///
+/// `direct` contains the transactions which triggered the removal. `removed` additionally contains
+/// transactions which were removed because they depended on a direct transaction.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct TransactionRemoval {
+    direct: HashSet<TransactionId>,
+    removed: HashSet<TransactionId>,
+}
+
+impl TransactionRemoval {
+    pub(crate) fn direct(&self) -> impl Iterator<Item = TransactionId> + '_ {
+        self.direct.iter().copied()
+    }
+
+    pub(crate) fn dependents(&self) -> impl Iterator<Item = TransactionId> + '_ {
+        self.removed.difference(&self.direct).copied()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.removed.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, transaction_id: &TransactionId) -> bool {
+        self.removed.contains(transaction_id)
+    }
+}
+
 impl TransactionGraph {
     /// Transactions are evicted after failing this number of times.
     pub const FAILURE_LIMIT: u32 = 3;
@@ -253,7 +283,8 @@ impl TransactionGraph {
     /// didn't ignore selected transactions here, we would revert committed ones as well, which
     /// breaks the state.
     ///
-    /// Returns the identifiers of transactions that were removed from the graph.
+    /// Returns both the directly expired transactions and all transactions removed from the graph,
+    /// including their dependents.
     ///
     /// # Note
     ///
@@ -262,17 +293,17 @@ impl TransactionGraph {
     /// transactions from expired batches (and therefore not committed) are deselected
     /// _before_ calling this function. i.e. first revert expired batches and deselect their
     /// transactions, then call this.
-    pub fn revert_expired(&mut self, chain_tip: BlockNumber) -> HashSet<TransactionId> {
-        let mut to_revert = self.inner.expired(chain_tip);
-        to_revert.retain(|tx| !self.inner.is_selected(tx));
+    pub fn revert_expired(&mut self, chain_tip: BlockNumber) -> TransactionRemoval {
+        let mut direct = self.inner.expired(chain_tip);
+        direct.retain(|tx| !self.inner.is_selected(tx));
 
-        let mut reverted = HashSet::with_capacity(to_revert.len());
+        let mut removed = HashSet::with_capacity(direct.len());
 
-        for tx in to_revert {
-            reverted.extend(&self.revert_tx_and_descendants(tx));
+        for tx in direct.iter().copied() {
+            removed.extend(&self.revert_tx_and_descendants(tx));
         }
 
-        reverted
+        TransactionRemoval { direct, removed }
     }
 
     /// Reverts the given transaction and _all_ its descendants _IFF_ it is present in the graph.
@@ -337,11 +368,12 @@ impl TransactionGraph {
     ///
     /// # Returns
     ///
-    /// Returns the set of reverted transactions.
+    /// Returns both the transactions which reached the failure limit directly and all transactions
+    /// removed from the graph, including their dependents.
     pub fn increment_failure_count(
         &mut self,
         txs: impl Iterator<Item = TransactionId>,
-    ) -> HashSet<TransactionId> {
+    ) -> TransactionRemoval {
         let mut to_revert = Vec::default();
 
         for tx in txs {
@@ -353,12 +385,13 @@ impl TransactionGraph {
             }
         }
 
-        let mut reverted = HashSet::default();
-        for tx in to_revert {
-            reverted.extend(self.revert_tx_and_descendants(tx));
+        let direct = to_revert.into_iter().collect::<HashSet<_>>();
+        let mut removed = HashSet::default();
+        for tx in direct.iter().copied() {
+            removed.extend(self.revert_tx_and_descendants(tx));
         }
 
-        reverted
+        TransactionRemoval { direct, removed }
     }
 
     /// Prunes the given given batch's transactions.

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use miden_protocol::Word;
@@ -102,8 +102,8 @@ pub struct TransactionGraph {
 /// transactions which were removed because they depended on a direct transaction.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct TransactionRemoval {
-    direct: HashSet<TransactionId>,
-    removed: HashSet<TransactionId>,
+    direct: BTreeSet<TransactionId>,
+    removed: BTreeSet<TransactionId>,
 }
 
 impl TransactionRemoval {
@@ -294,10 +294,14 @@ impl TransactionGraph {
     /// _before_ calling this function. i.e. first revert expired batches and deselect their
     /// transactions, then call this.
     pub fn revert_expired(&mut self, chain_tip: BlockNumber) -> TransactionRemoval {
-        let mut direct = self.inner.expired(chain_tip);
-        direct.retain(|tx| !self.inner.is_selected(tx));
+        let direct = self
+            .inner
+            .expired(chain_tip)
+            .into_iter()
+            .filter(|tx| !self.inner.is_selected(tx))
+            .collect::<BTreeSet<_>>();
 
-        let mut removed = HashSet::with_capacity(direct.len());
+        let mut removed = BTreeSet::new();
 
         for tx in direct.iter().copied() {
             removed.extend(&self.revert_tx_and_descendants(tx));
@@ -385,8 +389,8 @@ impl TransactionGraph {
             }
         }
 
-        let direct = to_revert.into_iter().collect::<HashSet<_>>();
-        let mut removed = HashSet::default();
+        let direct = to_revert.into_iter().collect::<BTreeSet<_>>();
+        let mut removed = BTreeSet::new();
         for tx in direct.iter().copied() {
             removed.extend(self.revert_tx_and_descendants(tx));
         }

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -713,6 +713,10 @@ impl Mempool {
 }
 
 fn emit_transaction_added(tx: &AuthenticatedTransaction) {
+    if !tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG) {
+        return;
+    }
+
     tracing::debug!(
         target: LOG_TARGET,
         {
@@ -725,6 +729,10 @@ fn emit_transaction_added(tx: &AuthenticatedTransaction) {
 }
 
 fn emit_transaction_expirations(removal: &graph::TransactionRemoval, chain_tip: BlockNumber) {
+    if !tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG) {
+        return;
+    }
+
     for transaction_id in sorted_transaction_ids(removal.direct()) {
         tracing::debug!(
             target: LOG_TARGET,
@@ -744,6 +752,10 @@ fn emit_transaction_evictions(
     direct_reason: &'static str,
     dependent_reason: &'static str,
 ) {
+    if !tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG) {
+        return;
+    }
+
     for transaction_id in sorted_transaction_ids(removal.direct()) {
         tracing::debug!(
             target: LOG_TARGET,

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -50,7 +50,7 @@
 //! Recently committed batches are retained in `committed_blocks` according to the configured
 //! `state_retention`, giving the mempool enough local history to validate newly authenticated
 //! transactions even if the store and block producer momentarily disagree on the chain tip.
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 
@@ -69,6 +69,7 @@ use crate::mempool::budget::BudgetStatus;
 use crate::{
     COMPONENT,
     DEFAULT_MEMPOOL_TX_CAPACITY,
+    LOG_TARGET,
     SERVER_MEMPOOL_EXPIRATION_SLACK,
     SERVER_MEMPOOL_STATE_RETENTION,
 };
@@ -269,6 +270,7 @@ impl Mempool {
             mempool.nullifiers = telemetry.nullifiers,
             mempool.output_notes = telemetry.output_notes,
         );
+        emit_transaction_added(&tx);
 
         Ok(self.committed_chain_tip)
     }
@@ -316,6 +318,9 @@ impl Mempool {
             mempool.nullifiers = telemetry.nullifiers,
             mempool.output_notes = telemetry.output_notes,
         );
+        for tx in txs {
+            emit_transaction_added(tx);
+        }
 
         Ok(self.committed_chain_tip)
     }
@@ -413,10 +418,13 @@ impl Mempool {
         // This could occur if this batch is the descendent of a separate batch or block rollback.
         // The batch and transaction graphs already ignore unknown reversions, alternatively we
         // could check this precondition above.
-        if let Some(batch) = reverted_batches.iter().find(|reverted| reverted.id() == batch) {
-            let failed_txs = batch.transactions().iter().map(|tx| tx.id());
-            self.transactions.increment_failure_count(failed_txs);
-        }
+        let evicted =
+            if let Some(batch) = reverted_batches.iter().find(|reverted| reverted.id() == batch) {
+                let failed_txs = batch.transactions().iter().map(|tx| tx.id());
+                self.transactions.increment_failure_count(failed_txs)
+            } else {
+                graph::TransactionRemoval::default()
+            };
 
         let telemetry = self.telemetry();
         miden_span_record!(
@@ -428,6 +436,7 @@ impl Mempool {
             mempool.nullifiers = telemetry.nullifiers,
             mempool.output_notes = telemetry.output_notes,
         );
+        emit_transaction_evictions(&evicted, "failure_limit", "dependency_evicted");
     }
 
     /// Marks a batch as proven if it exists.
@@ -516,7 +525,7 @@ impl Mempool {
         self.committed_blocks.push_back(block);
         self.prune_oldest_block();
 
-        self.revert_expired();
+        let expired = self.revert_expired();
         let telemetry = self.telemetry();
         miden_span_record!(
             mempool.transactions.uncommitted = telemetry.uncommitted_transactions,
@@ -527,6 +536,7 @@ impl Mempool {
             mempool.nullifiers = telemetry.nullifiers,
             mempool.output_notes = telemetry.output_notes,
         );
+        emit_transaction_expirations(&expired, self.committed_chain_tip);
     }
 
     /// Notify the pool that construction of the in flight block failed.
@@ -566,7 +576,7 @@ impl Mempool {
             .batches
             .iter()
             .flat_map(|batch| batch.transactions().as_slice().iter().map(TransactionHeader::id));
-        self.transactions.increment_failure_count(failed_txs);
+        let evicted = self.transactions.increment_failure_count(failed_txs);
         let telemetry = self.telemetry();
         miden_span_record!(
             mempool.transactions.uncommitted = telemetry.uncommitted_transactions,
@@ -577,6 +587,7 @@ impl Mempool {
             mempool.nullifiers = telemetry.nullifiers,
             mempool.output_notes = telemetry.output_notes,
         );
+        emit_transaction_evictions(&evicted, "failure_limit", "dependency_evicted");
     }
 
     // STATS & INSPECTION
@@ -645,7 +656,7 @@ impl Mempool {
     ///
     /// Transactions from batches are requeued. Expired transactions and their descendants are then
     /// reverted as well.
-    fn revert_expired(&mut self) -> HashSet<TransactionId> {
+    fn revert_expired(&mut self) -> graph::TransactionRemoval {
         let batches = self.batches.revert_expired(self.chain_tip());
         for batch in batches {
             self.transactions.requeue_transactions(&batch);
@@ -699,4 +710,71 @@ impl Mempool {
 
         Ok(())
     }
+}
+
+fn emit_transaction_added(tx: &AuthenticatedTransaction) {
+    tracing::debug!(
+        target: LOG_TARGET,
+        {
+            transaction.id = %tx.id(),
+            account.id = %tx.account_id(),
+            transaction.expires_at = %tx.expires_at(),
+        },
+        "Transaction added to mempool",
+    );
+}
+
+fn emit_transaction_expirations(removal: &graph::TransactionRemoval, chain_tip: BlockNumber) {
+    for transaction_id in sorted_transaction_ids(removal.direct()) {
+        tracing::debug!(
+            target: LOG_TARGET,
+            {
+                transaction.id = %transaction_id,
+                block.number = %chain_tip,
+            },
+            "Transaction expired from mempool",
+        );
+    }
+
+    emit_dependent_transaction_evictions(removal, "dependency_expired");
+}
+
+fn emit_transaction_evictions(
+    removal: &graph::TransactionRemoval,
+    direct_reason: &'static str,
+    dependent_reason: &'static str,
+) {
+    for transaction_id in sorted_transaction_ids(removal.direct()) {
+        tracing::debug!(
+            target: LOG_TARGET,
+            {
+                transaction.id = %transaction_id,
+                mempool.removal.reason = direct_reason,
+            },
+            "Transaction evicted from mempool",
+        );
+    }
+
+    emit_dependent_transaction_evictions(removal, dependent_reason);
+}
+
+fn emit_dependent_transaction_evictions(removal: &graph::TransactionRemoval, reason: &'static str) {
+    for transaction_id in sorted_transaction_ids(removal.dependents()) {
+        tracing::debug!(
+            target: LOG_TARGET,
+            {
+                transaction.id = %transaction_id,
+                mempool.removal.reason = reason,
+            },
+            "Transaction evicted from mempool",
+        );
+    }
+}
+
+fn sorted_transaction_ids(
+    transaction_ids: impl Iterator<Item = TransactionId>,
+) -> Vec<TransactionId> {
+    let mut transaction_ids = transaction_ids.collect::<Vec<_>>();
+    transaction_ids.sort_unstable();
+    transaction_ids
 }

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -58,7 +58,7 @@ use miden_node_utils::ErrorReport;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 use miden_protocol::batch::{BatchId, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber};
-use miden_protocol::transaction::{TransactionHeader, TransactionId};
+use miden_protocol::transaction::TransactionHeader;
 use thiserror::Error;
 
 use crate::block_builder::SelectedBlock;
@@ -733,7 +733,7 @@ fn emit_transaction_expirations(removal: &graph::TransactionRemoval, chain_tip: 
         return;
     }
 
-    for transaction_id in sorted_transaction_ids(removal.direct()) {
+    for transaction_id in removal.direct() {
         tracing::debug!(
             target: LOG_TARGET,
             {
@@ -756,7 +756,7 @@ fn emit_transaction_evictions(
         return;
     }
 
-    for transaction_id in sorted_transaction_ids(removal.direct()) {
+    for transaction_id in removal.direct() {
         tracing::debug!(
             target: LOG_TARGET,
             {
@@ -771,7 +771,7 @@ fn emit_transaction_evictions(
 }
 
 fn emit_dependent_transaction_evictions(removal: &graph::TransactionRemoval, reason: &'static str) {
-    for transaction_id in sorted_transaction_ids(removal.dependents()) {
+    for transaction_id in removal.dependents() {
         tracing::debug!(
             target: LOG_TARGET,
             {
@@ -781,12 +781,4 @@ fn emit_dependent_transaction_evictions(removal: &graph::TransactionRemoval, rea
             "Transaction evicted from mempool",
         );
     }
-}
-
-fn sorted_transaction_ids(
-    transaction_ids: impl Iterator<Item = TransactionId>,
-) -> Vec<TransactionId> {
-    let mut transaction_ids = transaction_ids.collect::<Vec<_>>();
-    transaction_ids.sort_unstable();
-    transaction_ids
 }

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use serial_test::serial;
 
 use super::*;
-use crate::mempool::graph::TransactionGraph;
+use crate::mempool::graph::{TransactionGraph, TransactionRemoval};
 use crate::test_utils::batch::TransactionBatchConstructor;
 use crate::test_utils::{MockProvenTxBuilder, mock_account_id};
 
@@ -429,7 +429,65 @@ fn transactions_exceeding_failure_limit_are_removed() {
 
     let reverted = uut.transactions.increment_failure_count(std::iter::once(tx_id));
     assert!(reverted.contains(&tx_id));
+    assert_eq!(reverted.direct().collect::<Vec<_>>(), vec![tx_id]);
+    assert!(reverted.dependents().next().is_none());
     assert_eq!(uut.unbatched_transactions_count(), 0);
+}
+
+#[test]
+fn failure_eviction_distinguishes_direct_and_dependent_transactions() {
+    let (mut uut, _) = Mempool::for_tests();
+    let [parent, child, _] = MockProvenTxBuilder::sequential();
+    let parent_id = parent.id();
+    let child_id = child.id();
+
+    uut.add_transaction(parent).unwrap();
+    uut.add_transaction(child).unwrap();
+
+    let mut removal = TransactionRemoval::default();
+    for _ in 0..TransactionGraph::FAILURE_LIMIT {
+        removal = uut.transactions.increment_failure_count(std::iter::once(parent_id));
+    }
+
+    assert_eq!(removal.direct().collect::<Vec<_>>(), vec![parent_id]);
+    assert_eq!(removal.dependents().collect::<Vec<_>>(), vec![child_id]);
+}
+
+#[test]
+fn expiration_distinguishes_direct_and_dependent_transactions() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.expiration_slack = 0;
+    let [parent_template, child_template, _] = MockProvenTxBuilder::sequential();
+    let parent_update = parent_template.account_update();
+    let child_update = child_template.account_update();
+    let parent = Arc::new(AuthenticatedTransaction::from_inner(
+        MockProvenTxBuilder::with_account(
+            parent_update.account_id(),
+            parent_update.initial_state_commitment(),
+            parent_update.final_state_commitment(),
+        )
+        .expiration_block_num(BlockNumber::from(1))
+        .build(),
+    ));
+    let child = Arc::new(AuthenticatedTransaction::from_inner(
+        MockProvenTxBuilder::with_account(
+            child_update.account_id(),
+            child_update.initial_state_commitment(),
+            child_update.final_state_commitment(),
+        )
+        .expiration_block_num(BlockNumber::from(10))
+        .build(),
+    ));
+    let parent_id = parent.id();
+    let child_id = child.id();
+
+    uut.add_transaction(parent).unwrap();
+    uut.add_transaction(child).unwrap();
+
+    let removal = uut.transactions.revert_expired(BlockNumber::from(1));
+
+    assert_eq!(removal.direct().collect::<Vec<_>>(), vec![parent_id]);
+    assert_eq!(removal.dependents().collect::<Vec<_>>(), vec![child_id]);
 }
 
 /// We've decided that transactions from a rolled back batch should be requeued.

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -209,7 +209,7 @@ pub async fn get_tx_inputs(
         current_block_height,
     );
 
-    tracing::debug!(target: LOG_TARGET, ?tx_inputs, "Transaction inputs");
+    tracing::debug!(target: LOG_TARGET, tx_inputs = %tx_inputs, "Transaction inputs");
 
     Ok(tx_inputs)
 }

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -587,7 +587,8 @@ impl Db {
     ///
     /// Consumed note IDs omitted from transaction headers are resolved from
     /// `unresolved_note_nullifiers` on a best-effort basis. The returned mapping is used only for
-    /// lifecycle events and never affects block application.
+    /// lifecycle events and never affects block application. `unresolved_note_nullifiers` is empty
+    /// when neither INFO nor DEBUG lifecycle events are enabled.
     // TODO: This span is logged in a root span, we should connect it to the parent one.
     #[miden_instrument(
         target = COMPONENT,

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -9,7 +9,11 @@ use anyhow::Context;
 use diesel::{Connection, SqliteConnection};
 use miden_crypto::dsa::ecdsa_k256_keccak::Signature;
 use miden_node_proto::domain::account::AccountInfo;
-use miden_node_utils::limiter::MAX_RESPONSE_PAYLOAD_BYTES;
+use miden_node_utils::limiter::{
+    MAX_RESPONSE_PAYLOAD_BYTES,
+    QueryParamLimiter,
+    QueryParamNoteCommitmentLimit,
+};
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::Word;
 use miden_protocol::account::{AccountHeader, AccountId, AccountStorageHeader, StorageMapKey};
@@ -569,6 +573,10 @@ impl Db {
     ///
     /// `allow_acquire` and `acquire_done` are used to synchronize writes to the DB with writes to
     /// the in-memory trees. Further details available on [`super::state::State::apply_block`].
+    ///
+    /// Consumed note IDs omitted from transaction headers are resolved from
+    /// `unresolved_note_nullifiers` on a best-effort basis. The returned mapping is used only for
+    /// lifecycle events and never affects block application.
     // TODO: This span is logged in a root span, we should connect it to the parent one.
     #[miden_instrument(
         target = COMPONENT,
@@ -581,8 +589,9 @@ impl Db {
         acquire_done: oneshot::Receiver<()>,
         signed_block: SignedBlock,
         notes: Vec<(NoteRecord, Option<Nullifier>)>,
-    ) -> Result<()> {
-        self.transact("apply block", move |conn| -> Result<()> {
+        unresolved_note_nullifiers: Vec<Nullifier>,
+    ) -> Result<BTreeMap<Nullifier, NoteId>> {
+        self.transact("apply block", move |conn| {
             models::queries::apply_block(conn, &signed_block, &notes)?;
 
             // XXX FIXME TODO free floating mutex MUST NOT exist it doesn't bind it properly to the
@@ -596,11 +605,29 @@ impl Db {
 
             models::queries::prune_history(conn, signed_block.header().block_num())?;
 
+            let mut resolved_note_ids = BTreeMap::new();
+            for chunk in
+                unresolved_note_nullifiers.chunks(QueryParamNoteCommitmentLimit::LIMIT)
+            {
+                match queries::select_note_ids_by_nullifier(conn, chunk) {
+                    Ok(note_ids) => resolved_note_ids.extend(note_ids),
+                    Err(err) => {
+                        tracing::warn!(
+                            target: COMPONENT,
+                            %err,
+                            nullifiers.count = chunk.len(),
+                            "Failed to resolve consumed note IDs for lifecycle events",
+                        );
+                        break;
+                    },
+                }
+            }
+
             let _span =
                 tracing::info_span!(target: COMPONENT, "acquire_done_lock").entered();
             acquire_done.blocking_recv()?;
 
-            Ok(())
+            Ok(resolved_note_ids)
         })
         .await
     }

--- a/crates/store/src/state/apply_block.rs
+++ b/crates/store/src/state/apply_block.rs
@@ -17,6 +17,7 @@ use tracing::{Instrument, info_span};
 
 use crate::db::NoteRecord;
 use crate::errors::{ApplyBlockError, ApplyBlockWithProvingInputsError, InvalidBlockError};
+use crate::state::block_lifecycle::{BlockLifecycle, lifecycle_events_enabled};
 use crate::state::{BlockNotification, State};
 use crate::{COMPONENT, HistoricalError, LOG_TARGET};
 
@@ -100,6 +101,12 @@ impl State {
 
         self.validate_block_header(header, body).await?;
 
+        let block_lifecycle =
+            lifecycle_events_enabled().then(|| BlockLifecycle::from_block_body(block_num, body));
+        let unresolved_note_nullifiers = block_lifecycle
+            .as_ref()
+            .map_or_else(Vec::new, BlockLifecycle::unresolved_note_nullifiers);
+
         // Save the block to the block store. In a case of a rolled-back DB transaction, the
         // in-memory state will be unchanged, but the file might still be written. Such blocks
         // should be considered candidates, not finalized blocks.
@@ -140,8 +147,17 @@ impl State {
         // lock. This requires the DB update to run concurrently, so a new task is spawned.
         let db = Arc::clone(&self.db);
         let db_update_task = tokio::spawn(
-            async move { db.apply_block(allow_acquire, acquire_done, signed_block, notes).await }
-                .in_current_span(),
+            async move {
+                db.apply_block(
+                    allow_acquire,
+                    acquire_done,
+                    signed_block,
+                    notes,
+                    unresolved_note_nullifiers,
+                )
+                .await
+            }
+            .in_current_span(),
         );
 
         // Wait for the message from the DB update task, that we ready to commit the DB transaction.
@@ -153,7 +169,7 @@ impl State {
         // Awaiting the block saving task to complete without errors.
         block_save_task.await??;
 
-        self.with_inner_write_blocking(|inner| {
+        let resolved_note_ids = self.with_inner_write_blocking(|inner| {
             // We need to check that neither the nullifier tree nor the account tree have changed
             // while we were waiting for the DB preparation task to complete. If either of them did
             // change, we do not proceed with in-memory and database updates, since it may lead to
@@ -173,7 +189,7 @@ impl State {
             // TODO: shutdown #91 Await for successful commit of the DB transaction. If the commit
             // fails, we mustn't change in-memory state, so we return a block applying error and
             // don't proceed with in-memory updates.
-            tokio::runtime::Handle::current()
+            let resolved_note_ids = tokio::runtime::Handle::current()
                 .block_on(db_update_task)?
                 .map_err(|err| ApplyBlockError::DbUpdateTaskFailed(err.as_report()))?;
 
@@ -189,7 +205,7 @@ impl State {
 
             inner.blockchain.push(block_commitment);
 
-            Ok(())
+            Ok(resolved_note_ids)
         })?;
 
         self.with_forest_write_blocking(|forest| {
@@ -202,6 +218,9 @@ impl State {
             .expect("block cache receives sequential block numbers");
         let _ = self.committed_tip_tx.send(block_num);
 
+        if let Some(block_lifecycle) = block_lifecycle {
+            block_lifecycle.emit(&resolved_note_ids);
+        }
         tracing::debug!(target: LOG_TARGET, "Block applied");
 
         Ok(())

--- a/crates/store/src/state/block_lifecycle.rs
+++ b/crates/store/src/state/block_lifecycle.rs
@@ -95,7 +95,7 @@ impl BlockLifecycle {
     )]
     pub(super) fn emit(self, resolved_note_ids: &BTreeMap<Nullifier, NoteId>) {
         for account in self.registered_accounts {
-            tracing::info!(
+            tracing::debug!(
                 target: LOG_TARGET,
                 {
                     account.id = %account.account_id,
@@ -107,7 +107,7 @@ impl BlockLifecycle {
         }
 
         for note in self.created_notes {
-            tracing::info!(
+            tracing::debug!(
                 target: LOG_TARGET,
                 {
                     note.id = %note.note_id,
@@ -123,7 +123,7 @@ impl BlockLifecycle {
         for note in self.consumed_notes {
             let note_id = note.note_id.or_else(|| resolved_note_ids.get(&note.nullifier).copied());
             if let Some(note_id) = note_id {
-                tracing::info!(
+                tracing::debug!(
                     target: LOG_TARGET,
                     {
                         note.id = %note_id,
@@ -134,7 +134,7 @@ impl BlockLifecycle {
                     "Note consumed",
                 );
             } else {
-                tracing::info!(
+                tracing::debug!(
                     target: LOG_TARGET,
                     {
                         note.nullifier = %note.nullifier,
@@ -155,8 +155,7 @@ impl BlockLifecycle {
 
 /// Returns whether any subscriber is interested in user-facing lifecycle events.
 pub(super) fn lifecycle_events_enabled() -> bool {
-    tracing::enabled!(target: LOG_TARGET, tracing::Level::INFO)
-        || tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG)
+    tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG)
 }
 
 struct RegisteredAccount {

--- a/crates/store/src/state/block_lifecycle.rs
+++ b/crates/store/src/state/block_lifecycle.rs
@@ -1,0 +1,494 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use miden_protocol::Word;
+use miden_protocol::account::{
+    AccountId,
+    AccountUpdateDetails,
+    StorageMapKey,
+    StoragePatchOperation,
+    StorageSlotName,
+};
+use miden_protocol::block::{BlockBody, BlockNumber};
+use miden_protocol::note::{NoteId, Nullifier};
+use miden_protocol::transaction::TransactionId;
+
+use crate::LOG_TARGET;
+
+/// Returns whether any subscriber is interested in user-facing lifecycle events.
+pub(super) fn lifecycle_events_enabled() -> bool {
+    tracing::enabled!(target: LOG_TARGET, tracing::Level::INFO)
+        || tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG)
+}
+
+/// User-facing lifecycle information derived from a block before it is committed.
+///
+/// The information is emitted only after the block has been committed to all store state.
+pub(super) struct BlockLifecycle {
+    block_num: BlockNumber,
+    registered_accounts: Vec<RegisteredAccount>,
+    created_notes: Vec<CreatedNote>,
+    consumed_notes: Vec<ConsumedNote>,
+    storage_changes: Vec<StorageChange>,
+}
+
+struct RegisteredAccount {
+    account_id: AccountId,
+    transaction_id: TransactionId,
+}
+
+struct CreatedNote {
+    note_id: NoteId,
+    sender: AccountId,
+    transaction_id: TransactionId,
+    erased: bool,
+}
+
+struct ConsumedNote {
+    note_id: Option<NoteId>,
+    nullifier: Nullifier,
+    transaction_id: TransactionId,
+}
+
+enum StorageChange {
+    Value {
+        account_id: AccountId,
+        slot_name: StorageSlotName,
+        operation: StoragePatchOperation,
+        value: Option<Word>,
+    },
+    MapEntry {
+        account_id: AccountId,
+        slot_name: StorageSlotName,
+        operation: StoragePatchOperation,
+        key: StorageMapKey,
+        value: Word,
+    },
+    MapSlot {
+        account_id: AccountId,
+        slot_name: StorageSlotName,
+        operation: StoragePatchOperation,
+        entries_count: usize,
+    },
+}
+
+impl BlockLifecycle {
+    pub(super) fn from_block_body(block_num: BlockNumber, body: &BlockBody) -> Self {
+        let persisted_note_ids =
+            body.output_notes().map(|(_, note)| note.id()).collect::<BTreeSet<_>>();
+
+        let mut registered_accounts = Vec::new();
+        let mut created_notes = Vec::new();
+        let mut consumed_notes = Vec::new();
+
+        for transaction in body.transactions().as_slice() {
+            let transaction_id = transaction.id();
+
+            if transaction.initial_state_commitment().is_empty() {
+                registered_accounts.push(RegisteredAccount {
+                    account_id: transaction.account_id(),
+                    transaction_id,
+                });
+            }
+
+            created_notes.extend(transaction.output_notes().iter().map(|header| {
+                let note_id = header.id();
+                CreatedNote {
+                    note_id,
+                    sender: header.metadata().sender(),
+                    transaction_id,
+                    erased: !persisted_note_ids.contains(&note_id),
+                }
+            }));
+
+            consumed_notes.extend(transaction.input_notes().iter().map(|commitment| {
+                ConsumedNote {
+                    note_id: commitment.header().map(miden_protocol::note::NoteHeader::id),
+                    nullifier: commitment.nullifier(),
+                    transaction_id,
+                }
+            }));
+        }
+
+        let storage_changes = body.updated_accounts().iter().flat_map(storage_changes).collect();
+
+        Self {
+            block_num,
+            registered_accounts,
+            created_notes,
+            consumed_notes,
+            storage_changes,
+        }
+    }
+
+    /// Returns nullifiers whose note IDs are not present in the transaction header.
+    pub(super) fn unresolved_note_nullifiers(&self) -> Vec<Nullifier> {
+        self.consumed_notes
+            .iter()
+            .filter_map(|note| note.note_id.is_none().then_some(note.nullifier))
+            .collect()
+    }
+
+    pub(super) fn emit(self, resolved_note_ids: &BTreeMap<Nullifier, NoteId>) {
+        for account in self.registered_accounts {
+            tracing::info!(
+                target: LOG_TARGET,
+                {
+                    account.id = %account.account_id,
+                    block.number = %self.block_num,
+                    transaction.id = %account.transaction_id,
+                },
+                "Account registered",
+            );
+        }
+
+        for note in self.created_notes {
+            tracing::info!(
+                target: LOG_TARGET,
+                {
+                    note.id = %note.note_id,
+                    note.sender = %note.sender,
+                    note.erased = note.erased,
+                    block.number = %self.block_num,
+                    transaction.id = %note.transaction_id,
+                },
+                "Note created",
+            );
+        }
+
+        for note in self.consumed_notes {
+            let note_id = note.note_id.or_else(|| resolved_note_ids.get(&note.nullifier).copied());
+            if let Some(note_id) = note_id {
+                tracing::info!(
+                    target: LOG_TARGET,
+                    {
+                        note.id = %note_id,
+                        note.nullifier = %note.nullifier,
+                        block.number = %self.block_num,
+                        transaction.id = %note.transaction_id,
+                    },
+                    "Note consumed",
+                );
+            } else {
+                tracing::info!(
+                    target: LOG_TARGET,
+                    {
+                        note.nullifier = %note.nullifier,
+                        note.id_resolved = false,
+                        block.number = %self.block_num,
+                        transaction.id = %note.transaction_id,
+                    },
+                    "Note consumed",
+                );
+            }
+        }
+
+        for change in self.storage_changes {
+            change.emit(self.block_num);
+        }
+    }
+}
+
+impl StorageChange {
+    fn emit(self, block_num: BlockNumber) {
+        match self {
+            StorageChange::Value {
+                account_id,
+                slot_name,
+                operation,
+                value: Some(value),
+            } => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    {
+                        account.id = %account_id,
+                        account.storage.slot = %slot_name,
+                        account.storage.kind = "value",
+                        account.storage.operation = storage_operation(operation),
+                        account.storage.value = %value,
+                        block.number = %block_num,
+                    },
+                    "Account storage updated",
+                );
+            },
+            StorageChange::Value {
+                account_id,
+                slot_name,
+                operation,
+                value: None,
+            } => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    {
+                        account.id = %account_id,
+                        account.storage.slot = %slot_name,
+                        account.storage.kind = "value",
+                        account.storage.operation = storage_operation(operation),
+                        block.number = %block_num,
+                    },
+                    "Account storage updated",
+                );
+            },
+            StorageChange::MapEntry {
+                account_id,
+                slot_name,
+                operation,
+                key,
+                value,
+            } => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    {
+                        account.id = %account_id,
+                        account.storage.slot = %slot_name,
+                        account.storage.kind = "map",
+                        account.storage.operation = storage_operation(operation),
+                        account.storage.map.key = %key,
+                        account.storage.map.entry.operation =
+                            if value.is_empty() { "remove" } else { "set" },
+                        account.storage.value = %value,
+                        block.number = %block_num,
+                    },
+                    "Account storage updated",
+                );
+            },
+            StorageChange::MapSlot {
+                account_id,
+                slot_name,
+                operation,
+                entries_count,
+            } => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    {
+                        account.id = %account_id,
+                        account.storage.slot = %slot_name,
+                        account.storage.kind = "map",
+                        account.storage.operation = storage_operation(operation),
+                        account.storage.map.entries.count = entries_count,
+                        block.number = %block_num,
+                    },
+                    "Account storage updated",
+                );
+            },
+        }
+    }
+}
+
+fn storage_changes(update: &miden_protocol::block::BlockAccountUpdate) -> Vec<StorageChange> {
+    let AccountUpdateDetails::Public(patch) = update.details() else {
+        return Vec::new();
+    };
+
+    let account_id = update.account_id();
+    let mut changes = Vec::with_capacity(patch.storage().num_slots());
+
+    changes.extend(patch.storage().values().map(|(slot_name, value_patch)| StorageChange::Value {
+        account_id,
+        slot_name: slot_name.clone(),
+        operation: value_patch.patch_op(),
+        value: value_patch.value(),
+    }));
+
+    for (slot_name, map_patch) in patch.storage().maps() {
+        let operation = map_patch.patch_op();
+        match map_patch.entries() {
+            Some(entries) if !entries.is_empty() => {
+                changes.extend(entries.as_map().iter().map(|(key, value)| {
+                    StorageChange::MapEntry {
+                        account_id,
+                        slot_name: slot_name.clone(),
+                        operation,
+                        key: *key,
+                        value: *value,
+                    }
+                }));
+            },
+            Some(entries) => {
+                changes.push(StorageChange::MapSlot {
+                    account_id,
+                    slot_name: slot_name.clone(),
+                    operation,
+                    entries_count: entries.num_entries(),
+                });
+            },
+            None => {
+                changes.push(StorageChange::MapSlot {
+                    account_id,
+                    slot_name: slot_name.clone(),
+                    operation,
+                    entries_count: 0,
+                });
+            },
+        }
+    }
+
+    changes
+}
+
+const fn storage_operation(operation: StoragePatchOperation) -> &'static str {
+    match operation {
+        StoragePatchOperation::Create => "create",
+        StoragePatchOperation::Update => "update",
+        StoragePatchOperation::Remove => "remove",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use miden_protocol::Felt;
+    use miden_protocol::account::{
+        AccountPatch,
+        AccountStoragePatch,
+        AccountVaultPatch,
+        StorageMapPatch,
+        StorageMapPatchEntries,
+        StorageSlotPatch,
+        StorageValuePatch,
+    };
+    use miden_protocol::block::{BlockAccountUpdate, BlockBody};
+    use miden_protocol::note::{
+        NoteAttachments,
+        NoteDetailsCommitment,
+        NoteHeader,
+        NoteMetadata,
+        NoteTag,
+        NoteType,
+        PartialNoteMetadata,
+    };
+    use miden_protocol::testing::account_id::{
+        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
+        ACCOUNT_ID_SENDER,
+    };
+    use miden_protocol::transaction::{
+        InputNoteCommitment,
+        InputNotes,
+        OrderedTransactionHeaders,
+        OutputNote,
+        PrivateOutputNote,
+        TransactionHeader,
+    };
+
+    use super::*;
+
+    #[test]
+    fn extracts_account_and_note_lifecycle_from_transaction_headers() {
+        let account_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+        let persisted_header = note_header(account_id, 1);
+        let erased_header = note_header(account_id, 2);
+        let unresolved_nullifier = Nullifier::from_raw(word(3));
+        let resolved_nullifier = Nullifier::from_raw(word(4));
+        let input_notes = InputNotes::new_unchecked(vec![
+            InputNoteCommitment::from(unresolved_nullifier),
+            InputNoteCommitment::from_parts_unchecked(resolved_nullifier, Some(erased_header)),
+        ]);
+        let transaction = TransactionHeader::new(
+            account_id,
+            Word::empty(),
+            word(5),
+            input_notes,
+            vec![persisted_header, erased_header],
+        );
+        let transaction_id = transaction.id();
+        let output_note = OutputNote::Private(
+            PrivateOutputNote::new(persisted_header, NoteAttachments::default()).unwrap(),
+        );
+        let body = BlockBody::new_unchecked(
+            Vec::new(),
+            vec![vec![(0, output_note)]],
+            Vec::new(),
+            OrderedTransactionHeaders::new_unchecked(vec![transaction]),
+        );
+
+        let lifecycle = BlockLifecycle::from_block_body(BlockNumber::from(7), &body);
+
+        assert_eq!(lifecycle.registered_accounts.len(), 1);
+        assert_eq!(lifecycle.registered_accounts[0].account_id, account_id);
+        assert_eq!(lifecycle.registered_accounts[0].transaction_id, transaction_id);
+        assert_eq!(lifecycle.created_notes.len(), 2);
+        assert!(!lifecycle.created_notes[0].erased);
+        assert!(lifecycle.created_notes[1].erased);
+        assert_eq!(lifecycle.consumed_notes.len(), 2);
+        assert_eq!(lifecycle.consumed_notes[0].note_id, None);
+        assert_eq!(lifecycle.consumed_notes[1].note_id, Some(erased_header.id()));
+        assert_eq!(lifecycle.unresolved_note_nullifiers(), vec![unresolved_nullifier],);
+    }
+
+    #[test]
+    fn extracts_public_storage_changes() {
+        let account_id =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+        let value_slot = StorageSlotName::mock(1);
+        let map_slot = StorageSlotName::mock(2);
+        let map_key = StorageMapKey::from_index(3);
+        let value = word(9);
+        let map_entries = StorageMapPatchEntries::from_raw(BTreeMap::from([(map_key, value)]));
+        let storage = AccountStoragePatch::from_raw(BTreeMap::from([
+            (value_slot.clone(), StorageSlotPatch::Value(StorageValuePatch::Update { value })),
+            (
+                map_slot.clone(),
+                StorageSlotPatch::Map(StorageMapPatch::Update { entries: map_entries }),
+            ),
+        ]))
+        .unwrap();
+        let patch = AccountPatch::new(
+            account_id,
+            storage,
+            AccountVaultPatch::default(),
+            None,
+            Some(Felt::new_unchecked(2)),
+        )
+        .unwrap();
+        let update =
+            BlockAccountUpdate::new(account_id, word(10), AccountUpdateDetails::Public(patch));
+        let body = BlockBody::new_unchecked(
+            vec![update],
+            Vec::new(),
+            Vec::new(),
+            OrderedTransactionHeaders::new_unchecked(Vec::new()),
+        );
+
+        let lifecycle = BlockLifecycle::from_block_body(BlockNumber::from(7), &body);
+
+        assert_eq!(lifecycle.storage_changes.len(), 2);
+        assert!(matches!(
+            &lifecycle.storage_changes[0],
+            StorageChange::Value {
+                account_id: actual_account_id,
+                slot_name,
+                operation: StoragePatchOperation::Update,
+                value: Some(actual_value),
+            } if *actual_account_id == account_id
+                && *slot_name == value_slot
+                && *actual_value == value
+        ));
+        assert!(matches!(
+            &lifecycle.storage_changes[1],
+            StorageChange::MapEntry {
+                account_id: actual_account_id,
+                slot_name,
+                operation: StoragePatchOperation::Update,
+                key,
+                value: actual_value,
+            } if *actual_account_id == account_id
+                && *slot_name == map_slot
+                && *key == map_key
+                && *actual_value == value
+        ));
+    }
+
+    fn note_header(sender: AccountId, value: u32) -> NoteHeader {
+        NoteHeader::new(
+            NoteDetailsCommitment::from_raw(word(value)),
+            NoteMetadata::new(
+                PartialNoteMetadata::new(sender, NoteType::Private).with_tag(NoteTag::new(value)),
+                &NoteAttachments::default(),
+            ),
+        )
+    }
+
+    fn word(value: u32) -> Word {
+        Word::from([value, 0, 0, 0u32])
+    }
+}

--- a/crates/store/src/state/block_lifecycle.rs
+++ b/crates/store/src/state/block_lifecycle.rs
@@ -14,12 +14,6 @@ use miden_protocol::transaction::TransactionId;
 
 use crate::LOG_TARGET;
 
-/// Returns whether any subscriber is interested in user-facing lifecycle events.
-pub(super) fn lifecycle_events_enabled() -> bool {
-    tracing::enabled!(target: LOG_TARGET, tracing::Level::INFO)
-        || tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG)
-}
-
 /// User-facing lifecycle information derived from a block before it is committed.
 ///
 /// The information is emitted only after the block has been committed to all store state.
@@ -29,46 +23,6 @@ pub(super) struct BlockLifecycle {
     created_notes: Vec<CreatedNote>,
     consumed_notes: Vec<ConsumedNote>,
     storage_changes: Vec<StorageChange>,
-}
-
-struct RegisteredAccount {
-    account_id: AccountId,
-    transaction_id: TransactionId,
-}
-
-struct CreatedNote {
-    note_id: NoteId,
-    sender: AccountId,
-    transaction_id: TransactionId,
-    erased: bool,
-}
-
-struct ConsumedNote {
-    note_id: Option<NoteId>,
-    nullifier: Nullifier,
-    transaction_id: TransactionId,
-}
-
-enum StorageChange {
-    Value {
-        account_id: AccountId,
-        slot_name: StorageSlotName,
-        operation: StoragePatchOperation,
-        value: Option<Word>,
-    },
-    MapEntry {
-        account_id: AccountId,
-        slot_name: StorageSlotName,
-        operation: StoragePatchOperation,
-        key: StorageMapKey,
-        value: Word,
-    },
-    MapSlot {
-        account_id: AccountId,
-        slot_name: StorageSlotName,
-        operation: StoragePatchOperation,
-        entries_count: usize,
-    },
 }
 
 impl BlockLifecycle {
@@ -186,6 +140,52 @@ impl BlockLifecycle {
             change.emit(self.block_num);
         }
     }
+}
+
+/// Returns whether any subscriber is interested in user-facing lifecycle events.
+pub(super) fn lifecycle_events_enabled() -> bool {
+    tracing::enabled!(target: LOG_TARGET, tracing::Level::INFO)
+        || tracing::enabled!(target: LOG_TARGET, tracing::Level::DEBUG)
+}
+
+struct RegisteredAccount {
+    account_id: AccountId,
+    transaction_id: TransactionId,
+}
+
+struct CreatedNote {
+    note_id: NoteId,
+    sender: AccountId,
+    transaction_id: TransactionId,
+    erased: bool,
+}
+
+struct ConsumedNote {
+    note_id: Option<NoteId>,
+    nullifier: Nullifier,
+    transaction_id: TransactionId,
+}
+
+enum StorageChange {
+    Value {
+        account_id: AccountId,
+        slot_name: StorageSlotName,
+        operation: StoragePatchOperation,
+        value: Option<Word>,
+    },
+    MapEntry {
+        account_id: AccountId,
+        slot_name: StorageSlotName,
+        operation: StoragePatchOperation,
+        key: StorageMapKey,
+        value: Word,
+    },
+    MapSlot {
+        account_id: AccountId,
+        slot_name: StorageSlotName,
+        operation: StoragePatchOperation,
+        entries_count: usize,
+    },
 }
 
 impl StorageChange {

--- a/crates/store/src/state/block_lifecycle.rs
+++ b/crates/store/src/state/block_lifecycle.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::Word;
 use miden_protocol::account::{
     AccountId,
@@ -12,7 +13,7 @@ use miden_protocol::block::{BlockBody, BlockNumber};
 use miden_protocol::note::{NoteId, Nullifier};
 use miden_protocol::transaction::TransactionId;
 
-use crate::LOG_TARGET;
+use crate::{COMPONENT, LOG_TARGET};
 
 /// User-facing lifecycle information derived from a block before it is committed.
 ///
@@ -26,6 +27,11 @@ pub(super) struct BlockLifecycle {
 }
 
 impl BlockLifecycle {
+    #[miden_instrument(
+        target = COMPONENT,
+        name = "block_lifecycle.from_block_body",
+        skip_all,
+    )]
     pub(super) fn from_block_body(block_num: BlockNumber, body: &BlockBody) -> Self {
         let persisted_note_ids =
             body.output_notes().map(|(_, note)| note.id()).collect::<BTreeSet<_>>();
@@ -82,6 +88,11 @@ impl BlockLifecycle {
             .collect()
     }
 
+    #[miden_instrument(
+        target = COMPONENT,
+        name = "block_lifecycle.emit",
+        skip_all,
+    )]
     pub(super) fn emit(self, resolved_note_ids: &BTreeMap<Nullifier, NoteId>) {
         for account in self.registered_accounts {
             tracing::info!(

--- a/crates/store/src/state/mod.rs
+++ b/crates/store/src/state/mod.rs
@@ -64,6 +64,7 @@ mod account;
 
 mod apply_block;
 mod apply_proof;
+mod block_lifecycle;
 mod bootstrap;
 mod disk_monitor;
 mod sync_state;

--- a/crates/utils/src/formatting.rs
+++ b/crates/utils/src/formatting.rs
@@ -9,8 +9,12 @@ pub fn format_opt<T: Display>(opt: Option<&T>) -> String {
 
 pub fn format_input_notes(notes: &InputNotes<InputNoteCommitment>) -> String {
     format_array(notes.iter().map(|c| match c.header() {
-        Some(header) => format!("({}, {})", c.nullifier().to_hex(), header.id().to_hex()),
-        None => format!("({})", c.nullifier().to_hex()),
+        Some(header) => format!(
+            "{{ nullifier: {}, note_id: {} }}",
+            c.nullifier().to_hex(),
+            header.id().to_hex()
+        ),
+        None => format!("{{ nullifier: {} }}", c.nullifier().to_hex()),
     }))
 }
 
@@ -32,5 +36,52 @@ pub fn format_array(list: impl IntoIterator<Item = impl Display>) -> String {
         "None".to_owned()
     } else {
         format!("[{comma_separated}]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::Word;
+    use miden_protocol::account::AccountId;
+    use miden_protocol::note::{
+        NoteAttachments,
+        NoteDetailsCommitment,
+        NoteHeader,
+        NoteMetadata,
+        NoteTag,
+        NoteType,
+        Nullifier,
+        PartialNoteMetadata,
+    };
+    use miden_protocol::transaction::{InputNoteCommitment, InputNotes};
+
+    use super::format_input_notes;
+
+    #[test]
+    fn input_notes_are_labeled() {
+        let unresolved_nullifier = Nullifier::from_raw(Word::from([1, 2, 3, 4u32]));
+        let resolved_nullifier = Nullifier::from_raw(Word::from([5, 6, 7, 8u32]));
+        let sender = AccountId::try_from(0xfa00_0000_0000_bb01_0000_cc00_0000_de00_u128).unwrap();
+        let header = NoteHeader::new(
+            NoteDetailsCommitment::from_raw(Word::from([9, 10, 11, 12u32])),
+            NoteMetadata::new(
+                PartialNoteMetadata::new(sender, NoteType::Private).with_tag(NoteTag::new(1)),
+                &NoteAttachments::default(),
+            ),
+        );
+        let notes = InputNotes::new_unchecked(vec![
+            InputNoteCommitment::from(unresolved_nullifier),
+            InputNoteCommitment::from_parts_unchecked(resolved_nullifier, Some(header)),
+        ]);
+
+        assert_eq!(
+            format_input_notes(&notes),
+            format!(
+                "[{{ nullifier: {} }}, {{ nullifier: {}, note_id: {} }}]",
+                unresolved_nullifier.to_hex(),
+                resolved_nullifier.to_hex(),
+                header.id().to_hex(),
+            ),
+        );
     }
 }

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -107,8 +107,14 @@ impl TracingConfig {
     pub fn from_env(open_telemetry: OpenTelemetry) -> Self {
         Self {
             open_telemetry,
-            stdout_filter: filter_env_or_default("MIDEN_STDOUT_FILTER", "info,user=debug"),
-            otel_filter: filter_env_or_default("MIDEN_OTEL_FILTER", "info,axum::rejection=trace"),
+            stdout_filter: filter_env_or_default(
+                "MIDEN_STDOUT_FILTER",
+                "info,user=debug,miden_prover=warn",
+            ),
+            otel_filter: filter_env_or_default(
+                "MIDEN_OTEL_FILTER",
+                "info,axum::rejection=trace,miden_prover=warn",
+            ),
         }
     }
 }
@@ -149,9 +155,9 @@ impl Drop for OtelGuard {
 
 /// Initializes tracing to stdout and optionally an open-telemetry exporter.
 ///
-/// Stdout trace filtering is configured with `MIDEN_STDOUT_FILTER`, then `RUST_LOG`, then `info,user=debug`.
+/// Stdout trace filtering is configured with `MIDEN_STDOUT_FILTER`, then `RUST_LOG`, then `info,user=debug,miden_prover=warn`.
 /// OpenTelemetry export filtering is configured with `MIDEN_OTEL_FILTER`, then `RUST_LOG`, then
-/// `info,axum::rejection=trace`.
+/// `info,axum::rejection=trace,miden_prover=warn`.
 ///
 /// The open-telemetry configuration is controlled via environment variables as defined in the
 /// [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#opentelemetry-protocol-exporter)


### PR DESCRIPTION
## Summary

  - Emit lifecycle events after successful block commits for account registration, note creation and consumption, and public account storage changes.
  - Resolve consumed note IDs from nullifiers on a best-effort basis and identify output notes erased within the same block.
  - Log mempool transaction additions, expirations, and evictions, distinguishing direct removals from dependent transaction removals.
  - Improve input-note formatting with explicit nullifier and note_id labels.

Resolves part 2 of issue #2330 

## Changelog

```toml
[[entry]]
scope       = "general"
impact      = "fixed"
description = "Account, note, storage and mempool lifecycle events are now logged on stdout."
```
