### PR TITLE
RpcBackend and RpcMode refactor

### DIFF
--- a/bin/node/src/commands/modes.rs
+++ b/bin/node/src/commands/modes.rs
@@ -95,7 +95,6 @@ impl SequencerCommand {
             listener: bind_rpc(runtime.rpc_listen).await?,
             state,
             mode: RpcMode::sequencer(block_producer.clone(), validator_clients),
-            sync_writers: None,
             ntx_builder: Some(ntx_builder_client),
             grpc_options: runtime.external_grpc_options,
             network_tx_auth,
@@ -299,8 +298,13 @@ impl FullNodeCommand {
         let rpc = Rpc {
             listener: bind_rpc(runtime.rpc_listen).await?,
             state,
-            mode: RpcMode::full_node(source_rpc, self.sync.readiness_threshold, pre_auth),
-            sync_writers: Some((block_writer, proof_writer)),
+            mode: RpcMode::full_node(
+                source_rpc,
+                self.sync.readiness_threshold,
+                pre_auth,
+                block_writer,
+                proof_writer,
+            ),
             ntx_builder: None,
             grpc_options: runtime.external_grpc_options,
             network_tx_auth,

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -31,7 +31,7 @@ use tonic::metadata::MetadataMap;
 use tonic::{IntoRequest, Request, Status};
 
 use crate::server::api::subscription::{IpBanList, MAX_REPLICA_SUBSCRIPTIONS};
-use crate::server::{NetworkTxAuth, RpcRouting};
+use crate::server::{NetworkTxAuth, RpcBackend};
 use crate::{COMPONENT, LOG_TARGET};
 
 // VALIDATOR FAN-OUT
@@ -112,7 +112,7 @@ impl From<InvalidBlockRange> for RpcInvalidBlockRange {
 
 pub struct RpcService {
     state: Arc<State>,
-    route: RpcRouting,
+    backend: RpcBackend,
     ntx_builder: Option<NtxBuilderClient>,
     network_tx_auth: Option<NetworkTxAuth>,
     genesis_commitment: Option<Word>,
@@ -125,14 +125,14 @@ pub struct RpcService {
 impl RpcService {
     pub(crate) fn new(
         state: Arc<State>,
-        route: RpcRouting,
+        backend: RpcBackend,
         ntx_builder: Option<NtxBuilderClient>,
         commitment_cache_capacity: NonZeroUsize,
         network_tx_auth: Option<NetworkTxAuth>,
     ) -> Self {
         Self {
             state,
-            route,
+            backend,
             ntx_builder,
             network_tx_auth,
             genesis_commitment: None,

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -31,7 +31,7 @@ use tonic::metadata::MetadataMap;
 use tonic::{IntoRequest, Request, Status};
 
 use crate::server::api::subscription::{IpBanList, MAX_REPLICA_SUBSCRIPTIONS};
-use crate::server::{NetworkTxAuth, RpcMode};
+use crate::server::{NetworkTxAuth, RpcRouting};
 use crate::{COMPONENT, LOG_TARGET};
 
 // VALIDATOR FAN-OUT
@@ -112,7 +112,7 @@ impl From<InvalidBlockRange> for RpcInvalidBlockRange {
 
 pub struct RpcService {
     state: Arc<State>,
-    mode: RpcMode,
+    route: RpcRouting,
     ntx_builder: Option<NtxBuilderClient>,
     network_tx_auth: Option<NetworkTxAuth>,
     genesis_commitment: Option<Word>,
@@ -125,14 +125,14 @@ pub struct RpcService {
 impl RpcService {
     pub(crate) fn new(
         state: Arc<State>,
-        mode: RpcMode,
+        route: RpcRouting,
         ntx_builder: Option<NtxBuilderClient>,
         commitment_cache_capacity: NonZeroUsize,
         network_tx_auth: Option<NetworkTxAuth>,
     ) -> Self {
         Self {
             state,
-            mode,
+            route,
             ntx_builder,
             network_tx_auth,
             genesis_commitment: None,

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -4,7 +4,7 @@ use miden_protocol::Word;
 use tonic::Request;
 use tracing::debug;
 
-use super::{RpcMode, RpcService};
+use super::{RpcRouting, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -53,8 +53,8 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
             forwarded_request.metadata_mut().insert(http::header::ACCEPT.as_str(), accept);
         }
 
-        let response = match &self.mode {
-            RpcMode::Sequencer { .. } => {
+        let response = match &self.route {
+            RpcRouting::Sequencer { .. } => {
                 let Some(ntx_builder) = &self.ntx_builder else {
                     return Err(tonic::Status::unavailable(
                         "Network transaction builder is not enabled",
@@ -67,7 +67,7 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
                     .await?
                     .into_inner()
             },
-            RpcMode::FullNode { source_rpc, .. } => source_rpc
+            RpcRouting::FullNode { source_rpc, .. } => source_rpc
                 .as_ref()
                 .clone()
                 .get_network_note_status(forwarded_request)

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -4,7 +4,7 @@ use miden_protocol::Word;
 use tonic::Request;
 use tracing::debug;
 
-use super::{RpcRouting, RpcService};
+use super::{RpcBackend, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -53,8 +53,8 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
             forwarded_request.metadata_mut().insert(http::header::ACCEPT.as_str(), accept);
         }
 
-        let response = match &self.route {
-            RpcRouting::Sequencer { .. } => {
+        let response = match &self.backend {
+            RpcBackend::Sequencer { .. } => {
                 let Some(ntx_builder) = &self.ntx_builder else {
                     return Err(tonic::Status::unavailable(
                         "Network transaction builder is not enabled",
@@ -67,7 +67,7 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
                     .await?
                     .into_inner()
             },
-            RpcRouting::FullNode { source_rpc, .. } => source_rpc
+            RpcBackend::FullNode { source_rpc, .. } => source_rpc
                 .as_ref()
                 .clone()
                 .get_network_note_status(forwarded_request)

--- a/crates/rpc/src/server/api/get_transaction_encryption_key.rs
+++ b/crates/rpc/src/server/api/get_transaction_encryption_key.rs
@@ -2,7 +2,7 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::tracing::miden_instrument;
 use tracing::debug;
 
-use super::{Request, RpcMode, RpcService};
+use super::{Request, RpcRouting, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -40,10 +40,10 @@ impl proto::server::rpc_api::GetTransactionEncryptionKey for RpcService {
 
         // Nodes connected to validators ask one directly, otherwise the request is forwarded. The
         // encryption key is shared by the whole validator set, so any single validator serves.
-        let validator = match &self.mode {
-            RpcMode::Sequencer { validators, .. } => validators.random(),
-            RpcMode::FullNode { pre_auth: Some(pre_auth), .. } => pre_auth.validators().random(),
-            RpcMode::FullNode { source_rpc, pre_auth: None, .. } => {
+        let validator = match &self.route {
+            RpcRouting::Sequencer { validators, .. } => validators.random(),
+            RpcRouting::FullNode { pre_auth: Some(pre_auth), .. } => pre_auth.validators().random(),
+            RpcRouting::FullNode { source_rpc, pre_auth: None, .. } => {
                 return source_rpc
                     .as_ref()
                     .clone()

--- a/crates/rpc/src/server/api/get_transaction_encryption_key.rs
+++ b/crates/rpc/src/server/api/get_transaction_encryption_key.rs
@@ -2,7 +2,7 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::tracing::miden_instrument;
 use tracing::debug;
 
-use super::{Request, RpcRouting, RpcService};
+use super::{Request, RpcBackend, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -40,10 +40,10 @@ impl proto::server::rpc_api::GetTransactionEncryptionKey for RpcService {
 
         // Nodes connected to validators ask one directly, otherwise the request is forwarded. The
         // encryption key is shared by the whole validator set, so any single validator serves.
-        let validator = match &self.route {
-            RpcRouting::Sequencer { validators, .. } => validators.random(),
-            RpcRouting::FullNode { pre_auth: Some(pre_auth), .. } => pre_auth.validators().random(),
-            RpcRouting::FullNode { source_rpc, pre_auth: None, .. } => {
+        let validator = match &self.backend {
+            RpcBackend::Sequencer { validators, .. } => validators.random(),
+            RpcBackend::FullNode { pre_auth: Some(pre_auth), .. } => pre_auth.validators().random(),
+            RpcBackend::FullNode { source_rpc, pre_auth: None, .. } => {
                 return source_rpc
                     .as_ref()
                     .clone()

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -3,7 +3,7 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::tracing::miden_instrument;
 use tracing::debug;
 
-use super::{ProtoMempoolStats, Request, RpcRouting, RpcService};
+use super::{ProtoMempoolStats, Request, RpcBackend, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -30,11 +30,11 @@ impl proto::server::rpc_api::Status for RpcService {
         _metadata: &tonic::metadata::MetadataMap,
         _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
-        let block_producer_status = match &self.route {
-            RpcRouting::Sequencer { block_producer, .. } => {
+        let block_producer_status = match &self.backend {
+            RpcBackend::Sequencer { block_producer, .. } => {
                 Some(block_producer_status_to_proto(block_producer.status().await))
             },
-            RpcRouting::FullNode { source_rpc, .. } => source_rpc
+            RpcBackend::FullNode { source_rpc, .. } => source_rpc
                 .as_ref()
                 .clone()
                 .status(Request::new(()))

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -3,7 +3,7 @@ use miden_node_proto::generated as proto;
 use miden_node_utils::tracing::miden_instrument;
 use tracing::debug;
 
-use super::{ProtoMempoolStats, Request, RpcMode, RpcService};
+use super::{ProtoMempoolStats, Request, RpcRouting, RpcService};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -30,11 +30,11 @@ impl proto::server::rpc_api::Status for RpcService {
         _metadata: &tonic::metadata::MetadataMap,
         _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
-        let block_producer_status = match &self.mode {
-            RpcMode::Sequencer { block_producer, .. } => {
+        let block_producer_status = match &self.route {
+            RpcRouting::Sequencer { block_producer, .. } => {
                 Some(block_producer_status_to_proto(block_producer.status().await))
             },
-            RpcMode::FullNode { source_rpc, .. } => source_rpc
+            RpcRouting::FullNode { source_rpc, .. } => source_rpc
                 .as_ref()
                 .clone()
                 .status(Request::new(()))

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -17,7 +17,7 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 use tonic::{Request, Status};
 use tracing::debug;
 
-use super::{COMPONENT, RpcMode, RpcService, submit_tx_to_validators};
+use super::{COMPONENT, RpcRouting, RpcService, submit_tx_to_validators};
 use crate::LOG_TARGET;
 
 #[tonic::async_trait]
@@ -118,8 +118,8 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
             Status::internal(format!("transaction proof verification task failed: {err}"))
         })??;
 
-        match &self.mode {
-            RpcMode::Sequencer { block_producer, validators } => {
+        match &self.route {
+            RpcRouting::Sequencer { block_producer, validators } => {
                 submit_tx_to_validators(validators.as_slice(), &request).await?;
                 block_producer
                     .submit_proven_tx(rebuilt_tx)
@@ -127,7 +127,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
                     .map(Into::into)
                     .map_err(Into::into)
             },
-            RpcMode::FullNode { pre_auth: Some(pre_auth), .. } => {
+            RpcRouting::FullNode { pre_auth: Some(pre_auth), .. } => {
                 // Pre-authenticated transactions: validate and authenticate locally, then submit
                 // the authenticated transaction to the sequencer's pre-authenticated API.
                 self.submit_authenticated_to_sequencer(
@@ -138,7 +138,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
                 )
                 .await
             },
-            RpcMode::FullNode { source_rpc, pre_auth: None, .. } => {
+            RpcRouting::FullNode { source_rpc, pre_auth: None, .. } => {
                 // Unauthenticated transactions: forward the request to the source verbatim.
                 let mut forwarded_request = Request::new(request);
                 if let Some(accept) = original_accept_header {

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -17,7 +17,7 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 use tonic::{Request, Status};
 use tracing::debug;
 
-use super::{COMPONENT, RpcRouting, RpcService, submit_tx_to_validators};
+use super::{COMPONENT, RpcBackend, RpcService, submit_tx_to_validators};
 use crate::LOG_TARGET;
 
 #[tonic::async_trait]
@@ -118,8 +118,8 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
             Status::internal(format!("transaction proof verification task failed: {err}"))
         })??;
 
-        match &self.route {
-            RpcRouting::Sequencer { block_producer, validators } => {
+        match &self.backend {
+            RpcBackend::Sequencer { block_producer, validators } => {
                 submit_tx_to_validators(validators.as_slice(), &request).await?;
                 block_producer
                     .submit_proven_tx(rebuilt_tx)
@@ -127,7 +127,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
                     .map(Into::into)
                     .map_err(Into::into)
             },
-            RpcRouting::FullNode { pre_auth: Some(pre_auth), .. } => {
+            RpcBackend::FullNode { pre_auth: Some(pre_auth), .. } => {
                 // Pre-authenticated transactions: validate and authenticate locally, then submit
                 // the authenticated transaction to the sequencer's pre-authenticated API.
                 self.submit_authenticated_to_sequencer(
@@ -138,7 +138,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
                 )
                 .await
             },
-            RpcRouting::FullNode { source_rpc, pre_auth: None, .. } => {
+            RpcBackend::FullNode { source_rpc, pre_auth: None, .. } => {
                 // Unauthenticated transactions: forward the request to the source verbatim.
                 let mut forwarded_request = Request::new(request);
                 if let Some(accept) = original_accept_header {

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -10,7 +10,7 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx_batch::BatchVerifier;
 use tonic::{Request, Status};
 
-use super::{RpcMode, RpcService, submit_batch_to_validators};
+use super::{RpcRouting, RpcService, submit_batch_to_validators};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -107,8 +107,8 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         // Verify batch transaction proofs.
         verify_batch_proof(proven_batch, &proposed_batch).await?;
 
-        match &self.mode {
-            RpcMode::Sequencer { block_producer, validators } => {
+        match &self.route {
+            RpcRouting::Sequencer { block_producer, validators } => {
                 submit_batch_to_validators(
                     validators.as_slice(),
                     &proposed_batch,
@@ -121,7 +121,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
                     .map(Into::into)
                     .map_err(Into::into)
             },
-            RpcMode::FullNode { pre_auth: Some(pre_auth), .. } => {
+            RpcRouting::FullNode { pre_auth: Some(pre_auth), .. } => {
                 // Pre-authenticated transactions: validate and authenticate locally, then submit
                 // the authenticated batch to the sequencer's pre-authenticated API.
                 self.submit_authenticated_batch_to_sequencer(
@@ -132,7 +132,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
                 )
                 .await
             },
-            RpcMode::FullNode { source_rpc, pre_auth: None, .. } => {
+            RpcRouting::FullNode { source_rpc, pre_auth: None, .. } => {
                 // Unauthenticated transactions: forward the request to the source verbatim.
                 let mut forwarded_request = Request::new(request);
                 if let Some(accept) = original_accept_header {

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -10,7 +10,7 @@ use miden_protocol::utils::serde::{Deserializable, Serializable};
 use miden_tx_batch::BatchVerifier;
 use tonic::{Request, Status};
 
-use super::{RpcRouting, RpcService, submit_batch_to_validators};
+use super::{RpcBackend, RpcService, submit_batch_to_validators};
 use crate::{COMPONENT, LOG_TARGET};
 
 #[tonic::async_trait]
@@ -107,8 +107,8 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         // Verify batch transaction proofs.
         verify_batch_proof(proven_batch, &proposed_batch).await?;
 
-        match &self.route {
-            RpcRouting::Sequencer { block_producer, validators } => {
+        match &self.backend {
+            RpcBackend::Sequencer { block_producer, validators } => {
                 submit_batch_to_validators(
                     validators.as_slice(),
                     &proposed_batch,
@@ -121,7 +121,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
                     .map(Into::into)
                     .map_err(Into::into)
             },
-            RpcRouting::FullNode { pre_auth: Some(pre_auth), .. } => {
+            RpcBackend::FullNode { pre_auth: Some(pre_auth), .. } => {
                 // Pre-authenticated transactions: validate and authenticate locally, then submit
                 // the authenticated batch to the sequencer's pre-authenticated API.
                 self.submit_authenticated_batch_to_sequencer(
@@ -132,7 +132,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
                 )
                 .await
             },
-            RpcRouting::FullNode { source_rpc, pre_auth: None, .. } => {
+            RpcBackend::FullNode { source_rpc, pre_auth: None, .. } => {
                 // Unauthenticated transactions: forward the request to the source verbatim.
                 let mut forwarded_request = Request::new(request);
                 if let Some(accept) = original_accept_header {

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -61,7 +61,7 @@ pub(crate) struct NetworkTxAuth(pub(crate) AsciiMetadataValue);
 ///
 /// Deliberately not `Clone`: the full-node variant owns the store's single-writer capabilities,
 /// which must not be duplicated. Per-request handlers never need those, so they read through
-/// [`RpcRouting`] instead — the `Clone`-able subset [`Self::routing`] derives from this.
+/// [`RpcBackend`] instead — the `Clone`-able subset [`Self::backend`] derives from this.
 pub enum RpcMode {
     /// Sequencer RPC validates submissions locally, re-executes them through every validator, then
     /// forwards them to the block producer.
@@ -92,14 +92,14 @@ pub enum RpcMode {
     },
 }
 
-/// The per-request submission-routing subset of [`RpcMode`], held by
+/// The clients handlers forward requests to — the per-request subset of [`RpcMode`], held by
 /// [`RpcService`](api::RpcService) for the server's lifetime and read by every handler.
 ///
 /// `Clone` because it is cloned once into `RpcService` and then read on every request; it never
 /// carries the full-node's store write capabilities ([`RpcMode`] does), since no handler needs
 /// them — those are consumed once by the sync loop at startup.
 #[derive(Clone, Debug)]
-pub(crate) enum RpcRouting {
+pub(crate) enum RpcBackend {
     Sequencer {
         block_producer: Box<BlockProducerApi>,
         validators: ValidatorClients,
@@ -111,9 +111,9 @@ pub(crate) enum RpcRouting {
 }
 
 #[cfg(test)]
-impl RpcRouting {
-    /// Test-only: production code only ever builds a routing value from an [`RpcMode`] via
-    /// [`RpcMode::routing`]; these let handler-level tests construct one directly, without a store
+impl RpcBackend {
+    /// Test-only: production code only ever builds a backend from an [`RpcMode`] via
+    /// [`RpcMode::backend`]; these let handler-level tests construct one directly, without a store
     /// or write capabilities.
     pub(crate) fn sequencer(
         block_producer: BlockProducerApi,
@@ -232,15 +232,15 @@ impl RpcMode {
         }
     }
 
-    /// Returns the `Clone`-able per-request routing subset handed to
+    /// Returns the `Clone`-able per-request backend subset handed to
     /// [`RpcService`](api::RpcService).
-    fn routing(&self) -> RpcRouting {
+    fn backend(&self) -> RpcBackend {
         match self {
-            Self::Sequencer { block_producer, validators } => RpcRouting::Sequencer {
+            Self::Sequencer { block_producer, validators } => RpcBackend::Sequencer {
                 block_producer: block_producer.clone(),
                 validators: validators.clone(),
             },
-            Self::FullNode { source_rpc, pre_auth, .. } => RpcRouting::FullNode {
+            Self::FullNode { source_rpc, pre_auth, .. } => RpcBackend::FullNode {
                 source_rpc: source_rpc.clone(),
                 pre_auth: pre_auth.clone(),
             },
@@ -261,7 +261,7 @@ impl Rpc {
         let mode = self.mode.as_str();
         let mut api = api::RpcService::new(
             self.state.clone(),
-            self.mode.routing(),
+            self.mode.backend(),
             self.ntx_builder.clone(),
             NonZeroUsize::new(1_000_000).unwrap(),
             self.network_tx_auth.map(NetworkTxAuth),

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -47,11 +47,6 @@ pub struct Rpc {
     pub listener: TcpListener,
     pub state: Arc<State>,
     pub mode: RpcMode,
-    /// Store write capabilities consumed by the full-node sync loop.
-    ///
-    /// Must be provided in full-node mode and omitted in sequencer mode. The RPC service itself
-    /// only ever reads through `state`; these are passed through untouched to the sync tasks.
-    pub sync_writers: Option<(BlockWriter, ProofWriter)>,
     pub ntx_builder: Option<NtxBuilderClient>,
     pub grpc_options: GrpcOptionsExternal,
     pub network_tx_auth: Option<AsciiMetadataValue>,
@@ -61,7 +56,12 @@ pub struct Rpc {
 /// Shared secret value expected in the fixed `x-miden-network-tx-auth` metadata header.
 pub(crate) struct NetworkTxAuth(pub(crate) AsciiMetadataValue);
 
-#[derive(Clone, Debug)]
+/// How the RPC is wired at startup: which submission path it runs and, in full-node mode, the
+/// store write capabilities its sync loop consumes.
+///
+/// Deliberately not `Clone`: the full-node variant owns the store's single-writer capabilities,
+/// which must not be duplicated. Per-request handlers never need those, so they read through
+/// [`RpcRouting`] instead — the `Clone`-able subset [`Self::routing`] derives from this.
 pub enum RpcMode {
     /// Sequencer RPC validates submissions locally, re-executes them through every validator, then
     /// forwards them to the block producer.
@@ -85,7 +85,55 @@ pub enum RpcMode {
         source_rpc: Box<SourceRpcClient>,
         readiness_threshold: u32,
         pre_auth: Option<PreAuthSubmission>,
+        /// The store's block-write capability, handed to the sync loop.
+        block_writer: BlockWriter,
+        /// The store's proof-write capability, handed to the sync loop.
+        proof_writer: ProofWriter,
     },
+}
+
+/// The per-request submission-routing subset of [`RpcMode`], held by
+/// [`RpcService`](api::RpcService) for the server's lifetime and read by every handler.
+///
+/// `Clone` because it is cloned once into `RpcService` and then read on every request; it never
+/// carries the full-node's store write capabilities ([`RpcMode`] does), since no handler needs
+/// them — those are consumed once by the sync loop at startup.
+#[derive(Clone, Debug)]
+pub(crate) enum RpcRouting {
+    Sequencer {
+        block_producer: Box<BlockProducerApi>,
+        validators: ValidatorClients,
+    },
+    FullNode {
+        source_rpc: Box<SourceRpcClient>,
+        pre_auth: Option<PreAuthSubmission>,
+    },
+}
+
+#[cfg(test)]
+impl RpcRouting {
+    /// Test-only: production code only ever builds a routing value from an [`RpcMode`] via
+    /// [`RpcMode::routing`]; these let handler-level tests construct one directly, without a store
+    /// or write capabilities.
+    pub(crate) fn sequencer(
+        block_producer: BlockProducerApi,
+        validators: ValidatorClients,
+    ) -> Self {
+        Self::Sequencer {
+            block_producer: Box::new(block_producer),
+            validators,
+        }
+    }
+
+    pub(crate) fn full_node(
+        source_rpc: SourceRpcClient,
+        pre_auth: Option<PreAuthSubmission>,
+    ) -> Self {
+        Self::FullNode {
+            source_rpc: Box::new(source_rpc),
+            pre_auth,
+        }
+    }
 }
 
 /// A non-empty set of validator clients.
@@ -165,11 +213,15 @@ impl RpcMode {
         source_rpc: SourceRpcClient,
         readiness_threshold: u32,
         pre_auth: Option<PreAuthSubmission>,
+        block_writer: BlockWriter,
+        proof_writer: ProofWriter,
     ) -> Self {
         Self::FullNode {
             source_rpc: Box::new(source_rpc),
             readiness_threshold,
             pre_auth,
+            block_writer,
+            proof_writer,
         }
     }
 
@@ -177,6 +229,21 @@ impl RpcMode {
         match self {
             Self::Sequencer { .. } => "sequencer",
             Self::FullNode { .. } => "full",
+        }
+    }
+
+    /// Returns the `Clone`-able per-request routing subset handed to
+    /// [`RpcService`](api::RpcService).
+    fn routing(&self) -> RpcRouting {
+        match self {
+            Self::Sequencer { block_producer, validators } => RpcRouting::Sequencer {
+                block_producer: block_producer.clone(),
+                validators: validators.clone(),
+            },
+            Self::FullNode { source_rpc, pre_auth, .. } => RpcRouting::FullNode {
+                source_rpc: source_rpc.clone(),
+                pre_auth: pre_auth.clone(),
+            },
         }
     }
 }
@@ -194,7 +261,7 @@ impl Rpc {
         let mode = self.mode.as_str();
         let mut api = api::RpcService::new(
             self.state.clone(),
-            self.mode.clone(),
+            self.mode.routing(),
             self.ntx_builder.clone(),
             NonZeroUsize::new(1_000_000).unwrap(),
             self.network_tx_auth.map(NetworkTxAuth),
@@ -224,29 +291,26 @@ impl Rpc {
                 let chain_tip = self.state.committed_tip();
                 log_node_ready(mode, endpoint, chain_tip);
             },
-            RpcMode::FullNode { source_rpc, readiness_threshold, .. } => {
-                health_reporter
-                    .set_service_status(
-                        rpc_api::service_name(),
-                        tonic_health::ServingStatus::NotServing,
-                    )
-                    .await;
-                let readiness = RpcReadiness::new(health_reporter, readiness_threshold);
-                let (block_writer, proof_writer) = self.sync_writers.context(
-                    "full-node RPC requires the store write capabilities for its sync loop",
-                )?;
-                tasks.spawn(
-                    "RPC sync",
-                    RpcSync {
-                        state: Arc::clone(&self.state),
-                        block_writer,
-                        proof_writer,
-                        source_rpc: *source_rpc,
-                        readiness,
-                    }
-                    .run(shutdown.clone()),
-                );
-                log_node_synchronizing(mode, endpoint, readiness_threshold);
+            RpcMode::FullNode {
+                source_rpc,
+                readiness_threshold,
+                block_writer,
+                proof_writer,
+                ..
+            } => {
+                Self::spawn_full_node_sync(
+                    &self.state,
+                    &mut tasks,
+                    health_reporter,
+                    mode,
+                    endpoint,
+                    shutdown.clone(),
+                    *source_rpc,
+                    readiness_threshold,
+                    block_writer,
+                    proof_writer,
+                )
+                .await;
             },
         }
 
@@ -306,6 +370,41 @@ impl Rpc {
         tasks.spawn("RPC server", async move { rpc.await.map_err(|e| anyhow::anyhow!(e)) });
 
         tasks.join_next_or_cancelled(shutdown).await
+    }
+
+    /// Marks the RPC `NotServing` until synchronized, then spawns the full-node sync loop.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "assembles the full-node sync task from Rpc::serve's local state"
+    )]
+    async fn spawn_full_node_sync(
+        state: &Arc<State>,
+        tasks: &mut Tasks,
+        health_reporter: tonic_health::server::HealthReporter,
+        mode: &str,
+        endpoint: impl Display,
+        shutdown: CancellationToken,
+        source_rpc: SourceRpcClient,
+        readiness_threshold: u32,
+        block_writer: BlockWriter,
+        proof_writer: ProofWriter,
+    ) {
+        health_reporter
+            .set_service_status(rpc_api::service_name(), tonic_health::ServingStatus::NotServing)
+            .await;
+        let readiness = RpcReadiness::new(health_reporter, readiness_threshold);
+        tasks.spawn(
+            "RPC sync",
+            RpcSync {
+                state: Arc::clone(state),
+                block_writer,
+                proof_writer,
+                source_rpc,
+                readiness,
+            }
+            .run(shutdown),
+        );
+        log_node_synchronizing(mode, endpoint, readiness_threshold);
     }
 }
 

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -56,7 +56,7 @@ use tonic::Request;
 use tonic::metadata::MetadataMap;
 use url::Url;
 
-use crate::server::RpcRouting;
+use crate::server::RpcBackend;
 use crate::server::api::RpcService;
 use crate::{PreAuthSubmission, Rpc, RpcMode, ValidatorClients};
 
@@ -516,7 +516,7 @@ async fn rpc_rejects_post_deployment_network_account_tx() {
 
     let service = RpcService::new(
         Arc::clone(&store.state),
-        RpcRouting::full_node(source_rpc_client(), None),
+        RpcBackend::full_node(source_rpc_client(), None),
         None,
         NonZeroUsize::new(1_000_000).unwrap(),
         None,
@@ -641,7 +641,7 @@ async fn start_source_rpc(
         );
         let source_rpc = RpcService::new(
             state,
-            RpcRouting::sequencer(block_producer, ValidatorClients::new(vec![validator]).unwrap()),
+            RpcBackend::sequencer(block_producer, ValidatorClients::new(vec![validator]).unwrap()),
             Some(ntx_builder),
             NonZeroUsize::new(1_000_000).unwrap(),
             None,
@@ -858,7 +858,7 @@ async fn full_node_with_validator_forwards_get_transaction_encryption_key() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcRouting::full_node(
+        RpcBackend::full_node(
             dummy_client::<RpcClient>(),
             Some(
                 PreAuthSubmission::new(vec![validator], dummy_client::<SequencerClient>())
@@ -899,7 +899,7 @@ async fn full_node_forwards_get_transaction_encryption_key_to_source_rpc() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcRouting::full_node(source_rpc, None),
+        RpcBackend::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -924,7 +924,7 @@ async fn full_node_preserves_original_accept_metadata_when_forwarding_encryption
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcRouting::full_node(source_rpc, None),
+        RpcBackend::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -966,7 +966,7 @@ async fn full_node_forwards_get_network_note_status_to_source_rpc() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcRouting::full_node(source_rpc, None),
+        RpcBackend::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -997,7 +997,7 @@ async fn full_node_preserves_original_accept_metadata_when_forwarding() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcRouting::full_node(source_rpc, None),
+        RpcBackend::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -56,6 +56,7 @@ use tonic::Request;
 use tonic::metadata::MetadataMap;
 use url::Url;
 
+use crate::server::RpcRouting;
 use crate::server::api::RpcService;
 use crate::{PreAuthSubmission, Rpc, RpcMode, ValidatorClients};
 
@@ -515,7 +516,7 @@ async fn rpc_rejects_post_deployment_network_account_tx() {
 
     let service = RpcService::new(
         Arc::clone(&store.state),
-        RpcMode::full_node(source_rpc_client(), 100, None),
+        RpcRouting::full_node(source_rpc_client(), None),
         None,
         NonZeroUsize::new(1_000_000).unwrap(),
         None,
@@ -640,7 +641,7 @@ async fn start_source_rpc(
         );
         let source_rpc = RpcService::new(
             state,
-            RpcMode::sequencer(block_producer, ValidatorClients::new(vec![validator]).unwrap()),
+            RpcRouting::sequencer(block_producer, ValidatorClients::new(vec![validator]).unwrap()),
             Some(ntx_builder),
             NonZeroUsize::new(1_000_000).unwrap(),
             None,
@@ -857,9 +858,8 @@ async fn full_node_with_validator_forwards_get_transaction_encryption_key() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcMode::full_node(
+        RpcRouting::full_node(
             dummy_client::<RpcClient>(),
-            100,
             Some(
                 PreAuthSubmission::new(vec![validator], dummy_client::<SequencerClient>())
                     .expect("one validator is configured"),
@@ -899,7 +899,7 @@ async fn full_node_forwards_get_transaction_encryption_key_to_source_rpc() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcMode::full_node(source_rpc, 100, None),
+        RpcRouting::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -924,7 +924,7 @@ async fn full_node_preserves_original_accept_metadata_when_forwarding_encryption
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcMode::full_node(source_rpc, 100, None),
+        RpcRouting::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -966,7 +966,7 @@ async fn full_node_forwards_get_network_note_status_to_source_rpc() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcMode::full_node(source_rpc, 100, None),
+        RpcRouting::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -997,7 +997,7 @@ async fn full_node_preserves_original_accept_metadata_when_forwarding() {
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
-        RpcMode::full_node(source_rpc, 100, None),
+        RpcRouting::full_node(source_rpc, None),
         None,
         NonZeroUsize::new(1_000).unwrap(),
         None,
@@ -1131,7 +1131,6 @@ async fn start_rpc_with_options(
                 block_producer,
                 ValidatorClients::new(vec![validator]).unwrap(),
             ),
-            sync_writers: None,
             ntx_builder: None,
             grpc_options,
             network_tx_auth: None,


### PR DESCRIPTION
## Summary

Closes #2428.

- `RpcMode` (`crates/rpc/src/server/mod.rs`) is now the non-`Clone` startup-time enum — `FullNode` carries `block_writer`/`proof_writer` directly, so `sync_writers: Option<(BlockWriter, ProofWriter)>` is gone from `Rpc` entirely (no more runtime `.context()` error for a missing writer pair in full-node mode — it's now a compile-time requirement).
- `RpcBackend` is the new `pub(crate)`, `Clone`-able per-request subset (`RpcService`'s field), built from `RpcMode::backend()` by cloning only the individually-`Clone` fields.
- `RpcMode::full_node()` now takes `block_writer`/`proof_writer`; `RpcBackend`'s own constructors are `#[cfg(test)]`-gated since production only builds it via `.backend()`.
- Extracted `Rpc::spawn_full_node_sync` out of `serve()` to keep it under clippy's line-count lint after the match arm grew.
- Updated the 5 per-request handlers (`submit_proven_tx(_batch)`, `get_transaction_encryption_key`, `get_network_note_status`, `status`) to match on `RpcBackend` instead of `RpcMode`, and fixed all call sites in `bin/node/src/commands/modes.rs` and `crates/rpc/src/tests.rs`.

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```
