### PR TITLE
fix: Docker invalid cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,19 +83,10 @@ COPY . .
 # as fresh. Touching while holding the lock guarantees sources are newer than
 # anything already in the cache. The mounted ./target is pruned from the walk
 # so cached fingerprints and artifacts keep their original mtimes.
-#
-# Diagnostics for stale-cache debugging: dump the current time and the mtimes
-# of cached fingerprints and sources so "artifact newer than touched sources"
-# anomalies are visible in CI logs, and have Cargo log its per-unit
-# fresh/dirty verdicts.
 RUN --mount=type=cache,sharing=locked,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
     --mount=type=cache,sharing=locked,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
     --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
-    date --iso-8601=seconds && \
-    (ls -la --time-style=full-iso /app/target/release/.fingerprint/ | grep miden-node-utils || true) && \
     find . -path ./target -prune -o -type f -exec touch {} + && \
-    ls -la --time-style=full-iso /app/crates/utils/src/ && \
-    CARGO_LOG=cargo::core::compiler::fingerprint=info \
     cargo build --release --locked --bin ${BIN} && \
     mkdir -p /app/bin && \
     cp /app/target/release/${BIN} /app/bin/${BIN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,16 +75,25 @@ COPY . .
 # incompatible .rlib. Touch all sources to the current time so every
 # workspace crate is always rebuilt; external dependencies are unaffected
 # (they are fingerprinted by checksum and stay cached via `cargo chef cook`).
-RUN find . -exec touch {} +
+#
+# The touch must happen inside the locked RUN below, after the target cache
+# mount is acquired: a concurrent build of another branch can hold the mount
+# and write artifacts into it, and a touch performed before lock acquisition
+# would leave those artifacts newer than our sources, making Cargo treat them
+# as fresh. Touching while holding the lock guarantees sources are newer than
+# anything already in the cache. The mounted ./target is pruned from the walk
+# so cached fingerprints and artifacts keep their original mtimes.
+#
 # Diagnostics for stale-cache debugging: dump the current time and the mtimes
 # of cached fingerprints and sources so "artifact newer than touched sources"
-# anomalies (e.g. written by a concurrent build after our touch step) are
-# visible in CI logs, and have Cargo log its per-unit fresh/dirty verdicts.
+# anomalies are visible in CI logs, and have Cargo log its per-unit
+# fresh/dirty verdicts.
 RUN --mount=type=cache,sharing=locked,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
     --mount=type=cache,sharing=locked,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
     --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
     date --iso-8601=seconds && \
     (ls -la --time-style=full-iso /app/target/release/.fingerprint/ | grep miden-node-utils || true) && \
+    find . -path ./target -prune -o -type f -exec touch {} + && \
     ls -la --time-style=full-iso /app/crates/utils/src/ && \
     CARGO_LOG=cargo::core::compiler::fingerprint=info \
     cargo build --release --locked --bin ${BIN} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,15 @@ ARG BIN
 # invalidating) a shared, lock-guarded mount for artifacts they can't reuse
 # anyway. Registry/git-db mounts stay arch-only since raw sources have no
 # feature dependence and are worth sharing across binaries.
+#
+# Sharing modes: the target mount is sharing=locked because the correctness
+# of the touch-then-build sequence below requires that no other build can
+# write artifacts into it between the touch and the build. The registry and
+# git-db mounts are sharing=shared: Cargo coordinates concurrent access to
+# CARGO_HOME with its own file locks (downloads and index updates take the
+# package-cache lock; extracted sources are immutable once unpacked), so
+# BuildKit-level serialization is redundant there and would needlessly make
+# every matrix job queue on a single registry mount.
 ARG TARGETARCH
 # Disable incremental compilation: Docker normalises COPY timestamps, which
 # breaks Rust's mtime-based fingerprinting and causes stale .rlib reuse.
@@ -60,8 +69,8 @@ COPY --from=planner /app/recipe.json recipe.json
 #
 # Cache Cargo's git DB, but leave checkout worktrees ephemeral; shared checkout
 # caches are fragile when concurrent CI builds race or a build is interrupted.
-RUN --mount=type=cache,sharing=locked,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
-    --mount=type=cache,sharing=locked,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
+RUN --mount=type=cache,sharing=shared,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
+    --mount=type=cache,sharing=shared,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
     --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
     cargo chef cook --release --recipe-path recipe.json --bin ${BIN}
 # Build application
@@ -83,8 +92,8 @@ COPY . .
 # as fresh. Touching while holding the lock guarantees sources are newer than
 # anything already in the cache. The mounted ./target is pruned from the walk
 # so cached fingerprints and artifacts keep their original mtimes.
-RUN --mount=type=cache,sharing=locked,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
-    --mount=type=cache,sharing=locked,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
+RUN --mount=type=cache,sharing=shared,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
+    --mount=type=cache,sharing=shared,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
     --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
     find . -path ./target -prune -o -type f -exec touch {} + && \
     cargo build --release --locked --bin ${BIN} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,17 @@ COPY . .
 # workspace crate is always rebuilt; external dependencies are unaffected
 # (they are fingerprinted by checksum and stay cached via `cargo chef cook`).
 RUN find . -exec touch {} +
+# Diagnostics for stale-cache debugging: dump the current time and the mtimes
+# of cached fingerprints and sources so "artifact newer than touched sources"
+# anomalies (e.g. written by a concurrent build after our touch step) are
+# visible in CI logs, and have Cargo log its per-unit fresh/dirty verdicts.
 RUN --mount=type=cache,sharing=locked,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
     --mount=type=cache,sharing=locked,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
     --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
+    date --iso-8601=seconds && \
+    (ls -la --time-style=full-iso /app/target/release/.fingerprint/ | grep miden-node-utils || true) && \
+    ls -la --time-style=full-iso /app/crates/utils/src/ && \
+    CARGO_LOG=cargo::core::compiler::fingerprint=info \
     cargo build --release --locked --bin ${BIN} && \
     mkdir -p /app/bin && \
     cp /app/target/release/${BIN} /app/bin/${BIN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ARG DEBIAN_RELEASE=bookworm
 ARG BIN
 ARG PORT
 
-FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} AS chef
+FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} AS builder
+ARG BIN
 # Disable incremental compilation: Docker normalises COPY timestamps, which
 # breaks Rust's mtime-based fingerprinting and causes stale .rlib reuse.
 # The /app/target cache still accelerates builds via pre-compiled dep .rlibs.
@@ -22,24 +23,7 @@ RUN apt-get update && \
         libssl-dev \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-RUN cargo install cargo-chef
 WORKDIR /app
-
-
-FROM chef AS planner
-ARG BIN
-COPY . .
-# Scope the recipe to this binary's dependency graph. Different binaries in
-# this workspace enable different, non-overlapping feature sets on shared
-# deps (e.g. miden-protocol, miden-tx); preparing/cooking for the whole
-# workspace would resolve a feature union that never matches what `cargo
-# build --bin ${BIN}` below actually needs, forcing those crates (and
-# everything downstream of them) to recompile on every build regardless of
-# caching.
-RUN cargo chef prepare --recipe-path recipe.json --bin ${BIN}
-
-FROM chef AS builder
-ARG BIN
 # Automatic per-platform arg (no manual wiring needed for multi-platform
 # buildx builds). Used, together with BIN, to key the cache mounts below so
 # that amd64 and arm64 builds never share compiled objects or checkouts —
@@ -60,30 +44,21 @@ ARG BIN
 # BuildKit-level serialization is redundant there and would needlessly make
 # every matrix job queue on a single registry mount.
 ARG TARGETARCH
-# Disable incremental compilation: Docker normalises COPY timestamps, which
-# breaks Rust's mtime-based fingerprinting and causes stale .rlib reuse.
-# The /app/target cache still accelerates builds via pre-compiled dep .rlibs.
-ENV CARGO_INCREMENTAL=0
-COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies while preserving Cargo artifacts across layer invalidations.
-#
-# Cache Cargo's git DB, but leave checkout worktrees ephemeral; shared checkout
-# caches are fragile when concurrent CI builds race or a build is interrupted.
-RUN --mount=type=cache,sharing=shared,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
-    --mount=type=cache,sharing=shared,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
-    --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
-    cargo chef cook --release --recipe-path recipe.json --bin ${BIN}
 # Build application
 COPY . .
 # Cargo's fingerprinting for workspace path crates is mtime-based: a crate is
 # rebuilt only if a source file is newer than the cached artifact. The
-# /app/target cache mount above is shared across branches and PRs on the
+# /app/target cache mount below is shared across branches and PRs on the
 # persistent builder, so its artifacts may come from source that differs from
 # this build context, and any source mtime older than those artifacts (local
 # checkouts, git-derived timestamps) makes Cargo silently link a stale,
 # incompatible .rlib. Touch all sources to the current time so every
 # workspace crate is always rebuilt; external dependencies are unaffected
-# (they are fingerprinted by checksum and stay cached via `cargo chef cook`).
+# (they are fingerprinted by checksum, not mtime, and stay cached in the
+# mounted target dir across builds).
+#
+# Cache Cargo's git DB, but leave checkout worktrees ephemeral; shared checkout
+# caches are fragile when concurrent CI builds race or a build is interrupted.
 #
 # The touch must happen inside the locked RUN below, after the target cache
 # mount is acquired: a concurrent build of another branch can hold the mount


### PR DESCRIPTION
## Summary

* Moved the source `touch` inside the locked build `RUN`** — the standalone touch layer ran before the target cache lock was acquired, so a concurrent build of another branch could write artifacts into the shared cache *after* our touch, making Cargo treat its stale rlibs as fresh (hopefully the root cause of the `format_endpoint` E0425 failures). Touching while holding the lock guarantees sources are always newer than anything in the cache. `./target` is pruned from the touch so cached fingerprints keep their mtimes.
- **Changed registry and git-db cache mounts from `sharing=locked` to `sharing=shared`** — Cargo already coordinates concurrent access to `CARGO_HOME` with its own file locks, so the BuildKit mutex was redundant and serialized every matrix job on one mount (~4–7 min queue stalls per step, which also widened the race window). The target mount stays `locked` because the touch-then-build atomicity depends on it.
- **Removed cargo-chef (planner stage, cook step, chef install)** — chef caches deps in Docker layers, but with cache mounts the artifacts live in the mounted `target/`, so cook was redundant: `cargo build` reuses mounted dep artifacts identically. Removal drops a full context copy + recipe prepare per build, chef compilation on cache resets, skeleton artifacts polluting the cache, and one extra locked mount acquisition.

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```