### PR TITLE
ntx-builder: actors self healing after error when submitting (#2371)

### DIFF
--- a/bin/ntx-builder/src/actor/mod.rs
+++ b/bin/ntx-builder/src/actor/mod.rs
@@ -353,7 +353,9 @@ impl AccountActor {
                     let tx_candidate = self.select_candidate(&account, chain_state).await?;
                     mode = match tx_candidate {
                         Some(candidate) => {
-                            let next = self.execute_transactions(account_id, candidate).await;
+                            let next = self
+                                .execute_transactions(account_id, candidate, &mut account)
+                                .await?;
                             // The actor did real work; push the idle deadline back.
                             idle_deadline = tokio::time::Instant::now() + self.config.idle_timeout;
                             next
@@ -515,12 +517,18 @@ impl AccountActor {
     /// error) are retried inside [`execute::NtxContext::execute_transaction`].
     /// Any error reaching this method is therefore terminal for the candidate: the batch's notes
     /// are marked failed and the actor moves on.
-    #[miden_instrument(name = "ntx.actor.execute_transactions", skip(self, tx_candidate))]
+    ///
+    /// On a submission rejection (`NtxError::Submission`), `account` is refreshed in place from the
+    /// DB before returning: the rejection usually means the in-memory account diverged from the
+    /// committed chain, so the next selection must build on the authoritative state rather than
+    /// re-declaring the stale commitment.
+    #[miden_instrument(name = "ntx.actor.execute_transactions", skip(self, tx_candidate, account))]
     async fn execute_transactions(
         &self,
         account_id: AccountId,
         tx_candidate: TransactionCandidate,
-    ) -> ActorMode {
+        account: &mut Account,
+    ) -> anyhow::Result<ActorMode> {
         let block_num = tx_candidate.chain_tip_header.block_num();
 
         // Execute the selected transaction.
@@ -547,7 +555,7 @@ impl AccountActor {
         );
 
         let execution_result = context.execute_transaction(tx_candidate).await;
-        match execution_result {
+        Ok(match execution_result {
             Ok(execute::NtxExecutionResult {
                 tx_id,
                 account_delta,
@@ -593,6 +601,13 @@ impl AccountActor {
                     "network transaction failed",
                 );
 
+                // A rejected submission (e.g. an account-commitment mismatch) means our in-memory
+                // account has diverged from the committed chain. Reload it from the DB below so the
+                // next selection builds on the authoritative state instead of re-declaring the same
+                // stale commitment. Resumption is gated on the next committed block by
+                // `NoViableNotes`, so this cannot hot-loop.
+                let submission_rejected = matches!(err, execute::NtxError::Submission(_));
+
                 // For `AllNotesFailed`, use the per-note errors which contain the specific reason
                 // each note failed (e.g. consumability check details).
                 let failed_notes: Vec<_> = match err {
@@ -617,9 +632,27 @@ impl AccountActor {
                     },
                 };
                 self.mark_notes_failed(&failed_notes, block_num).await;
+
+                if submission_rejected {
+                    if let Some(latest) = self
+                        .state
+                        .db
+                        .get_account(self.account_id)
+                        .await
+                        .context("failed to reload account after a rejected submission")?
+                    {
+                        tracing::info!(
+                            target: LOG_TARGET,
+                            %account_id,
+                            "reloaded account from the database after a rejected submission",
+                        );
+                        *account = latest;
+                    }
+                }
+
                 ActorMode::NoViableNotes
             },
-        }
+        })
     }
 
     /// Sends requests to the coordinator to cache note scripts fetched from the remote RPC service.


### PR DESCRIPTION
(cherry picked from commit 5066b383549b7448271ebf4d33a9530340b64328)

### Why

The network transaction builder's actor held a single in-memory copy of its account for its whole lifetime, refreshed from the DB only at spawn and on transaction expiry. When a submission was rejected (e.g. `AccountCommitmentMismatch`: the declared initial account commitment no longer matches the committed chain), the actor kept the stale in-memory account and re-executed against it, re-declaring the same stale commitment and failing repeatedly until an unrelated expiry or a respawn forced a reload. This showed up as repeated `SubmitProvenTx` rejections for a network account whose committed state had already moved on.

### How

On a submission rejection (`NtxError::Submission`), reload the account from the DB before the next selection, mirroring the existing expiry-reload path. Re-execution stays gated on the next committed block (the actor returns to `NoViableNotes`), so it re-syncs without tight-looping if the local DB is momentarily behind.


## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "ntx-builder"
impact      = "fixed"
description = "Reload account state from the database after a rejected submission so the actor stops re-submitting against a stale account commitment."
```