### PR TITLE
fix(ntx-builder): keep alive main loop connection (#2362)

### DIFF
--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use miden_node_utils::tracing::miden_instrument;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use backon::ExponentialBuilder;
 use futures::stream::{BoxStream, TryStreamExt};
@@ -50,6 +50,17 @@ type BlockSubscriptionItem = Result<(SignedBlock, BlockNumber), RpcError>;
 /// connection cannot spin the reconnect loop. Connection *failures* are already backed off
 /// exponentially inside [`RpcClient::block_subscription_with_retry`].
 const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+
+/// How long a single `stream.next()` poll waits before re-evaluating liveness.
+const BLOCK_POLL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Maximum time without a committed block before treating the subscription as stalled and forcing a
+/// reconnect.
+///
+/// This is a defensive backstop for a silently dropped connection that never surfaces an error on
+/// its own (client HTTP/2 keepalive is the primary, faster detector). It must be comfortably larger
+/// than the node's block interval so a legitimately quiet chain is not mistaken for a stall.
+const STALL_TIMEOUT: Duration = Duration::from_mins(2);
 
 /// Thin wrapper around the node RPC gRPC service that the ntx-builder uses to consume the
 /// committed-block subscription stream.
@@ -168,15 +179,24 @@ impl RpcClient {
         let client = self.clone();
 
         futures::stream::unfold(
-            (client, block_from, None),
-            |(client, mut next_from, mut inner)| async move {
+            (client, block_from, None, Instant::now()),
+            |(client, mut next_from, mut inner, mut last_block)| async move {
                 loop {
                     // Open the subscription if we don't hold a live one. The connect itself retries
                     // indefinitely with exponential backoff.
                     let stream = match &mut inner {
                         Some(stream) => stream,
                         None => match client.block_subscription_with_retry(next_from).await {
-                            Ok(stream) => inner.insert(stream),
+                            Ok(stream) => {
+                                tracing::info!(
+                                    target: COMPONENT, %next_from,
+                                    "block subscription connected",
+                                );
+                                // Reset the stall clock so time spent (re)connecting is not counted
+                                // against the next block's arrival.
+                                last_block = Instant::now();
+                                inner.insert(stream)
+                            },
                             Err(err) => {
                                 tracing::warn!(
                                     target: COMPONENT, err = %err.as_report(), %next_from,
@@ -188,23 +208,50 @@ impl RpcClient {
                         },
                     };
 
-                    match stream.next().await {
-                        Some(Ok((block, committed_tip))) => {
+                    // Poll on a short timeout so a silently dropped connection stays observable.
+                    // Each quiet poll emits a liveness log; once no block has arrived for
+                    // `STALL_TIMEOUT` the subscription is treated as stalled and reconnected.
+                    match tokio::time::timeout(BLOCK_POLL_TIMEOUT, stream.next()).await {
+                        Ok(Some(Ok((block, committed_tip)))) => {
                             next_from = block.header().block_num().child();
-                            return Some((Ok((block, committed_tip)), (client, next_from, inner)));
+                            last_block = Instant::now();
+                            return Some((
+                                Ok((block, committed_tip)),
+                                (client, next_from, inner, last_block),
+                            ));
                         },
-                        Some(Err(err)) => tracing::warn!(
+                        Ok(Some(Err(err))) => tracing::warn!(
                             target: COMPONENT, err = %err.as_report(), %next_from,
                             "block subscription failed, reconnecting",
                         ),
-                        None => tracing::warn!(
+                        Ok(None) => tracing::warn!(
                             target: COMPONENT, %next_from,
                             "block subscription closed by node, reconnecting",
                         ),
+                        Err(_elapsed) => {
+                            let idle = last_block.elapsed();
+                            if idle < STALL_TIMEOUT {
+                                // Quiet but not yet stalled: emit a liveness signal and keep
+                                // polling the same stream instead of reconnecting.
+                                tracing::debug!(
+                                    target: COMPONENT, %next_from,
+                                    idle = %humantime::format_duration(Duration::from_secs(idle.as_secs())),
+                                    "no block received recently; subscription still open",
+                                );
+                                continue;
+                            }
+                            tracing::warn!(
+                                target: COMPONENT, %next_from,
+                                idle = %humantime::format_duration(Duration::from_secs(idle.as_secs())),
+                                stall_timeout = %humantime::format_duration(STALL_TIMEOUT),
+                                "no block received within stall timeout; treating subscription as stalled, reconnecting",
+                            );
+                        },
                     }
 
-                    // The subscription dropped: discard it, pace the reconnect, and resume from the
-                    // next un-applied block on the following loop iteration.
+                    // Reached on an error/close/stall branch: discard the stream, pace the
+                    // reconnect, and resume from the next un-applied block on the following
+                    // iteration.
                     inner = None;
                     tokio::time::sleep(RECONNECT_DELAY).await;
                 }

--- a/crates/proto/src/clients/mod.rs
+++ b/crates/proto/src/clients/mod.rs
@@ -376,12 +376,25 @@ impl<State> Builder<State> {
     }
 }
 
+/// Client HTTP/2 keepalive interval.
+const HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(20);
+/// Client HTTP/2 keepalive: how long to wait for a PING ack before considering the connection dead.
+const HTTP2_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+/// OS-level TCP keepalive backstop for direct (non-proxied) connections.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
+
 impl Builder<WantsTls> {
     /// Create a new strict builder from a gRPC endpoint URL such as `http://localhost:8080` or
     /// `https://api.example.com:443`.
     pub fn new(url: Url) -> Builder<WantsTls> {
         let endpoint = Endpoint::from_shared(String::from(url))
-            .expect("Url type always results in valid endpoint");
+            .expect("Url type always results in valid endpoint")
+            // Detect silently dropped connections so long-lived streams can't hang forever; see the
+            // keepalive constants above.
+            .http2_keep_alive_interval(HTTP2_KEEPALIVE_INTERVAL)
+            .keep_alive_timeout(HTTP2_KEEPALIVE_TIMEOUT)
+            .keep_alive_while_idle(true)
+            .tcp_keepalive(Some(TCP_KEEPALIVE));
 
         Builder {
             endpoint,


### PR DESCRIPTION

Cherry pick of https://github.com/0xMiden/node/pull/2362 squash commit

## Summary

Fixes the ntx-builder going permanently silent after a period of idle note traffic.

### How:
1. Keepalive on every gRPC client.
2. bound `stream.next()` with a timeout so a stalled subscription is force-reconnected even if no error is ever surfaced.
3. Periodic log that escalates to a warning after no block is applied for a while, so a stall is a distinct signal instead of silence indistinguishable from an idle chain.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "ntx-builder"
impact      = "fixed"
description = "Network accounts no longer stop reactivating after idle periods: gRPC clients now use HTTP/2 keepalive to detect silently dropped block-subscription connections, plus a subscription stall watchdog and a liveness heartbeat."
```