### PR TITLE
fix: Various trace issues

### DIFF
--- a/bin/validator/Cargo.toml
+++ b/bin/validator/Cargo.toml
@@ -14,6 +14,9 @@ version.workspace      = true
 [lints]
 workspace = true
 
+[features]
+tracing-forest = ["miden-node-utils/tracing-forest"]
+
 [lib]
 doctest = false
 

--- a/bin/validator/src/db/mod.rs
+++ b/bin/validator/src/db/mod.rs
@@ -54,6 +54,9 @@ impl ValidatorDbReader {
 
     /// Loads the chain tip, or `None` if no block header has been persisted yet (i.e. bootstrap has
     /// not been run).
+    #[miden_instrument(
+        target = COMPONENT,
+    )]
     pub(crate) async fn load_chain_tip(&self) -> Result<Option<BlockHeader>, DatabaseError> {
         self.reader.read("load_chain_tip", queries::load_chain_tip).await
     }
@@ -169,6 +172,9 @@ impl ValidatorDbWriter {
 
     /// Inserts a validated transaction and its encrypted private inputs, returning the number of
     /// inserted rows. The count is zero if the transaction was already recorded.
+    #[miden_instrument(
+        target = COMPONENT,
+    )]
     pub async fn insert_validated_private_transaction(
         &self,
         record: StoredPrivateRecord,
@@ -181,6 +187,9 @@ impl ValidatorDbWriter {
     }
 
     /// Persists a block header, replacing any header already stored at the same height.
+    #[miden_instrument(
+        target = COMPONENT,
+    )]
     pub(crate) async fn upsert_block_header(
         &self,
         header: BlockHeader,

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -58,7 +58,6 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
         let chain_tip = self
             .db
             .load_chain_tip()
-            .instrument(info_span!("load_chain_tip"))
             .await
             .map_err(|err| {
                 tonic::Status::internal(format!("Failed to load chain tip: {}", err.as_report()))
@@ -80,16 +79,9 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
 
         // Persist the signed header.
         let new_block_num = header.block_num().as_u32();
-        self.db
-            .upsert_block_header(header)
-            .instrument(info_span!("persist_block_header"))
-            .await
-            .map_err(|err| {
-                tonic::Status::internal(format!(
-                    "Failed to persist block header: {}",
-                    err.as_report()
-                ))
-            })?;
+        self.db.upsert_block_header(header).await.map_err(|err| {
+            tonic::Status::internal(format!("Failed to persist block header: {}", err.as_report()))
+        })?;
 
         // Update the in-memory counters after successful persistence. The block has already been
         // backed up to the block store by `validate_block`, so it is available to subscribers by

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -6,6 +6,7 @@ use miden_protocol::Word;
 use miden_protocol::block::{BlockNumber, ProposedBlock};
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::{PublicKey, Signature};
 use miden_tx::utils::serde::{Deserializable, Serializable};
+use tracing::{Instrument, info_span};
 
 use super::ValidatorService;
 
@@ -44,14 +45,20 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
 
         // Serialize sign_block requests to prevent race conditions between loading the chain tip
         // and persisting the validated block header.
-        let _permit = self.sign_block_semaphore.acquire().await.map_err(|err| {
-            tonic::Status::internal(format!("sign_block semaphore closed: {err}"))
-        })?;
+        let _permit = self
+            .sign_block_semaphore
+            .acquire()
+            .instrument(info_span!("acquire_permit"))
+            .await
+            .map_err(|err| {
+                tonic::Status::internal(format!("sign_block semaphore closed: {err}"))
+            })?;
 
         // Load the current chain tip from the database.
         let chain_tip = self
             .db
             .load_chain_tip()
+            .instrument(info_span!("load_chain_tip"))
             .await
             .map_err(|err| {
                 tonic::Status::internal(format!("Failed to load chain tip: {}", err.as_report()))
@@ -73,9 +80,16 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
 
         // Persist the signed header.
         let new_block_num = header.block_num().as_u32();
-        self.db.upsert_block_header(header).await.map_err(|err| {
-            tonic::Status::internal(format!("Failed to persist block header: {}", err.as_report()))
-        })?;
+        self.db
+            .upsert_block_header(header)
+            .instrument(info_span!("persist_block_header"))
+            .await
+            .map_err(|err| {
+                tonic::Status::internal(format!(
+                    "Failed to persist block header: {}",
+                    err.as_report()
+                ))
+            })?;
 
         // Update the in-memory counters after successful persistence. The block has already been
         // backed up to the block store by `validate_block`, so it is available to subscribers by

--- a/crates/block-producer/src/rpc_sync.rs
+++ b/crates/block-producer/src/rpc_sync.rs
@@ -15,7 +15,7 @@ use miden_protocol::utils::serde::Deserializable;
 use tokio_stream::StreamExt;
 use tonic_health::ServingStatus;
 use tonic_health::server::HealthReporter;
-use tracing::{info, warn};
+use tracing::{Instrument, info, info_span, warn};
 
 use crate::{COMPONENT, LOG_TARGET};
 
@@ -236,7 +236,16 @@ impl BlockSync {
             let upstream_tip = BlockNumber::from(event.committed_chain_tip);
             let block = SignedBlock::read_from_bytes(&event.block)
                 .context("failed to deserialize block from upstream")?;
-            self.writer.apply_block(block).await?;
+            // Each synced block gets its own root span: the surrounding `sync` span lives for the
+            // whole subscription, so parenting under it would chain every block into one
+            // never-exported trace.
+            let block_span = info_span!(
+                target: COMPONENT,
+                parent: None,
+                "sync_block",
+                block.number = block.header().block_num().as_u32(),
+            );
+            self.writer.apply_block(block).instrument(block_span).await?;
 
             let local_tip = self.state.committed_tip();
             self.readiness.update(upstream_tip, local_tip).await;

--- a/crates/store/src/state/writer/mod.rs
+++ b/crates/store/src/state/writer/mod.rs
@@ -91,6 +91,9 @@ impl Future for WriterTask {
 pub(super) struct WriteRequest {
     signed_block: SignedBlock,
     result_tx: oneshot::Sender<Result<(), ApplyBlockError>>,
+    /// Span of the `apply_block` caller. The worker runs the write under it, keeping the write path
+    /// in the caller's trace across the channel hop.
+    span: tracing::Span,
 }
 
 impl BlockWriter {
@@ -130,7 +133,11 @@ impl BlockWriter {
     pub async fn apply_block(&mut self, signed_block: SignedBlock) -> Result<(), ApplyBlockError> {
         let (result_tx, result_rx) = oneshot::channel();
         self.write_tx
-            .send(WriteRequest { signed_block, result_tx })
+            .send(WriteRequest {
+                signed_block,
+                result_tx,
+                span: tracing::Span::current(),
+            })
             .await
             .map_err(|e| ApplyBlockError::WriterTaskSendFailed(e.as_report()))?;
         result_rx.await?

--- a/crates/store/src/state/writer/worker.rs
+++ b/crates/store/src/state/writer/worker.rs
@@ -19,6 +19,7 @@ use miden_protocol::utils::serde::Serializable;
 use rayon::ThreadPool;
 use thread_priority::{ThreadPriority, set_current_thread_priority};
 use tokio::sync::{mpsc, watch};
+use tracing::Instrument;
 
 use super::WriteRequest;
 use crate::account_state_forest::{
@@ -154,7 +155,7 @@ impl WriteWorker {
                     None => break,
                 },
             };
-            let result = self.write_block(req.signed_block).await;
+            let result = self.write_block(req.signed_block).instrument(req.span).await;
             let _ = req.result_tx.send(result);
         }
     }


### PR DESCRIPTION
## Summary

### 1. Adds instrumentation for the pre-validate_block part of sign block stack:

<img width="1414" height="181" alt="Screenshot 2026-08-19 at 1 12 47 PM" src="https://github.com/user-attachments/assets/620d85a4-4d1a-4c23-8e8c-7aa5551b143b" />

Fixed (acquire_permit and load_chain_tip):
```
rpc [ 595µs ] rpc.service: "validator.Api" | rpc.method: "SignBlock" ...
┝━ acquire_permit [ 2.92µs | 0.49% ]
┝━ load_chain_tip [ 103µs | 17.37% ]
┝━ validate_block [ 252µs | 42.38% ] tip.number: 0 | block.number: 1 ...
│  ┝━ sign_block [ 62.0µs ]
│  ┕━ store.block_store.save_block [ 28.8µs ]
┕━ persist_block_header [ 173µs | 29.12% ]
```

### 2. Fixes orphaned spans we are seeing on devnet:

<img width="1119" height="595" alt="Screenshot 2026-08-19 at 1 11 29 PM" src="https://github.com/user-attachments/assets/e8b48291-09ac-441d-8321-3fbe0363ec66" />

Fixed (added tracing forest support to Validator for this):

```
sync_block [ 1.88ms ] block.number: 1
┕━ apply_block [ 1.88ms ]
   ┕━ write_block [ 1.88ms ] block.number: 1 ...
      ┝━ validate_block_header ...
      ┝━ apply_block (db) ... prune_history ...
      ┕━ apply_mutations ...
```

And sequencer side also:

```
block_builder.build_block [ 3.80ms | 0.00% / 100.00% ] block.number: 1 | block.batches.count: 0 | block.batch.ids: None | block.transactions.ids: None | block.transactions.count: 0 | block.updated_accounts.count: 0 | block.erased_note_proofs.count: 0 | block.nullifiers.count: 0 | block.output_notes.count: 0 | block.batches.output_notes.count: 0 | block.erased_notes.count: 0
┝━ block_builder.select_block [ 61.3µs | 0.64% / 1.61% ]
│  ┝━ mempool.lock [ 1.21µs | 0.03% ]
│  ┕━ mempool.select_block [ 35.6µs | 0.94% ] mempool.transactions.uncommitted: 0 | mempool.transactions.unbatched: 0 | mempool.batches.proposed: 0 | mempool.batches.proven: 0 | mempool.accounts: 0 | mempool.nullifiers: 0 | mempool.output_notes: 0
┝━ block_builder.get_block_inputs [ 280µs | 7.38% ]
┝━ block_builder.propose_block [ 30.4µs | 0.80% ]
┝━ block_builder.validate_block [ 1.10ms | 0.00% / 28.83% ]
│  ┕━ validator.client.validate_block [ 1.10ms | 28.83% ]
┕━ block_builder.commit_block [ 2.33ms | 0.00% / 61.37% ] block.number: 1 | block.commitment: 0xc9e804cffa4c7fe9def74ef4234a773aa78abd0342aea1b427f1940088266678 | block.transactions.count: 0
   ┝━ apply_block_with_proving_inputs [ 2.31ms | 0.00% / 60.74% ]
   │  ┝━ store.block_store.save_proving_inputs [ 22.1µs | 0.58% ] block.number: 1 | inputs_size: 654
   │  ┕━ apply_block [ 2.29ms | 0.00% / 60.16% ]
   │     ┕━ write_block [ 2.29ms | 35.64% / 60.16% ] block.number: 1 | block.commitment: 0xc9e804cffa4c7fe9def74ef4234a773aa78abd0342aea1b427f1940088266678 | block.transactions.count: 0 | snapshots.live: 1
   │        ┝━ validate_block_header [ 96.9µs | 2.55% ]
   ...
```

Each block is its own rooted `sync_block` tree instead of an endless chain under `sync`, and `write_block` is stitched under `apply_block` across the channel hop (previously it would have printed as a separate orphan tree). The sequencer side shows the same stitching under `block_builder.commit_block → apply_block_with_proving_inputs → apply_block → write_block`.
<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

## Changelog

```toml
[[entry]]
scope       = "validator"
impact      = "added"
description = "`decode` and `acquire_validation_permit` spans on the validator's sign-block and transaction submission paths."
```