### PR TITLE
ci: update rust-cache action pins

### DIFF
--- a/.github/actions/debian/action.yml
+++ b/.github/actions/debian/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Rust cache
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         # Only update the cache on push onto the next branch. This strikes a nice balance between
         # cache hits and cache evictions (github has a 10GB cache limit).

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - name: Rustup
         run: rustup toolchain install --no-self-update
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: changelog
           save-if: ${{ env.SAVE_CACHE }}


### PR DESCRIPTION
## Summary

The existing `Swatinem/rust-cache` pins no longer matched their `v2` comments, which caused Zizmor to fail.

Pinact updates both uses to the current v2.9.2 commit.

## Changelog

```toml
changelog = "none"
reason    = "CI change only."
```