### PR TITLE
compose: support block explorer

### DIFF
--- a/compose/explorer.yml
+++ b/compose/explorer.yml
@@ -1,0 +1,10 @@
+# Midenscan is a third-party block explorer built and published by Gateway FM.
+include:
+  - explorer/database.yml
+  - explorer/migration.yml
+  - explorer/indexer.yml
+  - explorer/backend.yml
+  - explorer/frontend.yml
+
+volumes:
+  explorer-data:

--- a/compose/explorer/backend.yml
+++ b/compose/explorer/backend.yml
@@ -1,0 +1,35 @@
+services:
+  explorer-backend:
+    profiles: [explorer]
+    image: gatewayfm/midenscan-backend:v0.8.5
+    pull_policy: missing
+    environment:
+      DB_CONN: postgres://midenscan:midenscan@explorer-database:5432/midenscan?sslmode=disable
+      APP_ENVIRONMENT: development
+      SERVER_PLAYGROUND_ENABLED: "true"
+      SERVER_READ_TIMEOUT: 15s
+      SERVER_WRITE_TIMEOUT: 15s
+      SERVER_IDLE_TIMEOUT: 60s
+      SERVER_GRAPHQL_QUERY_CACHE_SIZE: "1000"
+      CORS_ALLOWED_ORIGINS: http://localhost:8080,http://127.0.0.1:8080
+      METRICS_ADDRESS: ":8200"
+      METRICS_NAMESPACE: midenscan
+      METRICS_SUBSYSTEM: api
+      METRICS_SCRAPE_INTERVAL: 15s
+      LOG_LEVEL: debug
+      LOG_ADD_SOURCE: "false"
+      GRACE_TIMEOUT: 15s
+      NETWORK_STATUS_URL: https://status.devnet.miden.io/status
+      NETWORK_STATUS_DASHBOARD_URL: https://status.devnet.miden.io
+      VERIFIED_COMPONENTS_URL: https://miden-playground-api.walnut.dev/verified-account-components/mdev
+      VERIFIED_COMPONENTS_TIMEOUT: 10s
+      VERIFIED_NOTES_URL: https://miden-playground-api.walnut.dev/verified-notes/mdev
+      VERIFIED_NOTES_TIMEOUT: 10s
+    ports:
+      - "127.0.0.1:8199:8199"
+    depends_on:
+      explorer-database:
+        condition: service_healthy
+      explorer-migration:
+        condition: service_completed_successfully
+    restart: unless-stopped

--- a/compose/explorer/database.yml
+++ b/compose/explorer/database.yml
@@ -1,0 +1,16 @@
+services:
+  explorer-database:
+    profiles: [explorer]
+    image: postgres:18
+    pull_policy: missing
+    environment:
+      POSTGRES_USER: midenscan
+      POSTGRES_PASSWORD: midenscan
+      POSTGRES_DB: midenscan
+    volumes:
+      - explorer-data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "midenscan", "-d", "midenscan"]
+      interval: 5s
+      timeout: 2s
+      retries: 10

--- a/compose/explorer/frontend.yml
+++ b/compose/explorer/frontend.yml
@@ -1,0 +1,16 @@
+services:
+  explorer-frontend:
+    profiles: [explorer]
+    image: gatewayfm/midenscan-frontend:v0.8.3
+    pull_policy: missing
+    environment:
+      GRAPHQL_URL: http://localhost:8199/graphql
+      # Gateway FM currently requires a named Miden network for frontend metadata.
+      MIDEN_NETWORK: devnet
+      GOOGLE_ANALYTICS: ""
+    ports:
+      - "127.0.0.1:8080:3000"
+    depends_on:
+      explorer-backend:
+        condition: service_started
+    restart: unless-stopped

--- a/compose/explorer/indexer.yml
+++ b/compose/explorer/indexer.yml
@@ -1,0 +1,18 @@
+services:
+  explorer-indexer:
+    profiles: [explorer]
+    image: gatewayfm/midenscan-indexer:v0.16.0
+    pull_policy: missing
+    environment:
+      POSTGRES_URL: postgres://midenscan:midenscan@explorer-database:5432/midenscan?sslmode=disable
+      RPC_URL: http://sequencer:57291
+      # Gateway FM currently requires a named Miden network even when RPC is local.
+      MIDEN_NETWORK: devnet
+    depends_on:
+      explorer-database:
+        condition: service_healthy
+      explorer-migration:
+        condition: service_completed_successfully
+      sequencer:
+        condition: service_started
+    restart: unless-stopped

--- a/compose/explorer/migration.yml
+++ b/compose/explorer/migration.yml
@@ -1,0 +1,11 @@
+services:
+  explorer-migration:
+    profiles: [explorer]
+    image: gatewayfm/midenscan-db-migration:v0.8.5
+    pull_policy: missing
+    environment:
+      POSTGRES_URL: postgres://midenscan:midenscan@explorer-database:5432/midenscan?sslmode=disable
+    depends_on:
+      explorer-database:
+        condition: service_healthy
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ include:
   - compose/ntx-builder.yml
   - compose/tx-prover.yml
   - compose/otel-collector.yml
+  - compose/explorer.yml
   - compose/telemetry.yml
   - compose/monitor.yml
 

--- a/docs/external/src/local-network-development.md
+++ b/docs/external/src/local-network-development.md
@@ -6,12 +6,13 @@ sidebar_position: 1
 # Local Network Development
 
 Use this guide to start a disposable Miden network for local development and testing. The provided Docker Compose setup
-includes a sequencer, three validators, a transaction prover, a network transaction builder, monitoring, and trace
-collection, so you can develop against a working environment without wiring the network services manually.
+includes a sequencer, three validators, a transaction prover, a network transaction builder, and optional block
+explorer, monitoring, and trace services, so you can develop against a working environment without wiring the network
+services manually.
 
-The Compose model lives in `docker-compose.yml` and uses profiles for optional telemetry and monitoring services. The
-guide uses `make` targets as shorthand for the underlying Docker image builds and Docker Compose commands; check the
-`Makefile` when you need the exact command.
+The Compose model lives in `docker-compose.yml` and uses profiles for optional explorer, telemetry, and monitoring
+services. The guide uses `make` targets as shorthand for the underlying Docker image builds and Docker Compose commands;
+check the `Makefile` when you need the exact command.
 
 This is not a production deployment guide and it is not the path for independent full node runners on an existing
 network.
@@ -48,11 +49,12 @@ docker compose -f "${COMPOSE_APPLICATION}" down -v
 ```
 
 The application includes an OpenTelemetry Collector that receives traces from the Miden services. Enable the optional
-Tempo, Grafana, and network monitor services with Compose profiles:
+Midenscan explorer, Tempo, Grafana, and network monitor services with Compose profiles:
 
 ```bash
 docker compose \
   -f "${COMPOSE_APPLICATION}" \
+  --profile explorer \
   --profile telemetry \
   --profile monitor \
   up -d
@@ -102,13 +104,28 @@ After `make local-network-delete`, run `make local-network-up` to bootstrap a fr
 
 Published ports are bound to `localhost`; the following services are available:
 
-| Service         | URL                      | Purpose                                          |
-| --------------- | ------------------------ | ------------------------------------------------ |
-| RPC API         | `http://localhost:57291` | Submit transactions and query local chain state. |
-| Grafana         | `http://localhost:3000`  | Inspect dashboards and traces.                   |
-| Network monitor | `http://localhost:3001`  | View local network health.                       |
-| Tempo HTTP API  | `http://localhost:3200`  | Query stored trace data.                         |
-| Tempo OTLP gRPC | `http://localhost:4317`  | Receive OpenTelemetry traces from services.      |
+| Service          | URL                             | Purpose                                          |
+| ---------------- | ------------------------------- | ------------------------------------------------ |
+| RPC API          | `http://localhost:57291`        | Submit transactions and query local chain state. |
+| Grafana          | `http://localhost:3000`         | Inspect dashboards and traces.                   |
+| Network monitor  | `http://localhost:3001`         | View local network health.                       |
+| Block explorer   | `http://localhost:8080`         | Browse locally indexed network data.             |
+| Explorer GraphQL | `http://localhost:8199/graphql` | Query the explorer backend.                      |
+| Tempo HTTP API   | `http://localhost:3200`         | Query stored trace data.                         |
+| Tempo OTLP gRPC  | `http://localhost:4317`         | Receive OpenTelemetry traces from services.      |
+
+## Block Explorer
+
+Enable the `explorer` profile to run the Gateway FM Midenscan frontend, backend, indexer, database, and database
+migration:
+
+```bash
+docker compose --profile explorer up -d
+```
+
+The indexer reads from the local sequencer and persists its state in the `explorer-data` volume. The frontend is
+available at `http://localhost:8080`, with its GraphQL API at `http://localhost:8199/graphql`. These third-party
+components are intended for local development and are not part of the Miden node implementation.
 
 ## Monitoring and Traces
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

This PR adds the block explorer under the `explorer` profile.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "general"
impact      = "added"
description = "Local dev network now bundles the block explorer"
```
