### PR TITLE
fix(rpc): preserve terminal status when subscription buffer is full

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -50,3 +50,4 @@ miden-standards  = { workspace = true }
 reqwest          = { workspace = true }
 rstest           = { workspace = true }
 tempfile         = { workspace = true }
+tokio            = { features = ["test-util"], workspace = true }

--- a/crates/rpc/src/server/api/subscription/stream/mod.rs
+++ b/crates/rpc/src/server/api/subscription/stream/mod.rs
@@ -114,11 +114,18 @@ impl SubscriptionStream {
         Self::reject_banned_client(client_ip, &ban_list)?;
         let subscription_permit = Self::acquire_subscription_permit(subscription_semaphore)?;
 
-        let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
+        // Keep one channel slot reserved for the terminal status. This prevents a full data buffer
+        // from causing the terminal status to be dropped as well.
+        let (tx, rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY + 1);
+        let terminal_permit = tx
+            .clone()
+            .try_reserve_owned()
+            .expect("a newly created subscription channel must have capacity");
         let producer = SubscriptionProducer {
             next: from,
             chain_tip,
             tx,
+            terminal_permit,
             client_ip,
             ban_list,
             _subscription_permit: subscription_permit,
@@ -177,6 +184,7 @@ struct SubscriptionProducer<GetData> {
     next: BlockNumber,
     chain_tip: watch::Receiver<BlockNumber>,
     tx: mpsc::Sender<tonic::Result<StreamItem>>,
+    terminal_permit: mpsc::OwnedPermit<tonic::Result<StreamItem>>,
     client_ip: Option<IpAddr>,
     ban_list: Arc<IpBanList>,
     _subscription_permit: OwnedSemaphorePermit,
@@ -201,7 +209,7 @@ where
         if let (Some(ip), StreamError::SlowSubscriber) = (self.client_ip, err) {
             self.ban_list.add(ip);
         }
-        let _ = self.tx.try_send(Err(err.into_status()));
+        self.terminal_permit.send(Err(err.into_status()));
     }
 
     /// Produces stream items until a terminal stream error occurs.

--- a/crates/rpc/src/server/api/subscription/stream/tests.rs
+++ b/crates/rpc/src/server/api/subscription/stream/tests.rs
@@ -155,6 +155,32 @@ async fn shutdown_while_send_is_pending_reports_server_shutdown() {
     wait_for_subscription_exit(&source).await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn full_buffer_reports_slow_subscriber_before_eos() {
+    let (_tip_tx, tip_rx) = watch::channel(BlockNumber::from(SUBSCRIBER_CHANNEL_CAPACITY as u32));
+    let source = TestSubscription::default();
+    let fetch_count = source.fetch_count();
+    let mut stream = source
+        .stream(BlockNumber::GENESIS, tip_rx)
+        .expect("subscription start should be valid");
+
+    wait_for_fetch_count(&fetch_count, SUBSCRIBER_CHANNEL_CAPACITY + 1).await;
+    tokio::time::advance(SEND_TIMEOUT).await;
+    tokio::task::yield_now().await;
+
+    for expected_block in 0..SUBSCRIBER_CHANNEL_CAPACITY {
+        let item = stream
+            .next()
+            .await
+            .expect("buffered stream item must be present")
+            .expect("buffered stream item must be ok");
+        assert_eq!(item.block, BlockNumber::from(expected_block as u32));
+    }
+
+    let terminal = stream.next().await.expect("terminal status must precede end of stream");
+    assert_stream_status(terminal, tonic::Code::ResourceExhausted);
+}
+
 #[tokio::test]
 async fn slow_subscriber_is_banned() {
     let (tip_tx, tip_rx) = watch::channel(BlockNumber::GENESIS);


### PR DESCRIPTION
## Summary

Closes https://github.com/0xMiden/node/issues/2424

Subscription producers previously reported terminal errors using `try_send()` on the same bounded channel used for normal stream items.

When a data send timed out because that channel was full, the subsequent terminal-status send could also fail with `TrySendError::Full`. Since that result was ignored, the receiver drained the buffered items and then observed a clean EOF instead of the expected gRPC error.

This change reserves one channel permit exclusively for the terminal status. The channel is allocated with one additional slot, so normal stream data still has the existing 32-item buffering capacity. The producer uses the reserved permit when it exits, ensuring that a terminal status is queued without blocking behind normal data.

The regression tests cover a full subscription buffer and verify that:

- buffered stream items are delivered first;
- `Code::ResourceExhausted` is delivered after a send timeout;
- the stream does not return `None` before the terminal status;
- shutdown while a data send is pending reports `Code::Unavailable`.

## Changelog

```toml
[[entry]]
scope       = "rpc"
impact      = "fixed"
description = "Subscription clients now receive terminal gRPC statuses when the stream buffer is full."
```