### PR TITLE
compose: embed validator key setup & caddy extension

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -54,6 +54,10 @@ jobs:
           - component: network-monitor
             bin: miden-network-monitor
             port: 3000
+          # The benchmark is a one-shot CLI, so build the portless runtime-tool stage.
+          - component: node-tps-benchmark
+            bin: miden-benchmark
+            target: runtime-tool
           - component: faucet
             bin: miden-faucet
             port: 8000
@@ -93,6 +97,7 @@ jobs:
           context: ${{ steps.build-inputs.outputs.context }}
           push: false
           file: ${{ steps.build-inputs.outputs.file }}
+          target: ${{ matrix.target }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
           pull: true
@@ -123,6 +128,7 @@ jobs:
           MIDEN_NTX_BUILDER_IMAGE: ghcr.io/0xmiden/miden-ntx-builder:dry-run
           MIDEN_REMOTE_PROVER_IMAGE: ghcr.io/0xmiden/miden-remote-prover:dry-run
           MIDEN_NETWORK_MONITOR_IMAGE: ghcr.io/0xmiden/miden-network-monitor:dry-run
+          MIDEN_BENCHMARK_IMAGE: ghcr.io/0xmiden/miden-node-tps-benchmark:dry-run
           MIDEN_FAUCET_IMAGE: ghcr.io/0xmiden/miden-faucet:dry-run
         with:
           compose-file: docker-compose.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,10 @@ jobs:
           - component: network-monitor
             bin: miden-network-monitor
             port: 3000
+          # The benchmark is a one-shot CLI, so build the portless runtime-tool stage.
+          - component: node-tps-benchmark
+            bin: miden-benchmark
+            target: runtime-tool
           - component: faucet
             bin: miden-faucet
             port: 8000
@@ -307,6 +311,7 @@ jobs:
           context: ${{ steps.build-inputs.outputs.context }}
           push: false
           file: ${{ steps.build-inputs.outputs.file }}
+          target: ${{ matrix.target }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
           pull: true
@@ -341,6 +346,8 @@ jobs:
           MIDEN_REMOTE_PROVER_IMAGE: ${{ env.REGISTRY }}/0xmiden/miden-remote-prover:${{ needs.preflight.outputs.tag }}
           MIDEN_NETWORK_MONITOR_IMAGE:
             ${{ env.REGISTRY }}/0xmiden/miden-network-monitor:${{ needs.preflight.outputs.tag }}
+          MIDEN_BENCHMARK_IMAGE:
+            ${{ env.REGISTRY }}/0xmiden/miden-node-tps-benchmark:${{ needs.preflight.outputs.tag }}
           MIDEN_FAUCET_IMAGE: ${{ env.REGISTRY }}/0xmiden/miden-faucet:${{ needs.preflight.outputs.tag }}
         with:
           compose-file: docker-compose.yml
@@ -379,6 +386,10 @@ jobs:
           - component: network-monitor
             bin: miden-network-monitor
             port: 3000
+          # The benchmark is a one-shot CLI, so build the portless runtime-tool stage.
+          - component: node-tps-benchmark
+            bin: miden-benchmark
+            target: runtime-tool
           - component: faucet
             bin: miden-faucet
             port: 8000
@@ -432,6 +443,7 @@ jobs:
           context: ${{ steps.build-inputs.outputs.context }}
           push: true
           file: ${{ steps.build-inputs.outputs.file }}
+          target: ${{ matrix.target }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
           pull: false
@@ -476,6 +488,8 @@ jobs:
           MIDEN_REMOTE_PROVER_IMAGE: ${{ env.REGISTRY }}/0xmiden/miden-remote-prover:${{ needs.preflight.outputs.tag }}
           MIDEN_NETWORK_MONITOR_IMAGE:
             ${{ env.REGISTRY }}/0xmiden/miden-network-monitor:${{ needs.preflight.outputs.tag }}
+          MIDEN_BENCHMARK_IMAGE:
+            ${{ env.REGISTRY }}/0xmiden/miden-node-tps-benchmark:${{ needs.preflight.outputs.tag }}
           MIDEN_FAUCET_IMAGE: ${{ env.REGISTRY }}/0xmiden/miden-faucet:${{ needs.preflight.outputs.tag }}
         with:
           compose-file: docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,13 +110,15 @@ RUN --mount=type=cache,sharing=shared,id=cargo-registry-local-${TARGETARCH},targ
         --bin miden-validator \
         --bin miden-ntx-builder \
         --bin miden-network-monitor \
-        --bin miden-remote-prover && \
+        --bin miden-remote-prover \
+        --bin miden-benchmark && \
     mkdir -p /app/bin && \
     cp /app/target/release/miden-node \
         /app/target/release/miden-validator \
         /app/target/release/miden-ntx-builder \
         /app/target/release/miden-network-monitor \
         /app/target/release/miden-remote-prover \
+        /app/target/release/miden-benchmark \
         /app/bin/
 
 # Alias stage so the runtime COPY below can select a builder via build arg.
@@ -130,9 +132,8 @@ RUN apt-get update && \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-FROM runtime-base AS runtime
+FROM runtime-base AS runtime-common
 ARG BIN
-ARG PORT
 COPY --from=build-result /app/bin/${BIN} /usr/local/bin/${BIN}
 LABEL org.opencontainers.image.authors=devops@miden.team \
     org.opencontainers.image.url=https://0xMiden.github.io/ \
@@ -146,7 +147,14 @@ ARG COMMIT
 LABEL org.opencontainers.image.created=$CREATED \
     org.opencontainers.image.version=$VERSION \
     org.opencontainers.image.revision=$COMMIT
-EXPOSE ${PORT}
 # Use exec to replace the shell so the binary runs as PID 1.
 ENV MIDEN_BIN=${BIN}
 CMD ["/bin/sh", "-c", "exec /usr/local/bin/$MIDEN_BIN"]
+
+# Command-line tools do not listen on a port.
+FROM runtime-common AS runtime-tool
+
+# Keep the default final target for the network's long-running services.
+FROM runtime-common AS runtime
+ARG PORT
+EXPOSE ${PORT}

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ local-network-logs: ## Follows logs for the local development network
 	$(DOCKER_COMMAND) compose $(COMPOSE_OVERRIDE_ARGS) $(COMPOSE_PROFILE_ARGS) logs -f
 
 .PHONY: docker-build
-docker-build: docker-build-node docker-build-validator docker-build-ntx-builder docker-build-monitor docker-build-remote-prover ## Builds all Docker images
+docker-build: docker-build-node docker-build-validator docker-build-ntx-builder docker-build-monitor docker-build-remote-prover docker-build-benchmark ## Builds all Docker images
 
 .PHONY: docker-build-node
 docker-build-node: ## Builds the Miden node using Docker
@@ -281,6 +281,20 @@ docker-build-remote-prover: ## Builds the remote prover using Docker
                  --build-arg BIN=miden-remote-prover \
                  --build-arg PORT=50051 \
                  -t miden-remote-prover .
+
+.PHONY: docker-build-benchmark
+docker-build-benchmark: ## Builds the benchmark and seed tool image using Docker
+	@CREATED=$$(date -u +'%Y-%m-%dT%H:%M:%SZ') && \
+	VERSION="$(DOCKER_VERSION)" && \
+	COMMIT=$$(git rev-parse HEAD) && \
+	$(DOCKER_COMMAND) build $(DOCKER_PULL_ARG) $(DOCKER_PLATFORM_ARG) \
+                 --build-arg CREATED="$$CREATED" \
+                 --build-arg VERSION="$$VERSION" \
+                 --build-arg COMMIT="$$COMMIT" \
+                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
+                 --build-arg BIN=miden-benchmark \
+                 --target runtime-tool \
+                 -t miden-node-tps-benchmark .
 
 ## --- setup --------------------------------------------------------------------------------------
 

--- a/compose/router.yml
+++ b/compose/router.yml
@@ -7,6 +7,8 @@ services:
     configs:
       - source: caddy
         target: /etc/caddy/Caddyfile
+      - source: caddy-routes-default
+        target: /etc/caddy/routes/default.caddy
     ports:
       - "127.0.0.1:80:80"
     restart: unless-stopped
@@ -62,3 +64,9 @@ configs:
       http://tempo.localhost {
         reverse_proxy tempo:3200
       }
+
+      # Out-of-tree Compose overrides can mount additional routes here.
+      import routes/*.caddy
+  caddy-routes-default:
+    content: |
+      # Additional route files are supplied by out-of-tree Compose overrides.

--- a/compose/seed.yml
+++ b/compose/seed.yml
@@ -1,0 +1,58 @@
+# Run on demand against an already-running network:
+# docker compose run --rm --no-deps seed 5
+services:
+  seed:
+    profiles: [tools]
+    image: ${MIDEN_BENCHMARK_IMAGE:-miden-node-tps-benchmark}
+    pull_policy: missing
+    restart: "no"
+    working_dir: /tmp
+    environment:
+      MIDEN_SEED_RPC_URL: ${MIDEN_SEED_RPC_URL:-http://sequencer:57291}
+      MIDEN_SEED_REMOTE_PROVER_URL: ${MIDEN_REMOTE_PROVER_URL:-http://tx-prover:50051}
+      MIDEN_SEED_VALIDATOR_1_SIGNING_PUBLIC_KEY: ${MIDEN_SEED_VALIDATOR_1_SIGNING_PUBLIC_KEY:-031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f}
+      MIDEN_SEED_VALIDATOR_2_SIGNING_PUBLIC_KEY: ${MIDEN_SEED_VALIDATOR_2_SIGNING_PUBLIC_KEY:-02531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe337}
+      MIDEN_SEED_VALIDATOR_3_SIGNING_PUBLIC_KEY: ${MIDEN_SEED_VALIDATOR_3_SIGNING_PUBLIC_KEY:-03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b}
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        count="$${1:-}"
+        case "$${count}" in
+          ''|*[!0-9]*|0)
+            echo "usage: docker compose run --rm --no-deps seed <transaction-count>" >&2
+            exit 2
+            ;;
+        esac
+
+        echo "Generating proofs for $${count} consume transactions plus supporting mints..."
+        miden-benchmark create-proofs \
+          --rpc-url "$${MIDEN_SEED_RPC_URL}" \
+          --num-transactions "$${count}" \
+          --remote-prover-url "$${MIDEN_SEED_REMOTE_PROVER_URL}"
+
+        echo "Submitting generated transactions..."
+        for attempt in 1 2 3 4 5 6 7 8; do
+          for public_key in \
+            "$${MIDEN_SEED_VALIDATOR_1_SIGNING_PUBLIC_KEY}" \
+            "$${MIDEN_SEED_VALIDATOR_2_SIGNING_PUBLIC_KEY}" \
+            "$${MIDEN_SEED_VALIDATOR_3_SIGNING_PUBLIC_KEY}"
+          do
+            if miden-benchmark run-benchmark \
+              --rpc-url "$${MIDEN_SEED_RPC_URL}" \
+              --validator-signing-public-key "$${public_key}" \
+              --concurrency 2 \
+              --connections 2 \
+              --wait-blocks 25
+            then
+              exit 0
+            fi
+          done
+          echo "Validators are not ready; retrying in 10 seconds..."
+          sleep 10
+        done
+
+        echo "Unable to submit generated transactions" >&2
+        exit 1
+      - seed
+    command: []

--- a/compose/validator.yml
+++ b/compose/validator.yml
@@ -3,10 +3,17 @@ x-validator: &validator
   pull_policy: missing
   volumes:
     - node-data:/data
-    - type: bind
-      source: ${MIDEN_VALIDATOR_STORAGE_KEY_DIRECTORY:-../scripts/testdata/insecure-golden-storage-key}
-      target: /storage-key
-      read_only: true
+  configs:
+    - source: validator-storage-key-setup-context
+      target: /storage-key/setup-context.wire
+    - source: validator-storage-key-public-set
+      target: /storage-key/public-key-set.wire
+    - source: validator-1-storage-key-secret-share
+      target: /storage-key/validator-1/secret-share.wire
+    - source: validator-2-storage-key-secret-share
+      target: /storage-key/validator-2/secret-share.wire
+    - source: validator-3-storage-key-secret-share
+      target: /storage-key/validator-3/secret-share.wire
   depends_on:
     bootstrap-validator:
       condition: service_completed_successfully
@@ -60,3 +67,38 @@ services:
       MIDEN_VALIDATOR_STORAGE_KEY_SECRET_SHARE: /storage-key/validator-3/secret-share.wire
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_RESOURCE_ATTRIBUTES: service.instance.id=validator-3
+
+# Keep the deterministic fixture inside the Compose model so an OCI-published
+# application contains the exact wire files instead of host bind declarations.
+configs:
+  validator-storage-key-setup-context:
+    content: !!binary |
+      Z29sZGVuLWRrZy13aXJlLXYzIAAAAAAAAAAXZWh0ZGgxLXNldHVwLWNvbnRleHQtdjEAAAAAAAAA
+      GGhhbG8yY3VydmVzLXNlY3AyNTZrMS12MQAAAAAAAAACAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB
+      AQEBAQEBAQEAAAAAAAAAAwAAAAEAAAACAAAAAwICAgICAgICAgICAgICAgICAgICAgICAgICAgIC
+      AgICtaDoZ74NkWKEuOTpnChdjjyGQrgJrp2verzqgHEiiIQDAwMDAwMDAwMDAwMDAwMDAwMDAwMD
+      AwMDAwMDAwMDAwQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQECQkJCQkJCQkJCQkJCQkJ
+      CQkJCQkJCQkJCQkJCQkJCQk=
+  validator-storage-key-public-set:
+    content: !!binary |
+      Z29sZGVuLWRrZy13aXJlLXYzIQAAAAAAAAAYZWh0ZGgxLXB1YmxpYy1rZXktc2V0LXYxAAAAAAAA
+      ABhoYWxvMmN1cnZlcy1zZWNwMjU2azEtdjEAAAAAAAAAAoDLCKBdiRfsu5F4weULmElWrFrGcGsk
+      9F4eQalY+OdKdwAAAAAAAAADAAAAAQDMp01EosJVz+f1GaPRKLrzoA+ZStuGAiuNI3+0DFcBVoCo
+      WkAZj9/t3s1YDmHG+3WwUYZ0wwXS0ceLKHXZwnOH8gAAAAIAFDdF9dcMymnicpXghD08JoPa7Waw
+      qSGrjda0CZsnSJIAikwMcYGtXF6IQLirsuE/wJcJ5MjvvQz0WNVQtrXNh2YAAAADgGU+FAfU29B1
+      HaYEmbj8z9rOePPiVOC2Ry2itU/XmQHTAG+LMIYvXFVeQouba/XpUCxr5QjEBktb3tonDwTQCsaA
+  validator-1-storage-key-secret-share:
+    content: !!binary |
+      Z29sZGVuLWRrZy13aXJlLXYzIwAAAAAAAAAWZWh0ZGgxLXNlY3JldC1zaGFyZS12MQAAAAAAAAAY
+      aGFsbzJjdXJ2ZXMtc2VjcDI1NmsxLXYxAAAAARIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      AAAADQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  validator-2-storage-key-secret-share:
+    content: !!binary |
+      Z29sZGVuLWRrZy13aXJlLXYzIwAAAAAAAAAWZWh0ZGgxLXNlY3JldC1zaGFyZS12MQAAAAAAAAAY
+      aGFsbzJjdXJ2ZXMtc2VjcDI1NmsxLXYxAAAAAhkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      AAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+  validator-3-storage-key-secret-share:
+    content: !!binary |
+      Z29sZGVuLWRrZy13aXJlLXYzIwAAAAAAAAAWZWh0ZGgxLXNlY3JldC1zaGFyZS12MQAAAAAAAAAY
+      aGFsbzJjdXJ2ZXMtc2VjcDI1NmsxLXYxAAAAAyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      AAAAJwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,15 @@
 #   The insecure defaults correspond to the public keys in the genesis config
 #   in compose/bootstrap.yml and are intended only for local development.
 # - MIDEN_VALIDATOR_STORAGE_KEY_EPOCH: hex-encoded 32-byte Golden key epoch.
+# - MIDEN_SEED_RPC_URL and MIDEN_SEED_VALIDATOR_1_SIGNING_PUBLIC_KEY through
+#   MIDEN_SEED_VALIDATOR_3_SIGNING_PUBLIC_KEY: overrides used by the on-demand
+#   seed service.
 # - MIDEN_NODE_IMAGE, MIDEN_VALIDATOR_IMAGE, MIDEN_NTX_BUILDER_IMAGE,
 #   MIDEN_REMOTE_PROVER_IMAGE, MIDEN_NETWORK_MONITOR_IMAGE,
-#   MIDEN_FAUCET_IMAGE, and MIDEN_NOTE_TRANSPORT_IMAGE: container images used
-#   by the local network. The core images default to the unqualified names
-#   built by the Makefile. Optional external images default to their pinned
-#   versions in the corresponding Compose files.
+#   MIDEN_BENCHMARK_IMAGE, MIDEN_FAUCET_IMAGE, and MIDEN_NOTE_TRANSPORT_IMAGE:
+#   container images used by the local network. The core images default to the
+#   unqualified names built by the Makefile. Optional external images default
+#   to their pinned versions in the corresponding Compose files.
 # - OTEL_EXPORTER_OTLP_ENDPOINT: optional additional OTLP/gRPC endpoint. Traces
 #   are always sent to the bundled collector, which forwards them to this
 #   endpoint and to Tempo when the telemetry profile is enabled.
@@ -24,6 +27,7 @@ include:
   - compose/node.yml
   - compose/ntx-builder.yml
   - compose/tx-prover.yml
+  - compose/seed.yml
   - compose/note-transport.yml
   - compose/otel-collector.yml
   - compose/router.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,6 @@
 #   MIDEN_VALIDATOR_3_SIGNING_KEY: private signing keys for the three validators.
 #   The insecure defaults correspond to the public keys in the genesis config
 #   in compose/bootstrap.yml and are intended only for local development.
-# - MIDEN_VALIDATOR_STORAGE_KEY_DIRECTORY: host directory containing
-#   setup-context.wire, public-key-set.wire, and secret-share.wire. Defaults to
-#   the committed insecure test fixture.
 # - MIDEN_VALIDATOR_STORAGE_KEY_EPOCH: hex-encoded 32-byte Golden key epoch.
 # - MIDEN_NODE_IMAGE, MIDEN_VALIDATOR_IMAGE, MIDEN_NTX_BUILDER_IMAGE,
 #   MIDEN_REMOTE_PROVER_IMAGE, MIDEN_NETWORK_MONITOR_IMAGE,


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

The validator key setup used `bind` mounting to include the files off-disk. This no longer works once the compose file is published - host files are not bundled.

This PR embeds the same binary values directly instead. This is more fragile, but the understanding is that this might be replaced with a key ceremony in the future so its not a long lived change 🤞 

In addition, this PR allows the compose "DNS" to be extending i.e. caddy allows adding more routes if our compose file is extended externally.

And in addition, I've added support for seeding the database via the benchmark tool.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```

