### PR TITLE
test: Benchmarks for lock free apply_block

### DIFF
--- a/bin/stress-test/src/main.rs
+++ b/bin/stress-test/src/main.rs
@@ -61,6 +61,50 @@ pub enum Command {
         account_update_blocks: usize,
     },
 
+    /// Benchmark read latency under concurrent write load.
+    ///
+    /// Seeds the store like `seed-store` while concurrent reader tasks continuously request the
+    /// latest block header (with its MMR proof) from the same in-process state. Reports read
+    /// latency percentiles alongside the usual seeding metrics, capturing how reads behave while
+    /// blocks are being applied.
+    BenchmarkMixed {
+        /// Directory in which to store the database and raw block data. If the directory contains a
+        /// database dump file, it will be replaced.
+        #[arg(short, long, value_name = "DATA_DIRECTORY")]
+        data_directory: PathBuf,
+
+        /// Number of accounts to create.
+        #[arg(short, long, value_name = "NUM_ACCOUNTS")]
+        num_accounts: NonZeroUsize,
+
+        /// Percentage of accounts that will be created as public accounts. The rest will be private
+        /// accounts.
+        #[arg(
+            short,
+            long,
+            value_name = "PUBLIC_ACCOUNTS_PERCENTAGE",
+            default_value = "0",
+            value_parser = clap::value_parser!(u8).range(0..=100)
+        )]
+        public_accounts_percentage: u8,
+
+        /// Number of entries to add to a deterministic storage map on every public account.
+        #[arg(long, value_name = "STORAGE_MAP_ENTRIES", default_value = "0")]
+        storage_map_entries: u32,
+
+        /// Number of distinct vault assets to add to every public account.
+        #[arg(long, value_name = "VAULT_ENTRIES", default_value = "1")]
+        vault_entries: NonZeroUsize,
+
+        /// Number of post-initialization blocks containing public account updates.
+        #[arg(long, value_name = "ACCOUNT_UPDATE_BLOCKS", default_value = "0")]
+        account_update_blocks: usize,
+
+        /// Number of concurrent reader tasks measuring read latency during seeding.
+        #[arg(short, long, value_name = "READERS", default_value = "8")]
+        readers: NonZeroUsize,
+    },
+
     /// Benchmark the performance of the store endpoints.
     BenchmarkStore {
         /// Store endpoint to test against.
@@ -136,6 +180,26 @@ async fn main() {
                 storage_map_entries,
                 vault_entries.get(),
                 account_update_blocks,
+            ))
+            .await;
+        },
+        Command::BenchmarkMixed {
+            data_directory,
+            num_accounts,
+            public_accounts_percentage,
+            storage_map_entries,
+            vault_entries,
+            account_update_blocks,
+            readers,
+        } => {
+            Box::pin(seeding::seed_store_with_readers(
+                data_directory,
+                num_accounts.get(),
+                public_accounts_percentage,
+                storage_map_entries,
+                vault_entries.get(),
+                account_update_blocks,
+                readers.get(),
             ))
             .await;
         },

--- a/bin/stress-test/src/seeding/mod.rs
+++ b/bin/stress-test/src/seeding/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -142,6 +143,34 @@ pub async fn seed_store(
     vault_entries: usize,
     account_update_blocks: usize,
 ) {
+    seed_store_with_readers(
+        data_directory,
+        num_accounts,
+        public_accounts_percentage,
+        storage_map_entries,
+        vault_entries,
+        account_update_blocks,
+        0,
+    )
+    .await;
+}
+
+/// Seeds the store while `readers` concurrent tasks measure read latency against the same state.
+///
+/// This is the mixed read/write benchmark: seeding provides a continuous block-application load,
+/// and each reader loops `get_block_header` (latest header plus MMR proof) against the live state,
+/// so the reported latencies capture how reads behave while blocks are being committed. With
+/// `readers == 0` this is plain seeding.
+#[expect(clippy::too_many_lines)]
+pub async fn seed_store_with_readers(
+    data_directory: PathBuf,
+    num_accounts: usize,
+    public_accounts_percentage: u8,
+    storage_map_entries: u32,
+    vault_entries: usize,
+    account_update_blocks: usize,
+    readers: usize,
+) {
     let start = Instant::now();
     assert!(num_accounts > 0, "--num-accounts must be greater than zero");
     assert!(vault_entries > 0, "--vault-entries must be greater than zero");
@@ -218,6 +247,17 @@ pub async fn seed_store(
         plan_account_batches(num_accounts, public_accounts_percentage, ACCOUNT_UPDATES_PER_BLOCK)
     };
 
+    // Spawn the benchmark readers before block generation starts so they observe the store under
+    // continuous write load for the whole run.
+    let stop_readers = Arc::new(AtomicBool::new(false));
+    let reader_tasks: Vec<_> = (0..readers)
+        .map(|_| {
+            let state = Arc::clone(&store_state);
+            let stop = Arc::clone(&stop_readers);
+            tokio::spawn(async move { read_latest_header_until(&state, &stop).await })
+        })
+        .collect();
+
     // start generating blocks
     let accounts_filepath = data_directory.join(ACCOUNTS_FILENAME);
     let data_directory =
@@ -243,8 +283,59 @@ pub async fn seed_store(
     ))
     .await;
 
+    // Stop the readers and report their latencies; they hold state references and the read phase
+    // should not include post-write quiescence.
+    let write_load_elapsed = start.elapsed();
+    stop_readers.store(true, Ordering::Relaxed);
+    let mut read_latencies = Vec::new();
+    for task in reader_tasks {
+        read_latencies.extend(task.await.expect("benchmark reader should not panic"));
+    }
+    if readers > 0 {
+        report_read_latencies(&read_latencies, readers, write_load_elapsed);
+    }
+
     println!("Total time: {:.3} seconds", start.elapsed().as_secs_f64());
     println!("{metrics}");
+}
+
+/// Loops `get_block_header` (latest header with MMR proof) against the state until `stop` is set,
+/// returning the latency of every request.
+///
+/// The request combines an in-memory read (opening the latest block's MMR proof, which contends
+/// with the writer's lock during block application) with a database header lookup, so it exercises
+/// the read path most exposed to concurrent block application.
+async fn read_latest_header_until(
+    state: &Arc<State>,
+    stop: &AtomicBool,
+) -> Vec<std::time::Duration> {
+    let mut latencies = Vec::new();
+    while !stop.load(Ordering::Relaxed) {
+        let start = Instant::now();
+        let (header, proof) = state
+            .get_block_header(None, true)
+            .await
+            .expect("get_block_header should succeed during seeding");
+        latencies.push(start.elapsed());
+        assert!(
+            header.is_some() && proof.is_some(),
+            "latest block header and MMR proof should exist"
+        );
+    }
+    latencies
+}
+
+/// Prints read-side statistics for the mixed read/write benchmark.
+#[expect(clippy::cast_precision_loss)]
+fn report_read_latencies(
+    latencies: &[std::time::Duration],
+    readers: usize,
+    elapsed: std::time::Duration,
+) {
+    println!("Concurrent read statistics ({readers} readers during seeding):");
+    println!("  Total reads: {}", latencies.len());
+    println!("  Reads per second: {:.0}", latencies.len() as f64 / elapsed.as_secs_f64());
+    crate::store::metrics::print_summary(latencies);
 }
 
 /// Generates batches of transactions to be inserted into the store.

--- a/bin/stress-test/src/store/mod.rs
+++ b/bin/stress-test/src/store/mod.rs
@@ -19,7 +19,7 @@ use tokio::fs;
 use crate::seeding::{ACCOUNTS_FILENAME, start_store};
 use crate::store::metrics::print_summary;
 
-mod metrics;
+pub(crate) mod metrics;
 
 // CONSTANTS
 // ================================================================================================


### PR DESCRIPTION
## Summary

These are benchmarks which will be used to compare results from #2345 work.

Preliminary results:

## Mixed read/write benchmark: lock-free store vs `next`

Workload: `benchmark-mixed -n 50000 -p 50 --storage-map-entries 64 --account-update-blocks 20 -r 16`
(238 blocks applied while 16 concurrent readers loop `get_block_header` with MMR proof; release build, identical parameters on both branches.)

| Metric | lock-free | `next` (locks) | Δ |
|---|---|---|---|
| Reads/sec | 83,770 | 73,834 | **+13%** |
| Total reads | 33.7M | 22.4M | +50% |
| P50 read latency | 90µs | 83µs | ~equal |
| P95 | 687µs | 664µs | ~equal |
| P99 | 1.26ms | 1.26ms | equal |
| **P99.9** | **4.1ms** | **9.8ms** | **2.4× better** |
| Avg block insertion | 426ms | 355ms | 20% slower (reader-contention artifact, see `-r 0` below) |
| Total seeding time | 405s | 304s | 33% slower (same artifact) |
| Avg get-batch-inputs | 2.0ms | 1.8ms | ~equal |

### Read side: confirms the thesis

P50–P99 are identical — uncontended reads cost the same on both branches. The entire
difference is in the extreme tail, exactly where lock waits live. On `next`, a read
arriving during a commit window waits for the writer's lock; with ~16 readers × 238
blocks those blocked samples are only ~0.02% of 22M reads, so they surface at P99.9
(9.8ms vs 4.1ms) and the true worst case is hidden — blocked reads on `next` can wait
up to a full insertion (~350ms), which the summary doesn't print (no max/P99.99).
Aggregate read throughput is also +13% despite the lock-free readers doing 50% more
total work.

### Write side: confirmed as a benchmark artifact

On `next`, the lock *throttles the readers*: during every commit, all 16 readers park
on the RwLock and donate their cores to the writer and the rayon block-building
pipeline. On the lock-free branch, wait-free readers never park — they run straight
through every commit, competing with the writer for CPU. `next` is not writing faster
because locks are cheaper; it is writing faster because its readers are forcibly
idled. A closed-loop, unthrottled reader workload maximizes this effect; production
readers are request-driven and would not saturate cores this way.

This was verified by re-running the identical workload with **zero readers**
(`seed-store`, same parameters), isolating the pure write path:

## Pure write path benchmark (`-r 0`): write perf is at parity

| Metric | lock-free | `next` (locks) | Δ |
|---|---|---|---|
| Avg block insertion | 262ms | 252ms | +4% (within run-to-run noise) |
| Total seeding time | 158.8s | 153.9s | +3% |
| Per-block insert spread | 228–345ms | 234–335ms | overlapping |
| Avg get-batch-inputs | 1.36ms | 1.11ms | +23% (µs-scale, ~once per block ≈ 60ms over the whole run) |

With no readers, the lock-free branch inserts blocks within 4% of `next`, and the
per-block distributions overlap almost entirely — so ≤4% (likely ~0) is the true cost
of the new commit path (per-block RocksDB snapshot creation and `ArcSwap` snapshot
publication). Putting all four data points together:

- `next`: 252ms → 355ms under 16 readers (**+41%** from reader CPU contention)
- lock-free: 262ms → 426ms under 16 readers (**+63%** from reader CPU contention)

Both writers slow down heavily when unthrottled readers saturate the machine; the
difference is that `next` partially shields its writer by stalling every reader
during every commit — which is precisely the read-tail cost the lock-free refactor
removes. The only measurable real regression is `get-batch-inputs` (+250µs per call,
once per block), which now reads through RocksDB snapshot views instead of the live
trees — a footnote, not a concern.

**Bottom line:** reads no longer stall behind block commits — the blocking tail is
gone (2.4× better P99.9, more at the unreported max) and read throughput is higher —
while the pure write path is unchanged (≤4%, within noise). The apparent write
slowdown in the mixed run is the writer no longer being subsidized by stalled
readers.

## Changelog

```toml
changelog = "none"
reason    = "Internal benchmark tooling for the stress-test binary only."
```