### PR TITLE
fix(ntx-builder): keep alive main loop connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "miden-benchmark"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "miden-large-smt-backend-rocksdb"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "miden-crypto",
  "miden-node-rocksdb-cxx-linkage-fix",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "build-rs",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "build-rs",
  "codegen",
@@ -3482,11 +3482,11 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rocksdb-cxx-linkage-fix"
-version = "0.15.1"
+version = "0.15.2"
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "clap",
  "fs-err",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-tracing-macro"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "backon",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "backon",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -7359,7 +7359,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.93"
-version      = "0.15.1"
+version      = "0.15.2"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]

--- a/bin/ntx-builder/src/builder.rs
+++ b/bin/ntx-builder/src/builder.rs
@@ -1,6 +1,5 @@
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Context;
 use futures::Stream;
@@ -21,14 +20,6 @@ use crate::db::{Db, LoopDb};
 use crate::server::NtxBuilderRpcServer;
 use crate::{LOG_TARGET, NtxBuilderConfig};
 
-/// How often the steady-state loop emits a chain-following liveness signal.
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
-
-/// How long without applying a committed block before the heartbeat escalates to a warning. This
-/// makes a stalled subscription visible in the logs (silence would otherwise look identical to an
-/// idle chain). Kept above the node's block interval so a briefly quiet chain does not warn.
-const STALENESS_WARN_THRESHOLD: Duration = Duration::from_secs(90);
-
 /// Discriminator returned by the steady-state `select!` so the dispatch can run on a fully-owned
 /// `&mut self` instead of three concurrent borrows. The `Block` variant is boxed since a
 /// `SignedBlock` dwarfs the other two payloads.
@@ -36,8 +27,6 @@ enum SteadyStateAction {
     Block(Box<Option<Result<(SignedBlock, BlockNumber), RpcError>>>),
     Request(Option<ActorRequest>),
     Respawn(Option<miden_protocol::account::AccountId>),
-    /// Periodic liveness tick: log whether the builder is still following the chain.
-    Heartbeat,
     Shutdown,
 }
 
@@ -182,16 +171,6 @@ impl NetworkTransactionBuilder {
             self.coordinator.spawn_actor_when_committed(account_id).await?;
         }
 
-        // Liveness heartbeat: gives operators a positive "still following the chain" signal and,
-        // crucially, escalates to a warning when no block has been applied for a while — so a
-        // stalled subscription is distinguishable from a genuinely idle chain instead of looking
-        // like identical silence.
-        let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
-        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // Consume the immediate first tick so the first heartbeat waits a full interval.
-        heartbeat.tick().await;
-        let mut last_block_at = tokio::time::Instant::now();
-
         // Phase 3: drive actors per committed block, plus serialize their DB writes.
         loop {
             // Split `&mut self` into disjoint borrows so each `select!` arm holds only the one
@@ -207,7 +186,6 @@ impl NetworkTransactionBuilder {
                     block = block_stream.next() => SteadyStateAction::Block(Box::new(block)),
                     request = actor_request_rx.recv() => SteadyStateAction::Request(request),
                     respawn = coordinator.next() => SteadyStateAction::Respawn(respawn?),
-                    _ = heartbeat.tick() => SteadyStateAction::Heartbeat,
                 }
             };
 
@@ -219,10 +197,6 @@ impl NetworkTransactionBuilder {
                         .apply_committed_block_with_effects(&loop_db, block, committed_tip)
                         .await?;
                     self.coordinator.handle_committed_block(&effects).await?;
-                    last_block_at = tokio::time::Instant::now();
-                },
-                SteadyStateAction::Heartbeat => {
-                    log_chain_follow_heartbeat(self.last_applied_block, last_block_at.elapsed());
                 },
                 SteadyStateAction::Request(request) => {
                     let Some(request) = request else {
@@ -305,27 +279,6 @@ impl NetworkTransactionBuilder {
         self.last_applied_block = block_num;
 
         Ok(effects)
-    }
-}
-
-/// Emits the steady-state liveness heartbeat: a debug line while blocks are flowing, escalating to
-/// a warning once no committed block has been applied for [`STALENESS_WARN_THRESHOLD`] so a stalled
-/// subscription is distinguishable from a genuinely idle chain.
-fn log_chain_follow_heartbeat(last_applied_block: BlockNumber, elapsed: Duration) {
-    if elapsed >= STALENESS_WARN_THRESHOLD {
-        tracing::warn!(
-            target: LOG_TARGET,
-            %last_applied_block,
-            stale_for_s = elapsed.as_secs(),
-            "no committed block applied recently; block subscription may be stalled",
-        );
-    } else {
-        tracing::debug!(
-            target: LOG_TARGET,
-            %last_applied_block,
-            since_last_block_s = elapsed.as_secs(),
-            "ntx-builder following chain",
-        );
     }
 }
 

--- a/bin/ntx-builder/src/builder.rs
+++ b/bin/ntx-builder/src/builder.rs
@@ -1,5 +1,6 @@
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use futures::Stream;
@@ -20,6 +21,14 @@ use crate::db::{Db, LoopDb};
 use crate::server::NtxBuilderRpcServer;
 use crate::{LOG_TARGET, NtxBuilderConfig};
 
+/// How often the steady-state loop emits a chain-following liveness signal.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long without applying a committed block before the heartbeat escalates to a warning. This
+/// makes a stalled subscription visible in the logs (silence would otherwise look identical to an
+/// idle chain). Kept above the node's block interval so a briefly quiet chain does not warn.
+const STALENESS_WARN_THRESHOLD: Duration = Duration::from_secs(90);
+
 /// Discriminator returned by the steady-state `select!` so the dispatch can run on a fully-owned
 /// `&mut self` instead of three concurrent borrows. The `Block` variant is boxed since a
 /// `SignedBlock` dwarfs the other two payloads.
@@ -27,6 +36,8 @@ enum SteadyStateAction {
     Block(Box<Option<Result<(SignedBlock, BlockNumber), RpcError>>>),
     Request(Option<ActorRequest>),
     Respawn(Option<miden_protocol::account::AccountId>),
+    /// Periodic liveness tick: log whether the builder is still following the chain.
+    Heartbeat,
     Shutdown,
 }
 
@@ -171,6 +182,16 @@ impl NetworkTransactionBuilder {
             self.coordinator.spawn_actor_when_committed(account_id).await?;
         }
 
+        // Liveness heartbeat: gives operators a positive "still following the chain" signal and,
+        // crucially, escalates to a warning when no block has been applied for a while — so a
+        // stalled subscription is distinguishable from a genuinely idle chain instead of looking
+        // like identical silence.
+        let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Consume the immediate first tick so the first heartbeat waits a full interval.
+        heartbeat.tick().await;
+        let mut last_block_at = tokio::time::Instant::now();
+
         // Phase 3: drive actors per committed block, plus serialize their DB writes.
         loop {
             // Split `&mut self` into disjoint borrows so each `select!` arm holds only the one
@@ -186,6 +207,7 @@ impl NetworkTransactionBuilder {
                     block = block_stream.next() => SteadyStateAction::Block(Box::new(block)),
                     request = actor_request_rx.recv() => SteadyStateAction::Request(request),
                     respawn = coordinator.next() => SteadyStateAction::Respawn(respawn?),
+                    _ = heartbeat.tick() => SteadyStateAction::Heartbeat,
                 }
             };
 
@@ -197,6 +219,10 @@ impl NetworkTransactionBuilder {
                         .apply_committed_block_with_effects(&loop_db, block, committed_tip)
                         .await?;
                     self.coordinator.handle_committed_block(&effects).await?;
+                    last_block_at = tokio::time::Instant::now();
+                },
+                SteadyStateAction::Heartbeat => {
+                    log_chain_follow_heartbeat(self.last_applied_block, last_block_at.elapsed());
                 },
                 SteadyStateAction::Request(request) => {
                     let Some(request) = request else {
@@ -279,6 +305,27 @@ impl NetworkTransactionBuilder {
         self.last_applied_block = block_num;
 
         Ok(effects)
+    }
+}
+
+/// Emits the steady-state liveness heartbeat: a debug line while blocks are flowing, escalating to
+/// a warning once no committed block has been applied for [`STALENESS_WARN_THRESHOLD`] so a stalled
+/// subscription is distinguishable from a genuinely idle chain.
+fn log_chain_follow_heartbeat(last_applied_block: BlockNumber, elapsed: Duration) {
+    if elapsed >= STALENESS_WARN_THRESHOLD {
+        tracing::warn!(
+            target: LOG_TARGET,
+            %last_applied_block,
+            stale_for_s = elapsed.as_secs(),
+            "no committed block applied recently; block subscription may be stalled",
+        );
+    } else {
+        tracing::debug!(
+            target: LOG_TARGET,
+            %last_applied_block,
+            since_last_block_s = elapsed.as_secs(),
+            "ntx-builder following chain",
+        );
     }
 }
 

--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -51,6 +51,14 @@ type BlockSubscriptionItem = Result<(SignedBlock, BlockNumber), RpcError>;
 /// exponentially inside [`RpcClient::block_subscription_with_retry`].
 const RECONNECT_DELAY: Duration = Duration::from_secs(5);
 
+/// Maximum time to wait for the next committed block before treating the subscription as stalled
+/// and forcing a reconnect.
+///
+/// This is a defensive backstop for a silently dropped connection that never surfaces an error on
+/// its own (client HTTP/2 keepalive is the primary, faster detector). It must be comfortably larger
+/// than the node's block interval so a legitimately quiet chain is not mistaken for a stall.
+const STALL_TIMEOUT: Duration = Duration::from_secs(120);
+
 /// Thin wrapper around the node RPC gRPC service that the ntx-builder uses to consume the
 /// committed-block subscription stream.
 #[derive(Clone, Debug)]
@@ -176,7 +184,13 @@ impl RpcClient {
                     let stream = match &mut inner {
                         Some(stream) => stream,
                         None => match client.block_subscription_with_retry(next_from).await {
-                            Ok(stream) => inner.insert(stream),
+                            Ok(stream) => {
+                                tracing::info!(
+                                    target: COMPONENT, %next_from,
+                                    "block subscription connected",
+                                );
+                                inner.insert(stream)
+                            },
                             Err(err) => {
                                 tracing::warn!(
                                     target: COMPONENT, err = %err.as_report(), %next_from,
@@ -188,18 +202,26 @@ impl RpcClient {
                         },
                     };
 
-                    match stream.next().await {
-                        Some(Ok((block, committed_tip))) => {
+                    // A silently dropped connection can leave `stream.next()` pending forever with
+                    // no error, so bound the wait: if no block arrives within `STALL_TIMEOUT`,
+                    // treat the subscription as stalled and reconnect.
+                    match tokio::time::timeout(STALL_TIMEOUT, stream.next()).await {
+                        Ok(Some(Ok((block, committed_tip)))) => {
                             next_from = block.header().block_num().child();
                             return Some((Ok((block, committed_tip)), (client, next_from, inner)));
                         },
-                        Some(Err(err)) => tracing::warn!(
+                        Ok(Some(Err(err))) => tracing::warn!(
                             target: COMPONENT, err = %err.as_report(), %next_from,
                             "block subscription failed, reconnecting",
                         ),
-                        None => tracing::warn!(
+                        Ok(None) => tracing::warn!(
                             target: COMPONENT, %next_from,
                             "block subscription closed by node, reconnecting",
+                        ),
+                        Err(_elapsed) => tracing::warn!(
+                            target: COMPONENT, %next_from,
+                            stall_timeout_s = STALL_TIMEOUT.as_secs(),
+                            "no block received within stall timeout; treating subscription as stalled, reconnecting",
                         ),
                     }
 

--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use miden_node_utils::tracing::miden_instrument;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use backon::ExponentialBuilder;
 use futures::stream::{BoxStream, TryStreamExt};
@@ -51,8 +51,11 @@ type BlockSubscriptionItem = Result<(SignedBlock, BlockNumber), RpcError>;
 /// exponentially inside [`RpcClient::block_subscription_with_retry`].
 const RECONNECT_DELAY: Duration = Duration::from_secs(5);
 
-/// Maximum time to wait for the next committed block before treating the subscription as stalled
-/// and forcing a reconnect.
+/// How long a single `stream.next()` poll waits before re-evaluating liveness.
+const BLOCK_POLL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Maximum time without a committed block before treating the subscription as stalled and forcing a
+/// reconnect.
 ///
 /// This is a defensive backstop for a silently dropped connection that never surfaces an error on
 /// its own (client HTTP/2 keepalive is the primary, faster detector). It must be comfortably larger
@@ -176,8 +179,8 @@ impl RpcClient {
         let client = self.clone();
 
         futures::stream::unfold(
-            (client, block_from, None),
-            |(client, mut next_from, mut inner)| async move {
+            (client, block_from, None, Instant::now()),
+            |(client, mut next_from, mut inner, mut last_block)| async move {
                 loop {
                     // Open the subscription if we don't hold a live one. The connect itself retries
                     // indefinitely with exponential backoff.
@@ -189,6 +192,9 @@ impl RpcClient {
                                     target: COMPONENT, %next_from,
                                     "block subscription connected",
                                 );
+                                // Reset the stall clock so time spent (re)connecting is not counted
+                                // against the next block's arrival.
+                                last_block = Instant::now();
                                 inner.insert(stream)
                             },
                             Err(err) => {
@@ -202,13 +208,17 @@ impl RpcClient {
                         },
                     };
 
-                    // A silently dropped connection can leave `stream.next()` pending forever with
-                    // no error, so bound the wait: if no block arrives within `STALL_TIMEOUT`,
-                    // treat the subscription as stalled and reconnect.
-                    match tokio::time::timeout(STALL_TIMEOUT, stream.next()).await {
+                    // Poll on a short timeout so a silently dropped connection stays observable.
+                    // Each quiet poll emits a liveness log; once no block has arrived for
+                    // `STALL_TIMEOUT` the subscription is treated as stalled and reconnected.
+                    match tokio::time::timeout(BLOCK_POLL_TIMEOUT, stream.next()).await {
                         Ok(Some(Ok((block, committed_tip)))) => {
                             next_from = block.header().block_num().child();
-                            return Some((Ok((block, committed_tip)), (client, next_from, inner)));
+                            last_block = Instant::now();
+                            return Some((
+                                Ok((block, committed_tip)),
+                                (client, next_from, inner, last_block),
+                            ));
                         },
                         Ok(Some(Err(err))) => tracing::warn!(
                             target: COMPONENT, err = %err.as_report(), %next_from,
@@ -218,15 +228,30 @@ impl RpcClient {
                             target: COMPONENT, %next_from,
                             "block subscription closed by node, reconnecting",
                         ),
-                        Err(_elapsed) => tracing::warn!(
-                            target: COMPONENT, %next_from,
-                            stall_timeout_s = STALL_TIMEOUT.as_secs(),
-                            "no block received within stall timeout; treating subscription as stalled, reconnecting",
-                        ),
+                        Err(_elapsed) => {
+                            let idle = last_block.elapsed();
+                            if idle < STALL_TIMEOUT {
+                                // Quiet but not yet stalled: emit a liveness signal and keep
+                                // polling the same stream instead of reconnecting.
+                                tracing::debug!(
+                                    target: COMPONENT, %next_from,
+                                    idle = %humantime::format_duration(Duration::from_secs(idle.as_secs())),
+                                    "no block received recently; subscription still open",
+                                );
+                                continue;
+                            }
+                            tracing::warn!(
+                                target: COMPONENT, %next_from,
+                                idle = %humantime::format_duration(Duration::from_secs(idle.as_secs())),
+                                stall_timeout = %humantime::format_duration(STALL_TIMEOUT),
+                                "no block received within stall timeout; treating subscription as stalled, reconnecting",
+                            );
+                        },
                     }
 
-                    // The subscription dropped: discard it, pace the reconnect, and resume from the
-                    // next un-applied block on the following loop iteration.
+                    // Reached on an error/close/stall branch: discard the stream, pace the
+                    // reconnect, and resume from the next un-applied block on the following
+                    // iteration.
                     inner = None;
                     tokio::time::sleep(RECONNECT_DELAY).await;
                 }

--- a/crates/proto/src/clients/mod.rs
+++ b/crates/proto/src/clients/mod.rs
@@ -376,12 +376,25 @@ impl<State> Builder<State> {
     }
 }
 
+/// Client HTTP/2 keepalive interval.
+const HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
+/// Client HTTP/2 keepalive: how long to wait for a PING ack before considering the connection dead.
+const HTTP2_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+/// OS-level TCP keepalive backstop for direct (non-proxied) connections.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
 impl Builder<WantsTls> {
     /// Create a new strict builder from a gRPC endpoint URL such as `http://localhost:8080` or
     /// `https://api.example.com:443`.
     pub fn new(url: Url) -> Builder<WantsTls> {
         let endpoint = Endpoint::from_shared(String::from(url))
-            .expect("Url type always results in valid endpoint");
+            .expect("Url type always results in valid endpoint")
+            // Detect silently dropped connections so long-lived streams can't hang forever; see the
+            // keepalive constants above.
+            .http2_keep_alive_interval(HTTP2_KEEPALIVE_INTERVAL)
+            .keep_alive_timeout(HTTP2_KEEPALIVE_TIMEOUT)
+            .keep_alive_while_idle(true)
+            .tcp_keepalive(Some(TCP_KEEPALIVE));
 
         Builder {
             endpoint,


### PR DESCRIPTION
> [!WARNING]
> This PR aims `main` as base branch.

Closes #2357

## Summary

Fixes the ntx-builder going permanently silent after a period of idle note traffic.

### How:
1. Keepalive on every gRPC client.
2. bound `stream.next()` with a timeout so a stalled subscription is force-reconnected even if no error is ever surfaced.
3. Periodic log that escalates to a warning after no block is applied for a while, so a stall is a distinct signal instead of silence indistinguishable from an idle chain.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "ntx-builder"
impact      = "fixed"
description = "Network accounts no longer stop reactivating after idle periods: gRPC clients now use HTTP/2 keepalive to detect silently dropped block-subscription connections, plus a subscription stall watchdog and a liveness heartbeat."
```