### PR TITLE
Update branch and release policy

### DIFF
--- a/.github/actions/verify-ruleset-target/action.yml
+++ b/.github/actions/verify-ruleset-target/action.yml
@@ -1,0 +1,124 @@
+# Verifies that a workflow's ref filters still match the ruleset intended to
+# protect every branch or tag that can trigger the workflow.
+name: "Verify ruleset target"
+description: "Verify a ruleset's target"
+
+inputs:
+  github-token:
+    description: "GitHub token with repository metadata read access"
+    required: true
+  ruleset-name:
+    description: "Exact name of the ruleset"
+    required: true
+  expected-patterns:
+    description: "JSON array of expected branch or tag patterns, without refs prefixes"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve ruleset ID
+      id: ruleset_id
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        RULESET_NAME: ${{ inputs.ruleset-name }}
+      run: |
+        set -euo pipefail
+
+        rulesets="$(
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/rulesets?includes_parents=true&per_page=100"
+        )"
+        matches="$(
+          jq -c --arg name "${RULESET_NAME}" \
+            '[.[] | select(.name == $name)]' <<< "${rulesets}"
+        )"
+        match_count="$(jq 'length' <<< "${matches}")"
+
+        if [[ "${match_count}" -ne 1 ]]; then
+          echo "::error::Expected exactly one ruleset named ${RULESET_NAME}, found ${match_count}"
+          exit 1
+        fi
+
+        ruleset_id="$(jq -r '.[0].id' <<< "${matches}")"
+        echo "id=${ruleset_id}" >> "${GITHUB_OUTPUT}"
+
+    - name: Fetch ruleset
+      id: ruleset
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        RULESET_ID: ${{ steps.ruleset_id.outputs.id }}
+      run: |
+        set -euo pipefail
+
+        ruleset="$(
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/rulesets/${RULESET_ID}?includes_parents=true" \
+            | jq -c .
+        )"
+        echo "json=${ruleset}" >> "${GITHUB_OUTPUT}"
+
+    - name: Resolve ruleset target prefix
+      id: target
+      shell: bash
+      env:
+        RULESET: ${{ steps.ruleset.outputs.json }}
+        RULESET_NAME: ${{ inputs.ruleset-name }}
+      run: |
+        set -euo pipefail
+
+        target="$(jq -r '.target' <<< "${RULESET}")"
+        case "${target}" in
+          branch)
+            ref_prefix="refs/heads/"
+            ;;
+          tag)
+            ref_prefix="refs/tags/"
+            ;;
+          *)
+            echo "::error::Ruleset ${RULESET_NAME} has unsupported target: ${target}"
+            exit 1
+            ;;
+        esac
+        echo "prefix=${ref_prefix}" >> "${GITHUB_OUTPUT}"
+
+    - name: Match targets
+      shell: bash
+      env:
+        RULESET: ${{ steps.ruleset.outputs.json }}
+        RULESET_NAME: ${{ inputs.ruleset-name }}
+        REF_PREFIX: ${{ steps.target.outputs.prefix }}
+        EXPECTED_PATTERNS: ${{ inputs.expected-patterns }}
+      run: |
+        set -euo pipefail
+
+        if ! expected_refs="$(
+          jq -ce --arg prefix "${REF_PREFIX}" '
+            if type == "array"
+              and length > 0
+              and all(.[]; type == "string" and length > 0)
+            then map($prefix + .) | sort
+            else error("expected-patterns must be a non-empty JSON array of strings")
+            end
+          ' <<< "${EXPECTED_PATTERNS}"
+        )"; then
+          echo "::error::Invalid expected-patterns input"
+          exit 1
+        fi
+
+        if ! jq -e \
+          --argjson expected_refs "${expected_refs}" '
+            .enforcement == "active"
+            and (.conditions.ref_name.include | sort) == $expected_refs
+            and .conditions.ref_name.exclude == []
+          ' <<< "${RULESET}" >/dev/null; then
+          actual="$(
+            jq -c \
+              '{target, enforcement, ref_name: .conditions.ref_name}' \
+              <<< "${RULESET}"
+          )"
+          echo "::error::Ruleset ${RULESET_NAME} target diverged from ${expected_refs}: ${actual}"
+          exit 1
+        fi

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,7 +2,7 @@ name: Docker Build Check
 
 on:
   push:
-    branches: [main, next]
+    branches: [next, "v*"]
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -14,7 +14,25 @@ env:
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
+  verify-ruleset:
+    name: Verify protected branch ruleset
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Verify protected branch ruleset target
+        uses: ./.github/actions/verify-ruleset-target
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ruleset-name: "Protected branches"
+          expected-patterns: '["next", "v*"]'
+
   docker-build:
+    needs: verify-ruleset
     runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,7 +2,7 @@ name: Docker Build Check
 
 on:
   push:
-    branches: [next, "v*"]
+    branches: [next, "release/v*"]
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -28,7 +28,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           ruleset-name: "Protected branches"
-          expected-patterns: '["next", "v*"]'
+          expected-patterns: '["next", "release/v*"]'
 
   docker-build:
     needs: verify-ruleset

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 env:
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
@@ -33,6 +32,9 @@ jobs:
 
   docker-build:
     needs: verify-ruleset
+    permissions:
+      contents: read
+      id-token: write
     runs-on: warp-ubuntu-latest-x64-8x
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Continuous integration jobs.
-# These get run on every pull-request, with Warp caches updated on push into `main` or `next`.
+# These run on every pull request, with Warp caches updated on pushes to protected branches.
 name: CI
 
 permissions:
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
       - next
+      - "v*"
     paths-ignore:
       - "**.txt"
   pull_request:
@@ -20,10 +20,10 @@ on:
 env:
   # Shared prefix key for the Rust caches.
   #
-  # Cache is trunk specific (next|main).
+  # Cache is specific to the target development or release branch.
   CACHE_PREFIX: rust-cache-${{ github.base_ref || github.ref_name }}
-  # Only trusted branch pushes should update caches; PRs restore from the target branch cache.
-  SAVE_CACHE: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next') }}
+  # Push triggers are limited to protected branches; PRs restore from the target branch cache.
+  SAVE_CACHE: ${{ github.event_name == 'push' }}
   # Reduce cache usage by removing debug information.
   CARGO_PROFILE_DEV_DEBUG: 0
 
@@ -119,6 +119,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Verify protected branch ruleset target
+        uses: ./.github/actions/verify-ruleset-target
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ruleset-name: "Protected branches"
+          expected-patterns: '["next", "v*"]'
       - name: Rustup
         run: rustup toolchain install --no-self-update
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - next
-      - "v*"
+      - "release/v*"
     paths-ignore:
       - "**.txt"
   pull_request:
@@ -124,7 +124,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           ruleset-name: "Protected branches"
-          expected-patterns: '["next", "v*"]'
+          expected-patterns: '["next", "release/v*"]'
       - name: Rustup
         run: rustup toolchain install --no-self-update
       - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "22.18.0"
-          cache: "npm"
-          cache-dependency-path: docs/external/package-lock.json
+          package-manager-cache: false
       - name: Install dependencies
         working-directory: ./docs/external
         run: npm ci

--- a/.github/workflows/cleanup-workflows.yml
+++ b/.github/workflows/cleanup-workflows.yml
@@ -40,7 +40,7 @@ jobs:
             while IFS= read -r ref; do
               git ls-tree -r "$ref" --name-only | grep '^.github/workflows/'
             done < <(
-              git for-each-ref --format='%(refname)' 'refs/remotes/origin/v*'
+              git for-each-ref --format='%(refname)' 'refs/remotes/origin/release/v*'
             )
           )
           printf "%s\n" "$WORKFLOWS"

--- a/.github/workflows/cleanup-workflows.yml
+++ b/.github/workflows/cleanup-workflows.yml
@@ -32,11 +32,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Workflows on main
-        id: main
+      - name: Workflows on release branches
+        id: releases
         run: |
-          git fetch origin main
-          WORKFLOWS=$(git ls-tree -r origin/main --name-only | grep '^.github/workflows/')
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+          WORKFLOWS=$(
+            while IFS= read -r ref; do
+              git ls-tree -r "$ref" --name-only | grep '^.github/workflows/'
+            done < <(
+              git for-each-ref --format='%(refname)' 'refs/remotes/origin/v*'
+            )
+          )
           printf "%s\n" "$WORKFLOWS"
           {
             echo "workflows<<EOF"
@@ -60,17 +66,17 @@ jobs:
         id: deleted
         env:
           GH_TOKEN: ${{ github.token }}
-          MAIN_WORKFLOWS: ${{ steps.main.outputs.workflows }}
           NEXT_WORKFLOWS: ${{ steps.next.outputs.workflows }}
+          RELEASE_WORKFLOWS: ${{ steps.releases.outputs.workflows }}
         run: |
           set -euo pipefail
 
-          # Union of `main` and `next` workflows as a JSON array of strings (paths)
+          # Union of workflows on `next` and all release branches.
           EXISTING=$(printf "%s\n%s\n" \
-            "$MAIN_WORKFLOWS" \
             "$NEXT_WORKFLOWS" \
+            "$RELEASE_WORKFLOWS" \
           )
-          EXISTING=$(echo "$EXISTING" | sort -u | jq -R . | jq -s .)
+          EXISTING=$(echo "$EXISTING" | sed '/^$/d' | sort -u | jq -R . | jq -s .)
 
           echo "Existing workflows:"
           echo "$EXISTING"
@@ -83,7 +89,7 @@ jobs:
           echo "Workflows on GitHub:"
           echo "$GITHUB"
 
-          # Find deleted workflows: present on GitHub but not in main/next
+          # Find workflows that no longer exist on any active branch.
           DELETED=$(echo "$GITHUB" | jq -c \
             --argjson existing "$EXISTING" '
               map(select(.path as $p | $existing | index($p) | not))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     tags:
+      # We can only apply a basic filter here, the proper filter is implemented in
+      # the tag ruleset "Release tags". We avoid duplicating that here and instead
+      # check the ruleset gate in a dedicated step below.
+      #
+      # This prevents drift between this workflow and the ruleset, as well as
+      # problems with the patterns using different "regex-like" engines. The ruleset
+      # remains the source of truth.
       - "v*"
 
 concurrency:
@@ -38,20 +45,49 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Check the tag against the `Release tags` ruleset, to ensure we only
+      # proceed if the `v*` tag actually is a valid release tag.
+      #
+      # This prevents running against tags that look like a release tag, but
+      # somehow avoided the actual ruleset checks.
+      - name: Verify release tag ruleset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ruleset_id="$(
+            gh api "repos/${REPO}/rulesets?targets=tag&includes_parents=true&per_page=100" \
+              --jq '.[] | select(.name == "Release tags") | .id'
+          )"
+          ruleset="$(
+            gh api "repos/${REPO}/rulesets/${ruleset_id}?includes_parents=true"
+          )"
+          pattern="$(jq -er '
+            select(.target == "tag" and .enforcement == "active")
+            | .conditions.ref_name.include[0]
+          ' <<< "${ruleset}")"
+
+          # Github uses `File.fnmatch` and not regex, so replicate that here.
+          if ! ruby -e '
+            pattern, ref = ARGV
+            exit(File.fnmatch?(pattern, ref, File::FNM_PATHNAME) ? 0 : 1)
+          ' "${pattern}" "${REF}"; then
+            echo "::error::${REF} is not targeted by the active Release tags ruleset"
+            exit 1
+          fi
+
       - name: Rustup
         run: rustup toolchain install --no-self-update
 
-      - name: Validate release tag and version
+      - name: Validate release version
         id: release
         env:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-            echo "::error::Release tags must look like v1.2.3 or v1.2.3-rc.1"
-            exit 1
-          fi
 
           version="${TAG#v}"
           metadata="$(cargo metadata --no-deps --format-version 1)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,46 +45,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Check the tag against the `Release tags` ruleset, to ensure we only
-      # proceed if the `v*` tag actually is a valid release tag.
-      #
-      # This prevents running against tags that look like a release tag, but
-      # somehow avoided the actual ruleset checks.
-      - name: Verify release tag ruleset
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          ruleset_id="$(
-            gh api "repos/${REPO}/rulesets?targets=tag&includes_parents=true&per_page=100" \
-              --jq '.[] | select(.name == "Release tags") | .id'
-          )"
-          ruleset="$(
-            gh api "repos/${REPO}/rulesets/${ruleset_id}?includes_parents=true"
-          )"
-
-          if ! jq -e --arg tag "${TAG}" '
-            select(.target == "tag" and .enforcement == "active")
-            | [
-                .rules[]
-                | select(
-                    .type == "tag_name_pattern"
-                    and .parameters.operator == "regex"
-                  )
-              ]
-            | length > 0
-              and all(
-                .[];
-                .parameters as $restriction
-                | ($tag | test($restriction.pattern)) != $restriction.negate
-              )
-          ' <<< "${ruleset}" >/dev/null; then
-            echo "::error::${TAG} does not satisfy the active Release tags ruleset"
-            exit 1
-          fi
+      # GitHub enforces the tag restrictions. This only guards against the
+      # workflow trigger and ruleset target drifting apart.
+      - name: Verify release tag ruleset target
+        uses: ./.github/actions/verify-ruleset-target
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ruleset-name: "Release tags"
+          expected-patterns: '["v*"]'
 
       - name: Rustup
         run: rustup toolchain install --no-self-update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Verify release tag ruleset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF: ${{ github.ref }}
           REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -65,17 +65,24 @@ jobs:
           ruleset="$(
             gh api "repos/${REPO}/rulesets/${ruleset_id}?includes_parents=true"
           )"
-          pattern="$(jq -er '
-            select(.target == "tag" and .enforcement == "active")
-            | .conditions.ref_name.include[0]
-          ' <<< "${ruleset}")"
 
-          # Github uses `File.fnmatch` and not regex, so replicate that here.
-          if ! ruby -e '
-            pattern, ref = ARGV
-            exit(File.fnmatch?(pattern, ref, File::FNM_PATHNAME) ? 0 : 1)
-          ' "${pattern}" "${REF}"; then
-            echo "::error::${REF} is not targeted by the active Release tags ruleset"
+          if ! jq -e --arg tag "${TAG}" '
+            select(.target == "tag" and .enforcement == "active")
+            | [
+                .rules[]
+                | select(
+                    .type == "tag_name_pattern"
+                    and .parameters.operator == "regex"
+                  )
+              ]
+            | length > 0
+              and all(
+                .[];
+                .parameters as $restriction
+                | ($tag | test($restriction.pattern)) != $restriction.negate
+              )
+          ' <<< "${ruleset}" >/dev/null; then
+            echo "::error::${TAG} does not satisfy the active Release tags ruleset"
             exit 1
           fi
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
-    branches: [main, next]
+    branches: [next, "v*"]
     paths:
       - ".github/workflows/**"
       - ".github/actions/**"
@@ -30,6 +30,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Verify protected branch ruleset target
+        uses: ./.github/actions/verify-ruleset-target
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ruleset-name: "Protected branches"
+          expected-patterns: '["next", "v*"]'
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
-    branches: [next, "v*"]
+    branches: [next, "release/v*"]
     paths:
       - ".github/workflows/**"
       - ".github/actions/**"
@@ -36,7 +36,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           ruleset-name: "Protected branches"
-          expected-patterns: '["next", "v*"]'
+          expected-patterns: '["next", "release/v*"]'
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miden node
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/node/blob/main/LICENSE)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/node/blob/next/LICENSE)
 [![CI][ci-badge]][ci-link]
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.93+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-node)](https://crates.io/crates/miden-node)

--- a/docs/internal/src/SUMMARY.md
+++ b/docs/internal/src/SUMMARY.md
@@ -4,6 +4,8 @@
 
 - [Overview](./index.md)
 - [Contributing](./contributing.md)
+- [Branching policy](./branching-policy.md)
+- [Release process](./releases.md)
 - [Navigating the codebase](./codebase.md)
 - [Monitoring](./monitoring.md)
 - [Components](./components.md)

--- a/docs/internal/src/branching-policy.md
+++ b/docs/internal/src/branching-policy.md
@@ -1,0 +1,35 @@
+# Branching policy
+
+The repository has two kinds of protected branches:
+
+- `next` is the active development branch and the default target for pull requests.
+- `vX.Y` is a maintained branch for a specific minor release line, for example `v0.16`.
+
+## Creating a version branch
+
+`next` may continue to represent the latest stable release line until development requires a breaking change. Before
+that change is merged, maintainers create the corresponding `vX.Y` branch from `next`. The version branch preserves the
+compatible release line while breaking development continues on `next`.
+
+Version branch names contain only the major and minor version. Each component is a non-negative integer without leading
+zeroes. Only repository administrators create new version branches.
+
+## Applying changes
+
+After a version branch is created, it permanently diverges from `next`. Releases are not promoted by merging `next` into
+a version branch or by merging a version branch back into `next`.
+
+Changes should target the branch where they are required:
+
+- New development targets `next`.
+- Maintenance changes target the applicable `vX.Y` branch.
+- A change needed on multiple branches is applied to each branch through its own pull request, normally by backporting
+  the original change.
+
+## Branch protection
+
+The `Protected branches` ruleset applies to `next` and all `vX.Y` branches. It prevents deletion and non-fast-forward
+updates, requires pull requests, and requires the repository's test status check.
+
+Administrators can bypass reviews and required checks through a pull request when necessary, but cannot bypass the pull
+request requirement. This preserves an audit trail for every protected branch change.

--- a/docs/internal/src/branching-policy.md
+++ b/docs/internal/src/branching-policy.md
@@ -3,33 +3,33 @@
 The repository has two kinds of protected branches:
 
 - `next` is the active development branch and the default target for pull requests.
-- `vX.Y` is a maintained branch for a specific minor release line, for example `v0.16`.
+- `release/vX.Y` is a maintained branch for a specific minor release line, for example `release/v0.16`.
 
-## Creating a version branch
+## Creating a release branch
 
 `next` may continue to represent the latest stable release line until development requires a breaking change. Before
-that change is merged, maintainers create the corresponding `vX.Y` branch from `next`. The version branch preserves the
-compatible release line while breaking development continues on `next`.
+that change is merged, maintainers create the corresponding `release/vX.Y` branch from `next`. The release branch
+preserves the compatible release line while breaking development continues on `next`.
 
-Version branch names contain only the major and minor version. Each component is a non-negative integer without leading
-zeroes. Only repository administrators create new version branches.
+The version portion of a release branch contains only the major and minor version. Each component is a non-negative
+integer without leading zeroes. Only repository administrators create new release branches.
 
 ## Applying changes
 
-After a version branch is created, it permanently diverges from `next`. Releases are not promoted by merging `next` into
-a version branch or by merging a version branch back into `next`.
+After a release branch is created, it permanently diverges from `next`. Releases are not promoted by merging `next` into
+a release branch or by merging a release branch back into `next`.
 
 Changes should target the branch where they are required:
 
 - New development targets `next`.
-- Maintenance changes target the applicable `vX.Y` branch.
+- Maintenance changes target the applicable `release/vX.Y` branch.
 - A change needed on multiple branches is applied to each branch through its own pull request, normally by backporting
   the original change.
 
 ## Branch protection
 
-The `Protected branches` ruleset applies to `next` and all `vX.Y` branches. It prevents deletion and non-fast-forward
-updates, requires pull requests, and requires the repository's test status check.
+The `Protected branches` ruleset applies to `next` and all `release/vX.Y` branches. It prevents deletion and
+non-fast-forward updates, requires pull requests, and requires the repository's test status check.
 
 Administrators can bypass reviews and required checks through a pull request when necessary, but cannot bypass the pull
 request requirement. This preserves an audit trail for every protected branch change.

--- a/docs/internal/src/contributing.md
+++ b/docs/internal/src/contributing.md
@@ -1,16 +1,16 @@
 # Contributing to Miden Node
 
-#### First off, thanks for taking the time to contribute!
+Thanks for taking the time to contribute. We want to make contributing to this project as easy and transparent as
+possible.
 
-We want to make contributing to this project as easy and transparent as possible.
+## Before you begin
 
-## Before you begin..
+Start by commenting your interest in the issue you want to address. This lets us assign the issue to you, prevents
+multiple people from repeating the same work, and gives us a place to add any context you may need.
 
-Start by commenting your interest in the issue you want to address - this let's us assign the issue to you and prevents
-multiple people from repeating the same work. This also lets us add any additional information or context you may need.
-
-We use the `next` branch as our active development branch. This means your work should fork off the `next` branch (and
-not `main`).
+Most contributions should branch from and target `next`. Maintenance work may instead target a version branch; see the
+[branching policy](./branching-policy.md) for details. If you are unsure which branch to use, confirm the target on the
+issue before starting work.
 
 ### Typos and low-effort contributions
 
@@ -27,7 +27,8 @@ for the review process.
 
 ## Pre-PR checklist
 
-Before submitting a PR, ensure that you're up to date by rebasing onto `next`, and that tests and lints pass by running:
+Before submitting a PR, ensure that you're up to date by rebasing onto the branch your pull request targets, and that
+tests and lints pass by running:
 
 ```sh
 # Runs the various lints

--- a/docs/internal/src/contributing.md
+++ b/docs/internal/src/contributing.md
@@ -8,7 +8,7 @@ possible.
 Start by commenting your interest in the issue you want to address. This lets us assign the issue to you, prevents
 multiple people from repeating the same work, and gives us a place to add any context you may need.
 
-Most contributions should branch from and target `next`. Maintenance work may instead target a version branch; see the
+Most contributions should branch from and target `next`. Maintenance work may instead target a release branch; see the
 [branching policy](./branching-policy.md) for details. If you are unsure which branch to use, confirm the target on the
 issue before starting work.
 

--- a/docs/internal/src/releases.md
+++ b/docs/internal/src/releases.md
@@ -1,8 +1,8 @@
 # Release process
 
-A release is created by tagging the commit to release. It does not require a merge between `next` and a version branch.
-The commit may be on `next` while it still represents that release line, or on the applicable `vX.Y` branch after the
-branches have diverged.
+A release is created by tagging the commit to release. It does not require a merge between `next` and a release branch.
+The commit may be on `next` while it still represents that release line, or on the applicable `release/vX.Y` branch
+after the branches have diverged.
 
 ## Release tags
 

--- a/docs/internal/src/releases.md
+++ b/docs/internal/src/releases.md
@@ -1,0 +1,32 @@
+# Release process
+
+A release is created by tagging the commit to release. It does not require a merge between `next` and a version branch.
+The commit may be on `next` while it still represents that release line, or on the applicable `vX.Y` branch after the
+branches have diverged.
+
+## Release tags
+
+Release tags use one of these forms:
+
+- `vX.Y.Z` for a stable release, for example `v0.16.2`.
+- `vX.Y.Z-suffix` for a prerelease, for example `v0.17.0-rc.1`.
+
+`X`, `Y`, and `Z` are non-negative integers without leading zeroes. A prerelease suffix must start with `-` and contain
+at least one character after it.
+
+The `Release tags` ruleset is the source of truth for the accepted tag format and restricts who can create, update, or
+delete release tags.
+
+## Creating a release
+
+1. Ensure the target commit is in a publishable state. Every publishable workspace package must use the same version.
+2. Create the release tag on that commit and push it to GitHub. The tag without its leading `v` must exactly match the
+   workspace package version.
+3. The `Release` workflow validates the tag and package versions, checks crate builds and the minimum supported Rust
+   version, dry-runs crate and Docker publishing, and publishes the Docker images.
+4. After those checks pass, the workflow creates the GitHub release and release notes, then starts the crates.io and
+   Debian publishing workflows.
+
+The workflow uses a broad `v*` trigger because GitHub Actions does not use the same pattern language as repository
+rulesets. Its preflight step verifies that this trigger still matches the target of the `Release tags` ruleset, while
+the ruleset itself enforces the release-tag format.


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

This PR changes our branch policy, and updates the dev documentation to reflect this as well as the release flow.

Its best to read the docs changes, but in summary:

- I am scrapping `main`
- It is replaced by a dedicated `vX.Y` release branch
- `next` remains the default dev branch
- Release branches never merge back or from `next` again

I've also added some rulesets to enforce admin/maintainer only rights to version branching and releasing.

I have already created `v0.15` from current `main`. Once this PR is merged, I will delete `main` and back-propagate the workflow changes to `v0.15`. And then remove the existing legacy branch protections (which don't use rulesets).

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->
```toml
changelog = "none"
reason    = "Internal change only."
```
