### PR TITLE
compose: support note transport layer

### DIFF
--- a/compose/note-transport.yml
+++ b/compose/note-transport.yml
@@ -1,0 +1,28 @@
+# The note transport service is currently published for linux/amd64 only.
+# Keep it optional and allow a compatible image to be substituted on other
+# architectures.
+services:
+  note-transport:
+    profiles: [note-transport]
+    image: ${MIDEN_NOTE_TRANSPORT_IMAGE:-gatewayfm/miden-note-transport:v0.5.0-alpha.1}
+    pull_policy: missing
+    command:
+      - miden-note-transport-node
+      - --host
+      - 0.0.0.0
+      - --database-url
+      - /data/notes.sqlite3
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      OTEL_RESOURCE_ATTRIBUTES: service.instance.id=note-transport
+    volumes:
+      - note-transport-data:/data
+    ports:
+      - "127.0.0.1:57292:57292"
+    depends_on:
+      otel-collector:
+        condition: service_started
+    restart: unless-stopped
+
+volumes:
+  note-transport-data:

--- a/compose/otel-collector.yml
+++ b/compose/otel-collector.yml
@@ -80,6 +80,12 @@ configs:
           traces/local-null:
             receivers: [otlp/null]
             exporters: [file/null]
+          # The note transport service exports metrics whenever OTLP is
+          # enabled. Accept and discard them until this stack has a metrics
+          # backend, rather than returning an unimplemented response.
+          metrics/local-null:
+            receivers: [otlp]
+            exporters: [file/null]
         telemetry:
           logs:
             level: error

--- a/compose/router.yml
+++ b/compose/router.yml
@@ -27,6 +27,10 @@ configs:
         reverse_proxy tx-prover:50051
       }
 
+      http://ntl.localhost {
+        reverse_proxy note-transport:57292
+      }
+
       http://faucet.localhost {
         handle_path /api/* {
           reverse_proxy faucet:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@
 #   The insecure defaults correspond to the public keys in the genesis config
 #   in compose/bootstrap.yml and are intended only for local development.
 # - MIDEN_NODE_IMAGE, MIDEN_VALIDATOR_IMAGE, MIDEN_NTX_BUILDER_IMAGE,
-#   MIDEN_REMOTE_PROVER_IMAGE, MIDEN_NETWORK_MONITOR_IMAGE, and
-#   MIDEN_FAUCET_IMAGE: container images used by the local network. The core
-#   images default to the unqualified names built by the Makefile. The faucet
-#   defaults to the version built from the pinned upstream source in
-#   compose/faucet.yml.
+#   MIDEN_REMOTE_PROVER_IMAGE, MIDEN_NETWORK_MONITOR_IMAGE,
+#   MIDEN_FAUCET_IMAGE, and MIDEN_NOTE_TRANSPORT_IMAGE: container images used
+#   by the local network. The core images default to the unqualified names
+#   built by the Makefile. Optional external images default to their pinned
+#   versions in the corresponding Compose files.
 # - OTEL_EXPORTER_OTLP_ENDPOINT: optional additional OTLP/gRPC endpoint. Traces
 #   are always sent to the bundled collector, which forwards them to this
 #   endpoint and to Tempo when the telemetry profile is enabled.
@@ -23,6 +23,7 @@ include:
   - compose/node.yml
   - compose/ntx-builder.yml
   - compose/tx-prover.yml
+  - compose/note-transport.yml
   - compose/otel-collector.yml
   - compose/router.yml
   - compose/faucet.yml

--- a/docs/external/src/local-network-development.md
+++ b/docs/external/src/local-network-development.md
@@ -113,6 +113,7 @@ Existing direct ports remain available for native gRPC clients, automation, and 
 | ------------------ | ----------------------------------- | --------------------------------- |
 | RPC API (gRPC-Web) | `http://rpc.localhost`              | `localhost:57291` for native gRPC |
 | Transaction prover | `http://prover.localhost`           | Not published directly            |
+| Note transport     | `http://ntl.localhost`              | `localhost:57292` for native gRPC |
 | Faucet frontend    | `http://faucet.localhost`           | `http://localhost:8081`           |
 | Faucet API         | `http://faucet.localhost/api`       | `http://localhost:8000`           |
 | Block explorer     | `http://explorer.localhost`         | `http://localhost:8080`           |
@@ -134,6 +135,21 @@ docker compose --profile explorer up -d
 The indexer reads from the local sequencer and persists its state in the `explorer-data` volume. The frontend is
 available at `http://explorer.localhost`, with its GraphQL API at `http://explorer.localhost/graphql`. These third-party
 components are intended for local development and are not part of the Miden node implementation.
+
+## Note Transport
+
+The [Miden Note Transport service](https://github.com/0xMiden/note-transport-service) exchanges private notes between
+clients. Enable its optional profile explicitly:
+
+```bash
+docker compose --profile note-transport up -d
+```
+
+Its browser-facing gRPC-Web endpoint is `http://ntl.localhost`; native gRPC clients can use `localhost:57292`. Notes are
+persisted in the `note-transport-data` volume.
+
+The pinned Gateway FM image currently supports only `linux/amd64`. On another architecture, set
+`MIDEN_NOTE_TRANSPORT_IMAGE` to a compatible build before enabling the profile.
 
 ## Faucet
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Title. Available at `http://ntl.localhost`.

Closes #1886 

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "general"
impact      = "added"
description = "Local dev network now supports the note transaction layer"
```
