### PR TITLE
Fix docker workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,7 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       mode: dry-run
-      commit: ${{ github.sha }}
-      tag: dry-run
+      ref: ${{ github.sha }}
 
   clippy:
     name: lint - clippy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ on:
         required: true
         type: string
       tag:
-        description: "Custom image and Compose tag, for example demo"
+        description: "Image and Compose tag; v* tags must resolve to commit"
         required: true
         default: demo
         type: string
@@ -117,11 +117,6 @@ jobs:
             exit 1
           fi
 
-          if [[ "${tag}" == v* && "${release_tag}" != "true" ]]; then
-            echo "::error::The v* tag namespace is reserved for the release workflow"
-            exit 1
-          fi
-
           if [[ "${mode}" == "publish" && "${REPOSITORY_OWNER}" != "0xMiden" ]]; then
             echo "::error::Docker publication is restricted to the 0xMiden repository"
             exit 1
@@ -164,6 +159,7 @@ jobs:
         env:
           COMMIT: ${{ steps.inputs.outputs.commit }}
           CREATED: ${{ inputs.created }}
+          TAG: ${{ steps.inputs.outputs.tag }}
         run: |
           set -euo pipefail
 
@@ -171,6 +167,18 @@ jobs:
           if [[ "${actual_commit}" != "${COMMIT}" ]]; then
             echo "::error::Checked out ${actual_commit}, expected ${COMMIT}"
             exit 1
+          fi
+
+          if [[ "${TAG}" == v* ]]; then
+            if ! tag_commit="$(git rev-parse "refs/tags/${TAG}^{commit}" 2>/dev/null)"; then
+              echo "::error::Version tag ${TAG} does not exist"
+              exit 1
+            fi
+
+            if [[ "${tag_commit}" != "${actual_commit}" ]]; then
+              echo "::error::Version tag ${TAG} points to ${tag_commit}, expected ${actual_commit}"
+              exit 1
+            fi
           fi
 
           created="${CREATED}"
@@ -184,7 +192,11 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Ensure GitHub release does not exist
-        if: ${{ steps.inputs.outputs.mode == 'publish' }}
+        if: >-
+          ${{
+            steps.inputs.outputs.mode == 'publish' &&
+            steps.inputs.outputs.release_tag == 'true'
+          }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.inputs.outputs.tag }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker
 
 # Builds and validates all Docker images and the Compose application. CI calls it
-# in dry-run mode for pull requests and pushes to next or release/v*. Release and
-# manual publish runs continue through approval and publish the artifacts to GHCR.
+# in dry-run mode. Release and manually dispatched publish runs validate before
+# publishing to GHCR.
 
 on:
   workflow_call:
@@ -283,8 +283,8 @@ jobs:
           registry-prefix: ${{ env.REGISTRY_PREFIX }}
           tag: ${{ needs.preflight.outputs.tag }}
 
-  authorize-publish:
-    name: Approve Docker publish
+  publish-docker:
+    name: Publish ${{ matrix.component }}
     needs: [preflight, dry-run-docker, dry-run-compose]
     if: >-
       ${{
@@ -299,29 +299,6 @@ jobs:
           )
         )
       }}
-    runs-on: ubuntu-24.04
-    environment: publish-docker
-    permissions:
-      contents: read
-    steps:
-      - name: Ensure GitHub release still does not exist
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.preflight.outputs.tag }}
-        run: |
-          set -euo pipefail
-
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::error::GitHub release ${TAG} already exists. Refusing to publish Docker artifacts."
-            exit 1
-          fi
-
-      - name: Authorize publication
-        run: echo "Docker dry-run succeeded; publication is authorized."
-
-  publish-docker:
-    name: Publish ${{ matrix.component }}
-    needs: [preflight, authorize-publish]
     runs-on: warp-ubuntu-latest-x64-8x
     permissions:
       contents: read
@@ -386,6 +363,12 @@ jobs:
   publish-compose:
     name: Publish Compose
     needs: [preflight, publish-docker]
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.preflight.result == 'success' &&
+        needs.publish-docker.result == 'success'
+      }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,12 +12,8 @@ on:
         required: false
         type: string
         default: dry-run
-      commit:
-        description: "Full Git commit SHA to build"
-        required: true
-        type: string
-      tag:
-        description: "Tag to apply to the images and Compose application"
+      ref:
+        description: "Full Git commit SHA, tag name, or branch name to build"
         required: true
         type: string
       created:
@@ -35,18 +31,13 @@ on:
         options:
           - dry-run
           - publish
-      commit:
-        description: "Full Git commit SHA to build"
+      ref:
+        description: "Full Git commit SHA, tag name, or branch name to publish"
         required: true
-        type: string
-      tag:
-        description: "Image and Compose tag; v* tags must resolve to commit"
-        required: true
-        default: demo
         type: string
 
 concurrency:
-  group: "${{ github.workflow }} @ docker @ ${{ inputs.mode == 'publish' && inputs.tag || github.sha }}"
+  group: "${{ github.workflow }} @ docker @ ${{ inputs.mode == 'publish' && inputs.ref || github.sha }}"
   cancel-in-progress: false
 
 permissions:
@@ -64,38 +55,25 @@ jobs:
     permissions:
       contents: read
     outputs:
-      commit: ${{ steps.inputs.outputs.commit }}
+      commit: ${{ steps.metadata.outputs.commit }}
       created: ${{ steps.metadata.outputs.created }}
       images: ${{ steps.images.outputs.images }}
       immutable_tag: ${{ steps.metadata.outputs.immutable_tag }}
       mode: ${{ steps.inputs.outputs.mode }}
-      release_tag: ${{ steps.inputs.outputs.release_tag }}
-      tag: ${{ steps.inputs.outputs.tag }}
+      tag: ${{ steps.metadata.outputs.tag }}
     steps:
-      - name: Resolve and validate inputs
+      - name: Validate inputs
         id: inputs
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_REF_NAME: ${{ github.ref_name }}
-          EVENT_REF_TYPE: ${{ github.ref_type }}
-          INPUT_COMMIT: ${{ inputs.commit }}
           INPUT_MODE: ${{ inputs.mode }}
-          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_REF: ${{ inputs.ref }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
 
-          commit="${INPUT_COMMIT}"
           mode="${INPUT_MODE}"
-          tag="${INPUT_TAG}"
-
-          release_tag=false
-          if [[ "${tag}" == v* && "${EVENT_NAME}" == "push" && "${EVENT_REF_TYPE}" == "tag" && "${EVENT_REF_NAME}" == "${tag}" ]]; then
-            release_tag=true
-          fi
-
-          if [[ ! "${commit}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::A full, lowercase Git commit SHA is required"
+          if [[ -z "${INPUT_REF}" ]]; then
+            echo "::error::A Git commit, tag, or branch is required"
             exit 1
           fi
 
@@ -107,27 +85,12 @@ jobs:
               ;;
           esac
 
-          if [[ ! "${tag}" =~ ^[0-9A-Za-z_][0-9A-Za-z_.-]{0,127}$ ]]; then
-            echo "::error::Invalid container tag: ${tag}"
-            exit 1
-          fi
-
-          if [[ "${tag}" == "latest" || "${tag}" == sha-* ]]; then
-            echo "::error::The latest and sha-* tag namespaces are reserved"
-            exit 1
-          fi
-
           if [[ "${mode}" == "publish" && "${REPOSITORY_OWNER}" != "0xMiden" ]]; then
             echo "::error::Docker publication is restricted to the 0xMiden repository"
             exit 1
           fi
 
-          {
-            echo "commit=${commit}"
-            echo "mode=${mode}"
-            echo "release_tag=${release_tag}"
-            echo "tag=${tag}"
-          } >> "${GITHUB_OUTPUT}"
+          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
 
       - name: Define image matrix
         id: images
@@ -140,45 +103,56 @@ jobs:
                 {"component":"ntx-builder","bin":"miden-ntx-builder","port":50301},
                 {"component":"remote-prover","bin":"miden-remote-prover","port":50051},
                 {"component":"network-monitor","bin":"miden-network-monitor","port":3000},
-                {"component":"node-tps-benchmark","bin":"miden-benchmark","target":"runtime-tool"},
-                {"component":"faucet","bin":"miden-faucet","port":8000}
+                {"component":"node-tps-benchmark","bin":"miden-benchmark","target":"runtime-tool"}
               ]
             '
           )"
           echo "images=${images}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout repository
+        id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.inputs.outputs.commit }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Verify commit and prepare metadata
+      - name: Resolve ref and prepare metadata
         id: metadata
         env:
-          COMMIT: ${{ steps.inputs.outputs.commit }}
+          CHECKED_OUT_COMMIT: ${{ steps.checkout.outputs.commit }}
           CREATED: ${{ inputs.created }}
-          TAG: ${{ steps.inputs.outputs.tag }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
 
-          actual_commit="$(git rev-parse HEAD)"
-          if [[ "${actual_commit}" != "${COMMIT}" ]]; then
-            echo "::error::Checked out ${actual_commit}, expected ${COMMIT}"
+          actual_commit="${CHECKED_OUT_COMMIT}"
+          current_branch="$(git branch --show-current)"
+          ref="${INPUT_REF}"
+
+          if [[ "${ref}" == "${actual_commit}" ]]; then
+            ref_type=commit
+            ref_name="sha-${actual_commit:0:12}"
+          elif [[ -n "${current_branch}" && "${ref}" == "${current_branch}" ]]; then
+            ref_type=branch
+            ref_name="${ref}"
+          elif git show-ref --verify --quiet "refs/tags/${ref}" &&
+            [[ "$(git rev-parse "refs/tags/${ref}^{commit}")" == "${actual_commit}" ]]; then
+            ref_type=tag
+            ref_name="${ref}"
+          else
+            echo "::error::Input ${ref} does not match the checked-out commit, branch, or tag"
             exit 1
           fi
 
-          if [[ "${TAG}" == v* ]]; then
-            if ! tag_commit="$(git rev-parse "refs/tags/${TAG}^{commit}" 2>/dev/null)"; then
-              echo "::error::Version tag ${TAG} does not exist"
-              exit 1
-            fi
+          if [[ "${ref_type}" != "commit" && ! "${ref_name}" =~ ^[0-9A-Za-z_][0-9A-Za-z_.-]{0,127}$ ]]; then
+            echo "::error::Git ${ref_type} ${ref_name} is not a valid container tag"
+            exit 1
+          fi
 
-            if [[ "${tag_commit}" != "${actual_commit}" ]]; then
-              echo "::error::Version tag ${TAG} points to ${tag_commit}, expected ${actual_commit}"
-              exit 1
-            fi
+          if [[ "${ref_type}" != "commit" && ( "${ref_name}" == "latest" || "${ref_name}" == sha-* ) ]]; then
+            echo "::error::The latest and sha-* tag namespaces are reserved"
+            exit 1
           fi
 
           created="${CREATED}"
@@ -187,31 +161,15 @@ jobs:
           fi
 
           {
+            echo "commit=${actual_commit}"
             echo "created=${created}"
             echo "immutable_tag=sha-${actual_commit:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            echo "tag=${ref_name}"
           } >> "${GITHUB_OUTPUT}"
-
-      - name: Ensure GitHub release does not exist
-        if: >-
-          ${{
-            steps.inputs.outputs.mode == 'publish' &&
-            steps.inputs.outputs.release_tag == 'true'
-          }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.inputs.outputs.tag }}
-        run: |
-          set -euo pipefail
-
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::error::GitHub release ${TAG} already exists. Refusing to publish Docker artifacts."
-            exit 1
-          fi
 
   dry-run-docker:
     name: Build ${{ matrix.component }}
     needs: preflight
-    if: ${{ needs.preflight.outputs.mode == 'dry-run' || needs.preflight.outputs.release_tag != 'true' }}
     runs-on: warp-ubuntu-latest-x64-8x
     permissions:
       contents: read
@@ -265,7 +223,6 @@ jobs:
   dry-run-compose:
     name: Dry-run docker compose publishing
     needs: preflight
-    if: ${{ needs.preflight.outputs.mode == 'dry-run' || needs.preflight.outputs.release_tag != 'true' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -298,19 +255,7 @@ jobs:
   publish-docker:
     name: Publish ${{ matrix.component }}
     needs: [preflight, dry-run-docker, dry-run-compose]
-    if: >-
-      ${{
-        !cancelled() &&
-        needs.preflight.result == 'success' &&
-        needs.preflight.outputs.mode == 'publish' &&
-        (
-          needs.preflight.outputs.release_tag == 'true' ||
-          (
-            needs.dry-run-docker.result == 'success' &&
-            needs.dry-run-compose.result == 'success'
-          )
-        )
-      }}
+    if: ${{ needs.preflight.outputs.mode == 'publish' }}
     runs-on: warp-ubuntu-latest-x64-8x
     permissions:
       contents: read
@@ -375,12 +320,6 @@ jobs:
   publish-compose:
     name: Publish Compose
     needs: [preflight, publish-docker]
-    if: >-
-      ${{
-        !cancelled() &&
-        needs.preflight.result == 'success' &&
-        needs.publish-docker.result == 'success'
-      }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,8 +256,7 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       mode: dry-run
-      commit: ${{ needs.preflight.outputs.commit }}
-      tag: ${{ needs.preflight.outputs.tag }}
+      ref: ${{ needs.preflight.outputs.tag }}
       created: ${{ needs.preflight.outputs.created }}
 
   publish-docker:
@@ -272,8 +271,7 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       mode: publish
-      commit: ${{ needs.preflight.outputs.commit }}
-      tag: ${{ needs.preflight.outputs.tag }}
+      ref: ${{ needs.preflight.outputs.tag }}
       created: ${{ needs.preflight.outputs.created }}
 
   publish-github-release:

--- a/crates/store/src/db/models/queries/nullifiers.rs
+++ b/crates/store/src/db/models/queries/nullifiers.rs
@@ -73,8 +73,8 @@ pub(crate) fn select_nullifiers_by_prefix(
     pub const ROW_OVERHEAD_BYTES: usize = NULLIFIER_BYTES + BLOCK_NUM_BYTES; // 36 bytes
     pub const MAX_ROWS: usize = MAX_RESPONSE_PAYLOAD_BYTES / ROW_OVERHEAD_BYTES;
     // Pagination reports the last fully-included block, so it only makes progress if every block
-    // fits within a single page. A block that exceeded `MAX_ROWS` nullifiers would produce an
-    // empty page and stall clients forever on that block.
+    // fits within a single page. A block that exceeded `MAX_ROWS` nullifiers would produce an empty
+    // page and stall clients forever on that block.
     const _: () = assert!(
         miden_protocol::MAX_INPUT_NOTES_PER_BLOCK <= MAX_ROWS,
         "a block's nullifiers must fit in one response page or pagination cannot make progress",


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Latest `v0.16.0-rc.1` release failed to publish the docker images. This was because release skips the dry-run which in turn skipped later portions of the actual publishing. 

This was easy to overlook because the flow was a bit overcomplicated to shoe-horn reviews for manual publishing. This was pointless because manual publishing already requires elevated repo permissions - only benefit would be requiring multiple approvals.

This PR simplifies things again, removing the environment blocker, and cleans up the workflow.

Once merged, I'll manually re-publish the missing images.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```
