### PR TITLE
fix(logging): add startup and shutdown lifecycle events

### DIFF
--- a/bin/node/src/commands/lifecycle.rs
+++ b/bin/node/src/commands/lifecycle.rs
@@ -40,10 +40,38 @@ pub struct BootstrapCommand {
 
 impl BootstrapCommand {
     pub async fn handle(self) -> anyhow::Result<()> {
+        tracing::info!(
+            target: crate::LOG_TARGET,
+            {
+                service.name = "miden-node",
+                service.version = env!("CARGO_PKG_VERSION"),
+                genesis.source.kind =
+                    if self.genesis_block_file.is_some() { "file" } else { "network" },
+                genesis.source = %self.genesis_block_file.as_ref().map_or_else(
+                    || self.network.map_or_else(
+                        || "custom".to_owned(),
+                        |network| network.to_string(),
+                    ),
+                    |path| path.display().to_string(),
+                ),
+                data.directory = %self.data_directory.display(),
+            },
+            "Bootstrapping node",
+        );
         ensure_empty_directory(&self.data_directory)?;
         let signed_block =
             read_bootstrap_genesis_block(self.genesis_block_file.as_deref(), self.network).await?;
-        bootstrap_store(&self.data_directory, signed_block)
+        let genesis_commitment = signed_block.header().commitment();
+        bootstrap_store(&self.data_directory, signed_block)?;
+        tracing::info!(
+            target: crate::LOG_TARGET,
+            {
+                genesis.commitment = %genesis_commitment,
+                data.directory = %self.data_directory.display(),
+            },
+            "Node bootstrap complete",
+        );
+        Ok(())
     }
 }
 

--- a/bin/node/src/commands/modes.rs
+++ b/bin/node/src/commands/modes.rs
@@ -14,6 +14,7 @@ use miden_node_proto::clients::{
 use miden_node_rpc::{Rpc, RpcMode, SequencerInternal};
 use miden_node_store::State;
 use miden_node_utils::clap::{GrpcOptionsInternal, duration_to_human_readable_string};
+use miden_node_utils::formatting::format_endpoint;
 use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use tokio::net::TcpListener;
@@ -52,6 +53,7 @@ pub struct SequencerCommand {
 
 impl SequencerCommand {
     pub async fn handle(self, shutdown: CancellationToken) -> anyhow::Result<()> {
+        self.log_starting();
         let runtime = self.runtime.runtime_config(&self.store);
         self.block_producer.validate()?;
         let network_tx_auth = self.runtime.rpc.network_tx_auth()?;
@@ -101,6 +103,29 @@ impl SequencerCommand {
         }
 
         tasks.join_next_or_cancelled(shutdown).await
+    }
+
+    fn log_starting(&self) {
+        tracing::info!(
+            target: crate::LOG_TARGET,
+            {
+                service.name = "miden-node",
+                service.version = env!("CARGO_PKG_VERSION"),
+                node.role = "sequencer",
+                rpc.listen = %self.runtime.rpc.listen,
+                internal.listen = %self.internal.map_or_else(
+                    || "disabled".to_owned(),
+                    |address| address.to_string(),
+                ),
+                data.directory = %self.runtime.data_directory.display(),
+                validator.endpoint = %format_endpoint(&self.external_services.validator_url),
+                ntx_builder.endpoint = %format_endpoint(&self.external_services.ntx_builder_url),
+                block.interval = %humantime::Duration::from(self.block_producer.block.interval),
+                batch.interval = %humantime::Duration::from(self.block_producer.batch.interval),
+                store.sqlite.connection_pool_size = self.store.sqlite.connection_pool_size.get(),
+            },
+            "Starting node",
+        );
     }
 }
 
@@ -182,6 +207,7 @@ pub struct FullNodeCommand {
 
 impl FullNodeCommand {
     pub async fn handle(self, shutdown: CancellationToken) -> anyhow::Result<()> {
+        self.log_starting();
         let runtime = self.runtime.runtime_config(&self.store);
         let source_rpc = self.sync.source_rpc_client()?;
         let validator_client = self.validator_client();
@@ -207,6 +233,31 @@ impl FullNodeCommand {
         tasks.spawn("RPC server", rpc.serve(shutdown.clone()));
 
         tasks.join_next_or_cancelled(shutdown).await
+    }
+
+    fn log_starting(&self) {
+        tracing::info!(
+            target: crate::LOG_TARGET,
+            {
+                service.name = "miden-node",
+                service.version = env!("CARGO_PKG_VERSION"),
+                node.role = "full",
+                rpc.listen = %self.runtime.rpc.listen,
+                data.directory = %self.runtime.data_directory.display(),
+                sync.block_source.endpoint = %format_endpoint(&self.sync.block_source_url),
+                sync.ready_threshold = self.sync.readiness_threshold,
+                validator.endpoint = %self.validator_url.as_ref().map_or_else(
+                    || "disabled".to_owned(),
+                    format_endpoint,
+                ),
+                sequencer.endpoint = %self.sequencer_url.as_ref().map_or_else(
+                    || "disabled".to_owned(),
+                    format_endpoint,
+                ),
+                store.sqlite.connection_pool_size = self.store.sqlite.connection_pool_size.get(),
+            },
+            "Starting node",
+        );
     }
 
     fn sequencer_client(&self) -> Option<SequencerClient> {

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -43,5 +43,8 @@ async fn main() -> anyhow::Result<()> {
     // Configure tracing with optional OpenTelemetry exporting support.
     let _otel_guard = miden_node_utils::logging::setup_tracing(cli.command.open_telemetry())?;
 
-    miden_node_utils::shutdown::run_with_shutdown(|shutdown| cli.command.execute(shutdown)).await
+    miden_node_utils::shutdown::run_with_shutdown("miden-node", |shutdown| {
+        cli.command.execute(shutdown)
+    })
+    .await
 }

--- a/bin/ntx-builder/src/commands/mod.rs
+++ b/bin/ntx-builder/src/commands/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::Context;
 use clap::{ArgGroup, Parser};
 use miden_node_utils::clap::duration_to_human_readable_string;
+use miden_node_utils::formatting::format_endpoint;
 use miden_node_utils::fs::ensure_empty_directory;
 use miden_node_utils::genesis::{
     OfficialNetwork,
@@ -171,13 +172,41 @@ impl NtxBuilderCommand {
                 genesis_block_file,
                 network,
             } => {
+                tracing::info!(
+                    target: miden_ntx_builder::LOG_TARGET,
+                    {
+                        service.name = "miden-ntx-builder",
+                        service.version = env!("CARGO_PKG_VERSION"),
+                        genesis.source.kind =
+                            if genesis_block_file.is_some() { "file" } else { "network" },
+                        genesis.source = %genesis_block_file.as_ref().map_or_else(
+                            || network.map_or_else(
+                                || "custom".to_owned(),
+                                |network| network.to_string(),
+                            ),
+                            |path| path.display().to_string(),
+                        ),
+                        data.directory = %data_directory.display(),
+                    },
+                    "Bootstrapping NTX builder",
+                );
                 ensure_empty_directory(&data_directory)?;
                 let database_filepath = data_directory.join("ntx-builder.sqlite3");
                 let genesis =
                     read_bootstrap_genesis_block(genesis_block_file.as_deref(), network).await?;
+                let genesis_commitment = genesis.header().commitment();
                 miden_ntx_builder::bootstrap(database_filepath, &genesis)
                     .await
-                    .context("failed to bootstrap ntx-builder database")
+                    .context("failed to bootstrap ntx-builder database")?;
+                tracing::info!(
+                    target: miden_ntx_builder::LOG_TARGET,
+                    {
+                        genesis.commitment = %genesis_commitment,
+                        data.directory = %data_directory.display(),
+                    },
+                    "NTX builder bootstrap complete",
+                );
+                Ok(())
             },
             Self::Migrate { data_directory } => {
                 miden_ntx_builder::migrate(data_directory.join("ntx-builder.sqlite3"))
@@ -203,6 +232,24 @@ impl NtxBuilderCommand {
         else {
             unreachable!("start is only called for the Start variant")
         };
+
+        tracing::info!(
+            target: miden_ntx_builder::LOG_TARGET,
+            {
+                service.name = "miden-ntx-builder",
+                service.version = env!("CARGO_PKG_VERSION"),
+                ntx_builder.listen = %listen,
+                data.directory = %data_directory.display(),
+                rpc.endpoint = %format_endpoint(&rpc_url),
+                tx_prover.endpoint = %format_endpoint(&tx_prover_url),
+                rpc.authentication.configured = rpc_auth_header_value.is_some(),
+                ntx_builder.idle_timeout = %humantime::Duration::from(idle_timeout),
+                ntx_builder.max_cycles = max_tx_cycles,
+                ntx_builder.tx_expiration_delta = tx_expiration_delta.get(),
+                sqlite.connection_pool_size = sqlite_connection_pool_size.get(),
+            },
+            "Starting NTX builder",
+        );
 
         let listener = TcpListener::bind(listen)
             .await

--- a/bin/ntx-builder/src/lib.rs
+++ b/bin/ntx-builder/src/lib.rs
@@ -93,7 +93,7 @@ mod bootstrap_tests {
 const COMPONENT: &str = "miden-ntx-builder";
 
 // Tracing target used for user-visible events.
-const LOG_TARGET: &str = "user::miden-ntx-builder";
+pub const LOG_TARGET: &str = "user::miden-ntx-builder";
 
 /// Default maximum number of network notes a network transaction is allowed to consume.
 const DEFAULT_MAX_NOTES_PER_TX: NonZeroUsize = NonZeroUsize::new(20).expect("literal is non-zero");

--- a/bin/ntx-builder/src/main.rs
+++ b/bin/ntx-builder/src/main.rs
@@ -7,5 +7,8 @@ async fn main() -> anyhow::Result<()> {
 
     let _otel_guard = miden_node_utils::logging::setup_tracing(command.open_telemetry())?;
 
-    miden_node_utils::shutdown::run_with_shutdown(|shutdown| command.handle(shutdown)).await
+    miden_node_utils::shutdown::run_with_shutdown("miden-ntx-builder", |shutdown| {
+        command.handle(shutdown)
+    })
+    .await
 }

--- a/bin/ntx-builder/src/server.rs
+++ b/bin/ntx-builder/src/server.rs
@@ -9,7 +9,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tonic_reflection::server;
 use tower_http::trace::TraceLayer;
 
-use crate::COMPONENT;
+use crate::LOG_TARGET;
 use crate::db::Db;
 
 mod get_network_note_status;
@@ -43,10 +43,16 @@ impl NtxBuilderRpcServer {
             .build_v1()
             .context("failed to build reflection service")?;
 
+        let endpoint =
+            listener.local_addr().context("failed to read NTX builder listen address")?;
         tracing::info!(
-            target: COMPONENT,
-            endpoint = ?listener.local_addr(),
-            "NTX builder gRPC server initialized",
+            target: LOG_TARGET,
+            {
+                service.name = "miden-ntx-builder",
+                service.version = env!("CARGO_PKG_VERSION"),
+                ntx_builder.listen = %endpoint,
+            },
+            "NTX builder ready",
         );
 
         tonic::transport::Server::builder()

--- a/bin/remote-prover/src/main.rs
+++ b/bin/remote-prover/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use clap::Parser;
-use tracing::info;
 
 mod server;
 
@@ -12,9 +11,8 @@ async fn main() -> anyhow::Result<()> {
     let server = server::Server::parse();
 
     let _otel_guard = miden_node_utils::logging::setup_tracing(server.open_telemetry())?;
-    info!(target: LOG_TARGET, "Tracing initialized");
 
-    miden_node_utils::shutdown::run_with_shutdown(|shutdown| async move {
+    miden_node_utils::shutdown::run_with_shutdown("miden-remote-prover", |shutdown| async move {
         let (handle, _port) = server.spawn(shutdown).await.context("failed to spawn server")?;
 
         handle.await.context("proof server panicked").flatten()

--- a/bin/remote-prover/src/server/mod.rs
+++ b/bin/remote-prover/src/server/mod.rs
@@ -72,11 +72,15 @@ impl Server {
 
         tracing::info!(
             target: LOG_TARGET,
-            server_timeout=%humantime::Duration::from(self.timeout),
-            server_capacity=self.capacity,
-            proof_kind = %self.kind,
-            server_port = port,
-            "Proof server listening"
+            {
+                service.name = "miden-remote-prover",
+                service.version = env!("CARGO_PKG_VERSION"),
+                prover.timeout = %humantime::Duration::from(self.timeout),
+                prover.capacity = self.capacity.get(),
+                prover.kind = %self.kind,
+                prover.port = port,
+            },
+            "Remote prover ready",
         );
 
         let status_service =

--- a/bin/validator/src/commands/bootstrap.rs
+++ b/bin/validator/src/commands/bootstrap.rs
@@ -10,6 +10,11 @@ use miden_validator::{DataDirectory, ValidatorSigner};
 
 use super::ValidatorSigningKey;
 
+struct BootstrapSummary {
+    genesis_commitment: miden_protocol::Word,
+    account_count: usize,
+}
+
 // Bootstraps the validator component.
 pub async fn bootstrap(
     genesis_block_directory: &Path,
@@ -19,6 +24,23 @@ pub async fn bootstrap(
     genesis_config: Option<&PathBuf>,
     signing_key: ValidatorSigningKey,
 ) -> anyhow::Result<()> {
+    tracing::info!(
+        target: miden_validator::LOG_TARGET,
+        {
+            service.name = "miden-validator",
+            service.version = env!("CARGO_PKG_VERSION"),
+            genesis.config.source = if genesis_config.is_some() { "file" } else { "default" },
+            genesis.config.path = %genesis_config.map_or_else(
+                || "default".to_owned(),
+                |path| path.display().to_string(),
+            ),
+            genesis.directory = %genesis_block_directory.display(),
+            accounts.directory = %accounts_directory.display(),
+            data.directory = %data_directory.display(),
+        },
+        "Bootstrapping validator",
+    );
+
     let config = genesis_config
         .map(|file_path| {
             GenesisConfig::read_toml_file(file_path).with_context(|| {
@@ -39,7 +61,22 @@ pub async fn bootstrap(
         data_directory.to_path_buf(),
     )
     .context("failed to load bootstrap directories")?;
-    build_and_write_genesis(config, signer, dirs, sqlite_connection_pool_size).await
+    let summary =
+        build_and_write_genesis(config, signer, dirs, sqlite_connection_pool_size).await?;
+
+    tracing::info!(
+        target: miden_validator::LOG_TARGET,
+        {
+            genesis.commitment = %summary.genesis_commitment,
+            genesis.accounts.count = summary.account_count,
+            genesis.file = %genesis_block_directory.join("genesis.dat").display(),
+            accounts.directory = %accounts_directory.display(),
+            data.directory = %data_directory.display(),
+        },
+        "Validator bootstrap complete",
+    );
+
+    Ok(())
 }
 
 /// Builds the genesis state, writes account secret files, signs the genesis block, writes it to
@@ -49,7 +86,7 @@ async fn build_and_write_genesis(
     signer: ValidatorSigner,
     dirs: DataDirectory,
     sqlite_connection_pool_size: NonZeroUsize,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<BootstrapSummary> {
     let (genesis_state, secrets) = config.into_state(signer.public_key())?;
 
     for item in secrets.as_account_files(&genesis_state) {
@@ -74,6 +111,8 @@ async fn build_and_write_genesis(
     let genesis_block = unsigned_genesis_block
         .into_block(signature)
         .context("failed to build the genesis block")?;
+    let genesis_commitment = genesis_block.inner().header().commitment();
+    let account_count = genesis_block.inner().body().updated_accounts().len();
 
     let block_bytes = genesis_block.inner().to_bytes();
     fs_err::write(dirs.genesis_block_path().expect("bootstrap directories"), block_bytes)
@@ -94,5 +133,44 @@ async fn build_and_write_genesis(
     .await
     .context("failed to persist genesis block header as chain tip")?;
 
-    Ok(())
+    Ok(BootstrapSummary { genesis_commitment, account_count })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::INSECURE_SIGNING_KEY_HEX;
+
+    #[tokio::test]
+    async fn bootstrap_writes_all_outputs_before_returning_success() {
+        let root = tempfile::tempdir().unwrap();
+        let genesis_directory = root.path().join("genesis");
+        let accounts_directory = root.path().join("accounts");
+        let data_directory = root.path().join("data");
+        let validator_key = ValidatorSigningKey {
+            signing_key: INSECURE_SIGNING_KEY_HEX.to_owned(),
+            signing_key_kms_id: None,
+        };
+
+        bootstrap(
+            &genesis_directory,
+            &accounts_directory,
+            &data_directory,
+            NonZeroUsize::new(2).unwrap(),
+            None,
+            validator_key,
+        )
+        .await
+        .expect("bootstrap should complete");
+
+        assert!(genesis_directory.join("genesis.dat").is_file());
+        assert!(data_directory.join("validator.sqlite3").is_file());
+        assert!(
+            fs_err::read_dir(accounts_directory)
+                .expect("accounts directory should be readable")
+                .next()
+                .is_some(),
+            "bootstrap should write generated account files",
+        );
+    }
 }

--- a/bin/validator/src/commands/mod.rs
+++ b/bin/validator/src/commands/mod.rs
@@ -207,6 +207,18 @@ impl ValidatorCommand {
                 ..
             } => {
                 let address = listen;
+                tracing::info!(
+                    target: miden_validator::LOG_TARGET,
+                    {
+                        service.name = "miden-validator",
+                        service.version = env!("CARGO_PKG_VERSION"),
+                        validator.listen = %address,
+                        data.directory = %data_directory.display(),
+                        validator.signer = if signing_key_kms_id.is_some() { "kms" } else { "local" },
+                        sqlite.connection_pool_size = sqlite_connection_pool_size.get(),
+                    },
+                    "Starting validator",
+                );
 
                 let encryption_key_bytes = if let Some(ciphertext) = encryption_key_kms_ciphertext {
                     let ciphertext =

--- a/bin/validator/src/main.rs
+++ b/bin/validator/src/main.rs
@@ -10,5 +10,8 @@ async fn main() -> anyhow::Result<()> {
 
     let _otel_guard = miden_node_utils::logging::setup_tracing(command.open_telemetry())?;
 
-    miden_node_utils::shutdown::run_with_shutdown(|shutdown| command.handle(shutdown)).await
+    miden_node_utils::shutdown::run_with_shutdown("miden-validator", |shutdown| {
+        command.handle(shutdown)
+    })
+    .await
 }

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -60,8 +60,6 @@ impl ValidatorServer {
     /// Executes in place (i.e. not spawned) and will run indefinitely until a fatal error is
     /// encountered.
     pub async fn serve(self, shutdown: CancellationToken) -> anyhow::Result<()> {
-        tracing::info!(target: LOG_TARGET, endpoint=?self.address, "Initializing server");
-
         // Initialize database connection.
         let db = load_with_pool_size(
             self.data_directory.database_path(),
@@ -94,24 +92,35 @@ impl ValidatorServer {
             .build_v1()
             .context("failed to build reflection service")?;
 
+        let service = ValidatorService::new(
+            self.signer,
+            self.decrypter,
+            db,
+            block_store,
+            initial_chain_tip,
+            initial_tx_count,
+            initial_block_count,
+        )
+        .await
+        .context("failed to initialize validator server")?;
+        let endpoint = listener.local_addr().context("failed to read validator listen address")?;
+        tracing::info!(
+            target: LOG_TARGET,
+            {
+                service.name = "miden-validator",
+                service.version = env!("CARGO_PKG_VERSION"),
+                validator.listen = %endpoint,
+                block.number = initial_chain_tip,
+            },
+            "Validator ready",
+        );
+
         // Build the gRPC server with the API service and trace layer.
         tonic::transport::Server::builder()
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
             .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
             .timeout(self.grpc_options.request_timeout)
-            .add_service(validator_api::service(
-                ValidatorService::new(
-                    self.signer,
-                    self.decrypter,
-                    db,
-                    block_store,
-                    initial_chain_tip,
-                    initial_tx_count,
-                    initial_block_count,
-                )
-                .await
-                .context("failed to initialize validator server")?,
-            ))
+            .add_service(validator_api::service(service))
             .add_service(reflection_service)
             .serve_with_incoming_shutdown(
                 TcpListenerStream::new(listener),

--- a/crates/block-producer/src/rpc_sync.rs
+++ b/crates/block-producer/src/rpc_sync.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use anyhow::Context;
@@ -31,23 +32,96 @@ pub(crate) const RECONNECT_DELAY: Duration = Duration::from_secs(5);
 pub struct RpcReadiness {
     reporter: HealthReporter,
     threshold: u32,
+    state: Arc<AtomicU8>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReadinessTransition {
+    InitialNotReady,
+    BecameReady,
+    BecameNotReady,
+    Unchanged,
 }
 
 impl RpcReadiness {
     const SERVICE_NAME: &'static str = "rpc.Api";
+    const UNKNOWN: u8 = 0;
+    const NOT_READY: u8 = 1;
+    const READY: u8 = 2;
 
     pub fn new(reporter: HealthReporter, threshold: u32) -> Self {
-        Self { reporter, threshold }
+        Self {
+            reporter,
+            threshold,
+            state: Arc::new(AtomicU8::new(Self::UNKNOWN)),
+        }
     }
 
     /// Updates the RPC service health status based on the upstream/local tip gap.
     pub async fn update(&self, upstream_tip: BlockNumber, local_tip: BlockNumber) {
-        let status = if upstream_tip.as_u32().saturating_sub(local_tip.as_u32()) <= self.threshold {
+        let gap = upstream_tip.as_u32().saturating_sub(local_tip.as_u32());
+        let ready = gap <= self.threshold;
+        let status = if ready {
             ServingStatus::Serving
         } else {
             ServingStatus::NotServing
         };
         self.reporter.set_service_status(Self::SERVICE_NAME, status).await;
+
+        match self.record_transition(ready) {
+            ReadinessTransition::BecameReady => {
+                info!(
+                    target: LOG_TARGET,
+                    {
+                        service.name = "miden-node",
+                        service.version = env!("CARGO_PKG_VERSION"),
+                        node.role = "full",
+                        block.number = %local_tip,
+                        sync.upstream_block = %upstream_tip,
+                        sync.block_gap = gap,
+                        sync.ready_threshold = self.threshold,
+                    },
+                    "Node ready",
+                );
+            },
+            ReadinessTransition::BecameNotReady => {
+                warn!(
+                    target: LOG_TARGET,
+                    {
+                        block.number = %local_tip,
+                        sync.upstream_block = %upstream_tip,
+                        sync.block_gap = gap,
+                        sync.ready_threshold = self.threshold,
+                    },
+                    "Node no longer ready",
+                );
+            },
+            ReadinessTransition::InitialNotReady => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    {
+                        block.number = %local_tip,
+                        sync.upstream_block = %upstream_tip,
+                        sync.block_gap = gap,
+                        sync.ready_threshold = self.threshold,
+                    },
+                    "Node synchronizing",
+                );
+            },
+            ReadinessTransition::Unchanged => {},
+        }
+    }
+
+    fn record_transition(&self, ready: bool) -> ReadinessTransition {
+        let next = if ready { Self::READY } else { Self::NOT_READY };
+        match self.state.swap(next, Ordering::Relaxed) {
+            previous if previous == next => ReadinessTransition::Unchanged,
+            Self::UNKNOWN if ready => ReadinessTransition::BecameReady,
+            Self::UNKNOWN => ReadinessTransition::InitialNotReady,
+            Self::READY => ReadinessTransition::BecameNotReady,
+            Self::NOT_READY => ReadinessTransition::BecameReady,
+            _ => unreachable!("readiness state is one of the declared constants"),
+        }
     }
 }
 
@@ -120,10 +194,15 @@ impl BlockSync {
         err,
     )]
     async fn sync(&self, shutdown: CancellationToken) -> anyhow::Result<()> {
-        let block_from = self.state.chain_tip(Finality::Committed).await.child().as_u32();
+        let local_tip = self.state.chain_tip(Finality::Committed).await;
+        let mut client = self.source_rpc.clone();
+        let upstream_tip =
+            BlockNumber::from(client.status(tonic::Request::new(())).await?.into_inner().chain_tip);
+        self.readiness.update(upstream_tip, local_tip).await;
+
+        let block_from = local_tip.child().as_u32();
         info!(target: LOG_TARGET, block_from, "Connecting to upstream RPC for blocks");
 
-        let mut client = self.source_rpc.clone();
         let mut stream = client
             .block_subscription(BlockSubscriptionRequest { block_from })
             .await?
@@ -228,5 +307,22 @@ impl ProofSync {
 
             expected = expected.child();
         }
+    }
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use super::*;
+
+    #[test]
+    fn readiness_transitions_are_emitted_once_per_state_change() {
+        let (reporter, _service) = tonic_health::server::health_reporter();
+        let readiness = RpcReadiness::new(reporter, 10);
+
+        assert_eq!(readiness.record_transition(false), ReadinessTransition::InitialNotReady,);
+        assert_eq!(readiness.record_transition(false), ReadinessTransition::Unchanged,);
+        assert_eq!(readiness.record_transition(true), ReadinessTransition::BecameReady,);
+        assert_eq!(readiness.record_transition(true), ReadinessTransition::Unchanged,);
+        assert_eq!(readiness.record_transition(false), ReadinessTransition::BecameNotReady,);
     }
 }

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -12,7 +13,7 @@ use miden_node_proto::clients::{
 };
 use miden_node_proto::server::{rpc_api, sequencer_api};
 use miden_node_proto_build::rpc_api_descriptor;
-use miden_node_store::state::State;
+use miden_node_store::state::{Finality, State};
 use miden_node_utils::clap::{GrpcOptionsExternal, GrpcOptionsInternal};
 use miden_node_utils::cors::cors_for_grpc_web_layer;
 use miden_node_utils::grpc;
@@ -29,9 +30,9 @@ use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
+use crate::LOG_TARGET;
 use crate::server::api::SequencerInternalService;
 use crate::server::health::HealthCheckLayer;
-use crate::{COMPONENT, LOG_TARGET};
 
 mod accept;
 pub(crate) mod api;
@@ -99,6 +100,13 @@ impl RpcMode {
             validator: validator.map(Box::new),
         }
     }
+
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sequencer { .. } => "sequencer",
+            Self::FullNode { .. } => "full",
+        }
+    }
 }
 
 impl Rpc {
@@ -110,6 +118,8 @@ impl Rpc {
     /// Note: Executes in place (i.e. not spawned) and will run indefinitely until
     ///       a fatal error is encountered.
     pub async fn serve(self, shutdown: CancellationToken) -> anyhow::Result<()> {
+        let endpoint = self.listener.local_addr().context("failed to read RPC listen address")?;
+        let mode = self.mode.as_str();
         let mut api = api::RpcService::new(
             self.store.clone(),
             self.mode.clone(),
@@ -127,8 +137,6 @@ impl Rpc {
 
         let api_service = rpc_api::service(api);
 
-        info!(target: LOG_TARGET, endpoint=?self.listener, mode=?self.mode, "Server initialized");
-
         let mut tasks = Tasks::new();
 
         // Initialize health reporter and sync service based on the RPC mode.
@@ -141,6 +149,8 @@ impl Rpc {
                         tonic_health::ServingStatus::Serving,
                     )
                     .await;
+                let chain_tip = self.store.chain_tip(Finality::Committed).await;
+                log_node_ready(mode, endpoint, chain_tip);
             },
             RpcMode::FullNode { source_rpc, readiness_threshold, .. } => {
                 health_reporter
@@ -159,6 +169,7 @@ impl Rpc {
                     }
                     .run(shutdown.clone()),
                 );
+                log_node_synchronizing(mode, endpoint, readiness_threshold);
             },
         }
 
@@ -221,6 +232,34 @@ impl Rpc {
     }
 }
 
+fn log_node_ready(mode: &str, endpoint: impl Display, chain_tip: impl Display) {
+    info!(
+        target: LOG_TARGET,
+        {
+            service.name = "miden-node",
+            service.version = env!("CARGO_PKG_VERSION"),
+            node.role = mode,
+            rpc.listen = %endpoint,
+            block.number = %chain_tip,
+        },
+        "Node ready",
+    );
+}
+
+fn log_node_synchronizing(mode: &str, endpoint: impl Display, readiness_threshold: u32) {
+    info!(
+        target: LOG_TARGET,
+        {
+            service.name = "miden-node",
+            service.version = env!("CARGO_PKG_VERSION"),
+            node.role = mode,
+            rpc.listen = %endpoint,
+            sync.ready_threshold = readiness_threshold,
+        },
+        "Node started; synchronizing",
+    );
+}
+
 // INTERNAL SEQUENCER
 // ================================================================================================
 
@@ -247,7 +286,15 @@ impl SequencerInternal {
     /// Executes in place (i.e. not spawned) and will run indefinitely until a fatal error is
     /// encountered.
     pub async fn serve(self, shutdown: CancellationToken) -> anyhow::Result<()> {
-        info!(target: COMPONENT, endpoint = ?self.listener, "Internal sequencer server initialized");
+        let endpoint = self
+            .listener
+            .local_addr()
+            .context("failed to read internal sequencer listen address")?;
+        info!(
+            target: LOG_TARGET,
+            { internal.listen = %endpoint },
+            "Internal sequencer server ready",
+        );
 
         let service = SequencerInternalService { block_producer: self.block_producer };
 

--- a/crates/store/src/state/bootstrap.rs
+++ b/crates/store/src/state/bootstrap.rs
@@ -23,20 +23,20 @@ impl State {
             DataDirectory::load(data_directory.to_path_buf()).with_context(|| {
                 format!("failed to load data directory at {}", data_directory.display())
             })?;
-        tracing::info!(target: LOG_TARGET, path=%data_directory.display(), "Data directory loaded");
+        tracing::debug!(target: LOG_TARGET, path=%data_directory.display(), "Data directory loaded");
 
         let block_store_path = data_directory.block_store_dir();
         let block_store =
             BlockStore::bootstrap(block_store_path.clone(), &genesis).with_context(|| {
                 format!("failed to bootstrap block store at {}", block_store_path.display())
             })?;
-        tracing::info!(target: LOG_TARGET, path=%block_store.display(), "Block store created");
+        tracing::debug!(target: LOG_TARGET, path=%block_store.display(), "Block store created");
 
         let database_filepath = data_directory.database_path();
         Db::bootstrap(database_filepath.clone(), genesis).with_context(|| {
             format!("failed to bootstrap database at {}", database_filepath.display())
         })?;
-        tracing::info!(target: LOG_TARGET, path=%database_filepath.display(), "Database created");
+        tracing::debug!(target: LOG_TARGET, path=%database_filepath.display(), "Database created");
 
         Ok(())
     }

--- a/crates/utils/src/formatting.rs
+++ b/crates/utils/src/formatting.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use itertools::Itertools;
 use miden_protocol::transaction::{InputNoteCommitment, InputNotes, OutputNotes};
+use url::Url;
 
 pub fn format_opt<T: Display>(opt: Option<&T>) -> String {
     opt.map_or("None".to_owned(), ToString::to_string)
@@ -39,6 +40,16 @@ pub fn format_array(list: impl IntoIterator<Item = impl Display>) -> String {
     }
 }
 
+/// Formats a service endpoint without credentials, query parameters, or fragments.
+pub fn format_endpoint(endpoint: &Url) -> String {
+    let mut endpoint = endpoint.clone();
+    let _ = endpoint.set_username("");
+    let _ = endpoint.set_password(None);
+    endpoint.set_query(None);
+    endpoint.set_fragment(None);
+    endpoint.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use miden_protocol::Word;
@@ -54,8 +65,9 @@ mod tests {
         PartialNoteMetadata,
     };
     use miden_protocol::transaction::{InputNoteCommitment, InputNotes};
+    use url::Url;
 
-    use super::format_input_notes;
+    use super::{format_endpoint, format_input_notes};
 
     #[test]
     fn input_notes_are_labeled() {
@@ -83,5 +95,13 @@ mod tests {
                 header.id().to_hex(),
             ),
         );
+    }
+
+    #[test]
+    fn endpoint_formatting_redacts_sensitive_parts() {
+        let endpoint =
+            Url::parse("https://user:secret@example.com:443/grpc?token=secret#fragment").unwrap();
+
+        assert_eq!(format_endpoint(&endpoint), "https://example.com/grpc");
     }
 }

--- a/crates/utils/src/shutdown.rs
+++ b/crates/utils/src/shutdown.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Display, Formatter};
 use std::future::Future;
 use std::time::Duration;
 
@@ -7,42 +8,79 @@ pub use tokio_util::sync::CancellationToken;
 /// Time allowed for services to finish after a shutdown signal before the process exits.
 pub const GRACE_PERIOD: Duration = Duration::from_secs(10);
 
+/// Operating-system signal which requested service shutdown.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShutdownSignal {
+    Interrupt,
+    Terminate,
+}
+
+impl Display for ShutdownSignal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Interrupt => f.write_str("SIGINT"),
+            Self::Terminate => f.write_str("SIGTERM"),
+        }
+    }
+}
+
 /// Runs a service future until it completes or a shutdown signal is received.
 ///
 /// On `SIGTERM` or Ctrl-C, the provided root cancellation token is cancelled and the service future
 /// is given [`GRACE_PERIOD`] to complete. If it does not, the process exits immediately so
 /// blocking work cannot hold the Tokio runtime alive indefinitely.
-pub async fn run_with_shutdown<F, Fut>(run: F) -> anyhow::Result<()>
+pub async fn run_with_shutdown<F, Fut>(service_name: &'static str, run: F) -> anyhow::Result<()>
 where
     F: FnOnce(CancellationToken) -> Fut,
     Fut: Future<Output = anyhow::Result<()>>,
 {
+    run_with_shutdown_signal(service_name, run, shutdown_signal()).await
+}
+
+async fn run_with_shutdown_signal<F, Fut, Signal>(
+    service_name: &'static str,
+    run: F,
+    signal: Signal,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(CancellationToken) -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+    Signal: Future<Output = anyhow::Result<ShutdownSignal>>,
+{
     let token = CancellationToken::new();
     let service = run(token.clone());
     tokio::pin!(service);
+    tokio::pin!(signal);
 
     tokio::select! {
         result = &mut service => result,
-        result = shutdown_signal() => {
-            result?;
-            tracing::info!("Shutdown signal received; cancelling service tasks");
+        result = &mut signal => {
+            let signal = result?;
+            tracing::info!(
+                service.name = service_name,
+                shutdown.signal = %signal,
+                "Shutdown requested",
+            );
             token.cancel();
 
             let Ok(result) = tokio::time::timeout(GRACE_PERIOD, &mut service).await else {
                 tracing::error!(
+                    service.name = service_name,
                     grace_period = ?GRACE_PERIOD,
                     "Graceful shutdown timed out; exiting process",
                 );
-                std::process::exit(0);
+                std::process::exit(1);
             };
 
-            result
+            result?;
+            tracing::info!(service.name = service_name, "Shutdown complete");
+            Ok(())
         },
     }
 }
 
 /// Waits for SIGTERM or Ctrl-C.
-pub async fn shutdown_signal() -> anyhow::Result<()> {
+pub async fn shutdown_signal() -> anyhow::Result<ShutdownSignal> {
     #[cfg(unix)]
     {
         let mut terminate =
@@ -50,15 +88,64 @@ pub async fn shutdown_signal() -> anyhow::Result<()> {
                 .context("failed to install SIGTERM handler")?;
 
         tokio::select! {
-            _ = terminate.recv() => Ok(()),
+            _ = terminate.recv() => Ok(ShutdownSignal::Terminate),
             result = tokio::signal::ctrl_c() => {
-                result.context("failed to install Ctrl-C handler")
+                result
+                    .context("failed to install Ctrl-C handler")
+                    .map(|()| ShutdownSignal::Interrupt)
             },
         }
     }
 
     #[cfg(not(unix))]
     {
-        tokio::signal::ctrl_c().await.context("failed to install Ctrl-C handler")
+        tokio::signal::ctrl_c()
+            .await
+            .context("failed to install Ctrl-C handler")
+            .map(|()| ShutdownSignal::Interrupt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn signal_cancels_and_waits_for_service() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let service_cancelled = Arc::clone(&cancelled);
+
+        run_with_shutdown_signal(
+            "test-service",
+            move |shutdown| async move {
+                shutdown.cancelled().await;
+                service_cancelled.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+            std::future::ready(Ok(ShutdownSignal::Interrupt)),
+        )
+        .await
+        .expect("clean shutdown should succeed");
+
+        assert!(cancelled.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn signal_handler_error_is_propagated() {
+        let err = run_with_shutdown_signal(
+            "test-service",
+            |shutdown| async move {
+                shutdown.cancelled().await;
+                Ok(())
+            },
+            std::future::ready(Err(anyhow::anyhow!("signal handler failed"))),
+        )
+        .await
+        .expect_err("signal error should be returned");
+
+        assert_eq!(err.to_string(), "signal handler failed");
     }
 }


### PR DESCRIPTION
## Summary

  - Log structured startup configuration and readiness events for the node, validator, NTX builder, and remote prover.
  - Report bootstrap start and completion, including genesis sources, commitments, configuration paths, and output directories.
  - Track full-node synchronization readiness and log state transitions without duplicate events.
  - Sanitize service endpoints before including them in startup logs.
  - Log SIGINT/SIGTERM shutdown requests and successful completion, while returning a non-zero exit code when graceful shutdown times out.

Partially resolves part 5 of issue #2330 

## Changelog

```toml
[[entry]]
scope       = "general"
impact      = "added"
description = "User visible log events have been added for startup and shutdown to all services."
```
