### PR TITLE
fix: bump internal dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,21 +45,21 @@ debug = true
 
 [workspace.dependencies]
 # Workspace crates.
-miden-large-smt-backend-rocksdb = { path = "crates/large-smt-backend-rocksdb", version = "0.15.1" }
-miden-node-block-producer       = { path = "crates/block-producer", version = "0.15.1" }
-miden-node-db                   = { path = "crates/db", version = "0.15.1" }
-miden-node-grpc-error-macro     = { path = "crates/grpc-error-macro", version = "0.15.1" }
-miden-node-proto                = { path = "crates/proto", version = "0.15.1" }
-miden-node-proto-build          = { path = "proto", version = "0.15.1" }
-miden-node-rpc                  = { path = "crates/rpc", version = "0.15.1" }
-miden-node-store                = { path = "crates/store", version = "0.15.1" }
+miden-large-smt-backend-rocksdb = { path = "crates/large-smt-backend-rocksdb", version = "0.15.2" }
+miden-node-block-producer       = { path = "crates/block-producer", version = "0.15.2" }
+miden-node-db                   = { path = "crates/db", version = "0.15.2" }
+miden-node-grpc-error-macro     = { path = "crates/grpc-error-macro", version = "0.15.2" }
+miden-node-proto                = { path = "crates/proto", version = "0.15.2" }
+miden-node-proto-build          = { path = "proto", version = "0.15.2" }
+miden-node-rpc                  = { path = "crates/rpc", version = "0.15.2" }
+miden-node-store                = { path = "crates/store", version = "0.15.2" }
 miden-node-test-macro           = { path = "crates/test-macro" }
-miden-node-tracing-macro        = { path = "crates/tracing-macro", version = "0.15.1" }
-miden-node-utils                = { path = "crates/utils", version = "0.15.1" }
-miden-remote-prover-client      = { path = "crates/remote-prover-client", version = "0.15.1" }
+miden-node-tracing-macro        = { path = "crates/tracing-macro", version = "0.15.2" }
+miden-node-utils                = { path = "crates/utils", version = "0.15.2" }
+miden-remote-prover-client      = { path = "crates/remote-prover-client", version = "0.15.2" }
 # Temporary workaround until <https://github.com/rust-rocksdb/rust-rocksdb/pull/1029>
 # is part of `rocksdb-rust` release
-miden-node-rocksdb-cxx-linkage-fix = { path = "crates/rocksdb-cxx-linkage-fix", version = "0.15.1" }
+miden-node-rocksdb-cxx-linkage-fix = { path = "crates/rocksdb-cxx-linkage-fix", version = "0.15.2" }
 
 # miden-protocol dependencies. These should be updated in sync.
 # Requires the v0.15.2 patch release, which carries the network-account tx-script


### PR DESCRIPTION
## Summary

After merging https://github.com/0xMiden/node/pull/2362 I realized that I didn't bumped the internal crates version


Also @Mirko-von-Leipzig related to the changelog, should I do anything to generating and commiting it? Or it gets done on publishing?

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```
