### PR TITLE
compose: use routing for easier naming

### DIFF
--- a/compose/explorer/backend.yml
+++ b/compose/explorer/backend.yml
@@ -11,7 +11,7 @@ services:
       SERVER_WRITE_TIMEOUT: 15s
       SERVER_IDLE_TIMEOUT: 60s
       SERVER_GRAPHQL_QUERY_CACHE_SIZE: "1000"
-      CORS_ALLOWED_ORIGINS: http://localhost:8080,http://127.0.0.1:8080
+      CORS_ALLOWED_ORIGINS: http://explorer.localhost,http://localhost:8080,http://127.0.0.1:8080
       METRICS_ADDRESS: ":8200"
       METRICS_NAMESPACE: midenscan
       METRICS_SUBSYSTEM: api

--- a/compose/explorer/frontend.yml
+++ b/compose/explorer/frontend.yml
@@ -4,7 +4,7 @@ services:
     image: gatewayfm/midenscan-frontend:v0.8.3
     pull_policy: missing
     environment:
-      GRAPHQL_URL: http://localhost:8199/graphql
+      GRAPHQL_URL: http://explorer.localhost/graphql
       # Gateway FM currently requires a named Miden network for frontend metadata.
       MIDEN_NETWORK: devnet
       GOOGLE_ANALYTICS: ""

--- a/compose/faucet.yml
+++ b/compose/faucet.yml
@@ -27,7 +27,7 @@ services:
 
         exec /usr/local/bin/entrypoint.sh start
     environment:
-      MIDEN_FAUCET_API_PUBLIC_URL: http://localhost:8000
+      MIDEN_FAUCET_API_PUBLIC_URL: http://faucet.localhost/api
       MIDEN_FAUCET_DECIMALS: ${MIDEN_FAUCET_DECIMALS:-6}
       MIDEN_FAUCET_ENABLE_OTEL: "true"
       MIDEN_FAUCET_MAX_SUPPLY: ${MIDEN_FAUCET_MAX_SUPPLY:-100000000000000000}

--- a/compose/router.yml
+++ b/compose/router.yml
@@ -1,0 +1,60 @@
+# Caddy provides stable browser-facing hostnames while Compose service DNS
+# continues to handle container-to-container traffic.
+services:
+  router:
+    image: caddy:2.11.4-alpine
+    pull_policy: missing
+    configs:
+      - source: caddy
+        target: /etc/caddy/Caddyfile
+    ports:
+      - "127.0.0.1:80:80"
+    restart: unless-stopped
+
+configs:
+  caddy:
+    content: |
+      {
+        admin off
+        auto_https off
+      }
+
+      http://rpc.localhost {
+        reverse_proxy sequencer:57291
+      }
+
+      http://prover.localhost {
+        reverse_proxy tx-prover:50051
+      }
+
+      http://faucet.localhost {
+        handle_path /api/* {
+          reverse_proxy faucet:8000
+        }
+
+        handle {
+          reverse_proxy faucet:8080
+        }
+      }
+
+      http://explorer.localhost {
+        handle /graphql* {
+          reverse_proxy explorer-backend:8199
+        }
+
+        handle {
+          reverse_proxy explorer-frontend:3000
+        }
+      }
+
+      http://grafana.localhost {
+        reverse_proxy grafana:3000
+      }
+
+      http://monitor.localhost {
+        reverse_proxy monitor:3001
+      }
+
+      http://tempo.localhost {
+        reverse_proxy tempo:3200
+      }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ include:
   - compose/ntx-builder.yml
   - compose/tx-prover.yml
   - compose/otel-collector.yml
+  - compose/router.yml
   - compose/faucet.yml
   - compose/explorer.yml
   - compose/telemetry.yml

--- a/docs/external/src/local-network-development.md
+++ b/docs/external/src/local-network-development.md
@@ -103,19 +103,24 @@ After `make local-network-delete`, run `make local-network-up` to bootstrap a fr
 
 ## Exposed Endpoints
 
-Published ports are bound to `localhost`; the following services are available:
+The bundled Caddy router listens on port 80 and routes `.localhost` host names to services on the Compose network. Names
+under `.localhost` resolve to the local loopback address, so they require no hosts-file or external DNS changes. Port 80
+must be available on the host.
 
-| Service          | URL                             | Purpose                                          |
-| ---------------- | ------------------------------- | ------------------------------------------------ |
-| RPC API          | `http://localhost:57291`        | Submit transactions and query local chain state. |
-| Grafana          | `http://localhost:3000`         | Inspect dashboards and traces.                   |
-| Network monitor  | `http://localhost:3001`         | View local network health.                       |
-| Block explorer   | `http://localhost:8080`         | Browse locally indexed network data.             |
-| Faucet API       | `http://localhost:8000`         | Request tokens programmatically.                 |
-| Faucet frontend  | `http://localhost:8081`         | Request tokens through the faucet UI.            |
-| Explorer GraphQL | `http://localhost:8199/graphql` | Query the explorer backend.                      |
-| Tempo HTTP API   | `http://localhost:3200`         | Query stored trace data.                         |
-| Tempo OTLP gRPC  | `http://localhost:4317`         | Receive OpenTelemetry traces from services.      |
+Existing direct ports remain available for native gRPC clients, automation, and compatibility:
+
+| Service            | Routed URL                          | Direct address                    |
+| ------------------ | ----------------------------------- | --------------------------------- |
+| RPC API (gRPC-Web) | `http://rpc.localhost`              | `localhost:57291` for native gRPC |
+| Transaction prover | `http://prover.localhost`           | Not published directly            |
+| Faucet frontend    | `http://faucet.localhost`           | `http://localhost:8081`           |
+| Faucet API         | `http://faucet.localhost/api`       | `http://localhost:8000`           |
+| Block explorer     | `http://explorer.localhost`         | `http://localhost:8080`           |
+| Explorer GraphQL   | `http://explorer.localhost/graphql` | `http://localhost:8199/graphql`   |
+| Grafana            | `http://grafana.localhost`          | `http://localhost:3000`           |
+| Network monitor    | `http://monitor.localhost`          | `http://localhost:3001`           |
+| Tempo HTTP API     | `http://tempo.localhost`            | `http://localhost:3200`           |
+| Tempo OTLP gRPC    | Not routed                          | `localhost:4317`                  |
 
 ## Block Explorer
 
@@ -127,7 +132,7 @@ docker compose --profile explorer up -d
 ```
 
 The indexer reads from the local sequencer and persists its state in the `explorer-data` volume. The frontend is
-available at `http://localhost:8080`, with its GraphQL API at `http://localhost:8199/graphql`. These third-party
+available at `http://explorer.localhost`, with its GraphQL API at `http://explorer.localhost/graphql`. These third-party
 components are intended for local development and are not part of the Miden node implementation.
 
 ## Faucet
@@ -136,7 +141,8 @@ The faucet is maintained in the separate [0xMiden/faucet](https://github.com/0xM
 behind the node's protocol version. It is therefore excluded from the default stack. Enable its profile explicitly:
 
 ```bash
-docker compose --profile faucet up -d --build
+docker compose --profile faucet build faucet
+docker compose --profile faucet up -d
 ```
 
 For a repository checkout, the first run builds the exact upstream commit pinned in `compose/faucet.yml`. Node releases
@@ -144,8 +150,8 @@ publish an image built from the same pin, so the published Compose application c
 build.
 
 On its first successful start, the service creates a fungible faucet account and stores it in the `faucet-data` volume.
-Later starts reuse that account. The API is available at `http://localhost:8000` and the frontend at
-`http://localhost:8081`.
+Later starts reuse that account. The API is available at `http://faucet.localhost/api` and the frontend at
+`http://faucet.localhost`.
 
 The default token symbol is `MIDEN`, with 6 decimals and a maximum supply of `100000000000000000` base units. Override
 these before the first successful start with `MIDEN_FAUCET_TOKEN_SYMBOL`, `MIDEN_FAUCET_DECIMALS`, and
@@ -154,13 +160,13 @@ these before the first successful start with `MIDEN_FAUCET_TOKEN_SYMBOL`, `MIDEN
 ## Monitoring and Traces
 
 The bundled OpenTelemetry Collector receives traces from the local network. With the telemetry profile enabled, it
-forwards traces to Tempo. Grafana is preconfigured with Tempo as a data source, so use `http://localhost:3000` to
+forwards traces to Tempo. Grafana is preconfigured with Tempo as a data source, so use `http://grafana.localhost` to
 inspect traces when a request fails, stalls, or behaves differently than expected.
 
 Container logs are still useful for startup failures and quick checks, but traces usually provide a better view of how a
 request moved through the local network.
 
-The network monitor at `http://localhost:3001` provides a compact health view for the running local network.
+The network monitor at `http://monitor.localhost` provides a compact health view for the running local network.
 
 ## Prover Override
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Uses `caddy` to provide a nicer routing e.g. `rpc.localhost` instead of `localhost:<?port?>`.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "general"
impact      = "added"
description = "Local dev network now supports DNS e.g. `http://rpc.localhost`"
```
