### PR TITLE
compose: http2 and faucet fix

### DIFF
--- a/compose/faucet.yml
+++ b/compose/faucet.yml
@@ -10,6 +10,7 @@ services:
       context: https://github.com/0xMiden/faucet.git#48d3af2c58ffe16a585314208c8ed93fc3dfea35
     volumes:
       - faucet-data:/faucet
+      - node-data:/data:ro
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
@@ -28,14 +29,12 @@ services:
         exec /usr/local/bin/entrypoint.sh start
     environment:
       MIDEN_FAUCET_API_PUBLIC_URL: http://faucet.localhost/api
-      MIDEN_FAUCET_DECIMALS: ${MIDEN_FAUCET_DECIMALS:-6}
       MIDEN_FAUCET_ENABLE_OTEL: "true"
-      MIDEN_FAUCET_MAX_SUPPLY: ${MIDEN_FAUCET_MAX_SUPPLY:-100000000000000000}
+      MIDEN_FAUCET_IMPORT_ACCOUNT_PATH: /data/accounts/faucet_miden.mac
       MIDEN_FAUCET_NETWORK: localhost
       MIDEN_FAUCET_NODE_URL: http://rpc.localhost
       MIDEN_FAUCET_REMOTE_TX_PROVER_URL: http://tx-prover:50051
       MIDEN_FAUCET_STORE: /faucet/store.sqlite
-      MIDEN_FAUCET_TOKEN_SYMBOL: ${MIDEN_FAUCET_TOKEN_SYMBOL:-MIDEN}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_RESOURCE_ATTRIBUTES: service.instance.id=faucet
     ports:

--- a/compose/router.yml
+++ b/compose/router.yml
@@ -9,6 +9,11 @@ services:
         target: /etc/caddy/Caddyfile
       - source: caddy-routes-default
         target: /etc/caddy/routes/default.caddy
+    # The faucet uses the public browser URL from inside the Compose network.
+    networks:
+      default:
+        aliases:
+          - rpc.localhost
     ports:
       - "127.0.0.1:80:80"
     restart: unless-stopped
@@ -22,15 +27,15 @@ configs:
       }
 
       http://rpc.localhost {
-        reverse_proxy sequencer:57291
+        reverse_proxy h2c://sequencer:57291
       }
 
       http://prover.localhost {
-        reverse_proxy tx-prover:50051
+        reverse_proxy h2c://tx-prover:50051
       }
 
       http://ntl.localhost {
-        reverse_proxy note-transport:57292
+        reverse_proxy h2c://note-transport:57292
       }
 
       http://faucet.localhost {

--- a/docs/external/src/local-network-development.md
+++ b/docs/external/src/local-network-development.md
@@ -165,13 +165,9 @@ For a repository checkout, the first run builds the exact upstream commit pinned
 publish an image built from the same pin, so the published Compose application can pull it without requiring a source
 build.
 
-On its first successful start, the service creates a fungible faucet account and stores it in the `faucet-data` volume.
-Later starts reuse that account. The API is available at `http://faucet.localhost/api` and the frontend at
-`http://faucet.localhost`.
-
-The default token symbol is `MIDEN`, with 6 decimals and a maximum supply of `100000000000000000` base units. Override
-these before the first successful start with `MIDEN_FAUCET_TOKEN_SYMBOL`, `MIDEN_FAUCET_DECIMALS`, and
-`MIDEN_FAUCET_MAX_SUPPLY`. Delete `faucet-data` before changing these initialization settings for an existing stack.
+On its first successful start, the service imports the native `MIDEN` faucet account created at genesis and stores its
+client state in the `faucet-data` volume. Later starts reuse that state. The API is available at
+`http://faucet.localhost/api` and the frontend at `http://faucet.localhost`.
 
 ## Monitoring and Traces
 


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Fix issues discovered by @igamigo 

- faucet wasn't importing the official faucet account from genesis, but instead creating a new one
- http2 is required for gRPC so enable that on the public routes (`h2c`)

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->


```toml
changelog = "none"
reason    = "Internal change only."
```
