### PR TITLE
compose: emulate ntl layer

### DIFF
--- a/compose/note-transport.yml
+++ b/compose/note-transport.yml
@@ -1,10 +1,11 @@
-# The note transport service is currently published for linux/amd64 only.
-# Keep it optional and allow a compatible image to be substituted on other
-# architectures.
+# The default image is currently published for linux/amd64 only. Pin its
+# platform so Docker uses emulation on other architectures. Both the image and
+# platform remain overridable for compatible native builds.
 services:
   note-transport:
     profiles: [note-transport]
     image: ${MIDEN_NOTE_TRANSPORT_IMAGE:-gatewayfm/miden-note-transport:v0.5.0-alpha.1}
+    platform: ${MIDEN_NOTE_TRANSPORT_PLATFORM:-linux/amd64}
     pull_policy: missing
     command:
       - miden-note-transport-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@
 #   container images used by the local network. The core images default to the
 #   unqualified names built by the Makefile. Optional external images default
 #   to their pinned versions in the corresponding Compose files.
+# - MIDEN_NOTE_TRANSPORT_PLATFORM: platform used by the note transport image.
+#   Defaults to linux/amd64 because the pinned image is not multi-architecture.
 # - OTEL_EXPORTER_OTLP_ENDPOINT: optional additional OTLP/gRPC endpoint. Traces
 #   are always sent to the bundled collector, which forwards them to this
 #   endpoint and to Tempo when the telemetry profile is enabled.

--- a/docs/external/src/local-network-development.md
+++ b/docs/external/src/local-network-development.md
@@ -148,8 +148,9 @@ docker compose --profile note-transport up -d
 Its browser-facing gRPC-Web endpoint is `http://ntl.localhost`; native gRPC clients can use `localhost:57292`. Notes are
 persisted in the `note-transport-data` volume.
 
-The pinned Gateway FM image currently supports only `linux/amd64`. On another architecture, set
-`MIDEN_NOTE_TRANSPORT_IMAGE` to a compatible build before enabling the profile.
+The pinned Gateway FM image currently supports only `linux/amd64`. Compose selects that platform explicitly, allowing
+Docker to run it through emulation on ARM hosts. To use a compatible native build instead, set both
+`MIDEN_NOTE_TRANSPORT_IMAGE` and `MIDEN_NOTE_TRANSPORT_PLATFORM`.
 
 ## Faucet
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Because its amd only.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->


```toml
changelog = "none"
reason    = "Internal change only."
```
