### PR TITLE
fix: Bound tx validation and add spawn blocking calls

### DIFF
--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicU64;
 use miden_node_db::DatabaseError;
 use miden_node_proto::domain::encryption::TransactionEncryptionKeyInfo;
 use miden_node_store::BlockStore;
+use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 use miden_protocol::Word;
 use miden_protocol::block::{
@@ -107,6 +108,14 @@ pub(crate) struct ValidatorService {
     /// Serializes `sign_block` requests so that concurrent calls are processed sequentially,
     /// ensuring consistent chain tip reads and preventing race conditions.
     sign_block_semaphore: Semaphore,
+    /// Bounds concurrently executing transaction validations. Proof verification and re-execution
+    /// each pin a CPU on the blocking pool, and unbounded concurrency saturates every core,
+    /// starving the async runtime — and with it `sign_block` — of CPU time. A delayed block
+    /// signature stalls the whole chain. A delayed validation only slows transaction admission: the
+    /// RPC submits every transaction to every validator before it may enter the mempool, so blocks
+    /// are proposed exclusively from already-validated transactions and signing never waits on
+    /// validation. Validation is therefore capped below the core count to keep signing headroom.
+    tx_validation_semaphore: Semaphore,
     /// In-memory chain tip, updated after each signed block. Block subscriptions follow this to
     /// stream live blocks as they are signed.
     committed_tip: watch::Sender<BlockNumber>,
@@ -172,6 +181,7 @@ impl ValidatorService {
             db,
             block_store,
             sign_block_semaphore: Semaphore::new(1),
+            tx_validation_semaphore: Semaphore::new(tx_validation_permits()),
             committed_tip: watch::Sender::new(BlockNumber::from(initial_metrics.chain_tip)),
             validated_transactions_count: AtomicU64::new(initial_metrics.validated_transactions),
             signed_blocks_count: AtomicU64::new(initial_metrics.signed_blocks),
@@ -210,10 +220,14 @@ impl ValidatorService {
         if !unvalidated_txs.is_empty() {
             return Err(ValidatorError::UnvalidatedTransactions(unvalidated_txs));
         }
-        // Build the block header.
-        let (proposed_header, proposed_body) = proposed_block
-            .into_header_and_body()
-            .map_err(ValidatorError::BlockBuildingFailed)?;
+        // Build the block header. This computes the account, nullifier and note tree roots plus the
+        // chain and transaction commitments — hashing proportional to block contents — so it runs
+        // on a blocking thread rather than pinning an async worker.
+        let (proposed_header, proposed_body) =
+            spawn_blocking_in_current_span(move || proposed_block.into_header_and_body())
+                .await
+                .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+                .map_err(ValidatorError::BlockBuildingFailed)?;
 
         miden_span_record!(
             block.number = proposed_header.block_num().as_u32(),
@@ -272,8 +286,15 @@ impl ValidatorService {
             .expect("a single signature is within the signature set bounds");
         let signed_block =
             SignedBlock::new_unchecked(proposed_header, proposed_body, own_signature);
+        // Serializing the full block also scales with its contents; run it on a blocking thread.
+        let (signed_block, signed_block_bytes) = spawn_blocking_in_current_span(move || {
+            let bytes = signed_block.to_bytes();
+            (signed_block, bytes)
+        })
+        .await
+        .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()));
         self.block_store
-            .save_block(signed_block.header().block_num(), &signed_block.to_bytes())
+            .save_block(signed_block.header().block_num(), &signed_block_bytes)
             .await
             .map_err(ValidatorError::BlockBackupFailed)?;
 
@@ -296,4 +317,10 @@ impl ValidatorService {
             .await
             .map_err(|err| ValidatorError::BlockSigningFailed(err.to_string()))
     }
+}
+
+/// Number of transaction validations allowed to execute concurrently: the core count minus headroom
+/// reserved for the async runtime and the block-signing path, at least one.
+fn tx_validation_permits() -> usize {
+    std::thread::available_parallelism().map_or(1, |n| n.get().saturating_sub(2).max(1))
 }

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -181,7 +181,7 @@ impl ValidatorService {
             db,
             block_store,
             sign_block_semaphore: Semaphore::new(1),
-            tx_validation_semaphore: Semaphore::new(tx_validation_permits()),
+            tx_validation_semaphore: Semaphore::new(max_tx_concurrency()),
             committed_tip: watch::Sender::new(BlockNumber::from(initial_metrics.chain_tip)),
             validated_transactions_count: AtomicU64::new(initial_metrics.validated_transactions),
             signed_blocks_count: AtomicU64::new(initial_metrics.signed_blocks),
@@ -321,6 +321,6 @@ impl ValidatorService {
 
 /// Number of transaction validations allowed to execute concurrently: the core count minus headroom
 /// reserved for the async runtime and the block-signing path, at least one.
-fn tx_validation_permits() -> usize {
+fn max_tx_concurrency() -> usize {
     std::thread::available_parallelism().map_or(1, |n| n.get().saturating_sub(2).max(1))
 }

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::Ordering;
 
 use miden_node_proto::generated as grpc;
 use miden_node_utils::ErrorReport;
+use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::Word;
 use miden_protocol::block::{BlockNumber, ProposedBlock};
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::{PublicKey, Signature};
@@ -9,14 +10,18 @@ use miden_tx::utils::serde::{Deserializable, Serializable};
 use tracing::{Instrument, info_span};
 
 use super::ValidatorService;
+use crate::COMPONENT;
 
 #[tonic::async_trait]
 impl grpc::server::validator_api::SignBlock for ValidatorService {
     type Input = ProposedBlock;
     type Output = (Signature, Word, PublicKey);
 
+    #[miden_instrument(
+        target = COMPONENT,
+        err,
+    )]
     fn decode(request: grpc::blockchain::ProposedBlock) -> tonic::Result<Self::Input> {
-        let _span = info_span!("decode").entered();
         ProposedBlock::read_from_bytes(&request.proposed_block).map_err(|err| {
             tonic::Status::invalid_argument(
                 err.as_report_context("Failed to deserialize proposed block"),
@@ -24,6 +29,10 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
         })
     }
 
+    #[miden_instrument(
+        target = COMPONENT,
+        err,
+    )]
     fn encode(output: Self::Output) -> tonic::Result<grpc::blockchain::SignBlockResponse> {
         let (signature, block_commitment, public_key) = output;
         Ok(grpc::blockchain::SignBlockResponse {

--- a/bin/validator/src/server/validator_service/sign_block.rs
+++ b/bin/validator/src/server/validator_service/sign_block.rs
@@ -16,6 +16,7 @@ impl grpc::server::validator_api::SignBlock for ValidatorService {
     type Output = (Signature, Word, PublicKey);
 
     fn decode(request: grpc::blockchain::ProposedBlock) -> tonic::Result<Self::Input> {
+        let _span = info_span!("decode").entered();
         ProposedBlock::read_from_bytes(&request.proposed_block).map_err(|err| {
             tonic::Status::invalid_argument(
                 err.as_report_context("Failed to deserialize proposed block"),

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -3,11 +3,13 @@ use std::sync::atomic::Ordering;
 use miden_node_proto::domain::encryption::transaction_inputs_associated_data;
 use miden_node_proto::generated as grpc;
 use miden_node_utils::ErrorReport;
+use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 use miden_protocol::transaction::{ProvenTransaction, TransactionId, TransactionInputs};
 use miden_tx::utils::serde::{Deserializable, Serializable};
 use rand_core_06::OsRng;
 use tonic::Status;
+use tracing::{Instrument, info_span};
 
 use super::ValidatorService;
 use crate::tx_validation::validate_transaction;
@@ -53,24 +55,37 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
 
         let private_inputs = inputs.to_bytes();
 
+        // Bound concurrent validations; see `tx_validation_semaphore`. Acquired after the
+        // already-validated short-circuit so duplicate submissions never wait.
+        let _permit = self
+            .tx_validation_semaphore
+            .acquire()
+            .instrument(info_span!("acquire_validation_permit"))
+            .await
+            .map_err(|err| Status::internal(format!("validation semaphore closed: {err}")))?;
+
         // Validate the transaction.
         validate_transaction(tx, inputs).await.map_err(|err| {
             Status::invalid_argument(err.as_report_context("Invalid transaction"))
         })?;
 
-        // Re-encrypt the private inputs under a fresh content key.
+        // Re-encrypt the private inputs under a fresh content key. Sealing runs secp256k1 group
+        // operations, so it goes to a blocking thread rather than stalling an async worker.
         let record_id = PrivateRecordId::new(tx_id, &self.signer.public_key());
         let context = PrivateRecordContext::new(
             self.private_record_chain_id,
             self.private_record_sealer.key_epoch(),
             tx_id,
         );
-        let private_record = self
-            .private_record_sealer
-            .seal(&mut OsRng, record_id, context, &private_inputs)
-            .map_err(|err| {
-                Status::internal(err.as_report_context("Failed to protect transaction inputs"))
-            })?;
+        let sealer = self.private_record_sealer.clone();
+        let private_record = spawn_blocking_in_current_span(move || {
+            sealer.seal(&mut OsRng, record_id, context, &private_inputs)
+        })
+        .await
+        .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+        .map_err(|err| {
+            Status::internal(err.as_report_context("Failed to protect transaction inputs"))
+        })?;
 
         // Store the validated transaction and private record atomically.
         let count =


### PR DESCRIPTION
## Summary
Under load, the validator's `SignBlock` RPC was spiking from ~30ms to ~300ms, with the tracing added in #2487 showing the time spread uniformly across the request rather than concentrated in any one span — the signature of CPU starvation, not lock contention. Each submitted transaction runs proof verification and full VM re-execution on unbounded blocking threads, oversubscribing every core, while the Golden seal (secp256k1 ops) and the CPU-heavy parts of block signing ran directly on async workers.

The two paths have asymmetric failure modes: a delayed block signature stalls the whole chain, while a delayed transaction validation only slows admission — the RPC submits every transaction to every validator *before* it may enter the mempool, so blocks are proposed exclusively from already-validated transactions and signing never waits on validation. Signing must therefore always have CPU headroom; validation is the correct place to apply backpressure.

#### Changes:

- **Bounded validation concurrency**: `SubmitProvenTransaction` now acquires a permit from a semaphore sized to `available_parallelism - 2` (minimum 1) before validating, converting CPU oversubscription into visible queueing. The permit is acquired after the already-validated short-circuit, so duplicate submissions never wait. The wait is instrumented as an `acquire_validation_permit` span.
- **CPU work off the async workers**: the Golden seal (secp256k1 group ops), `into_header_and_body` (account/nullifier/note tree roots plus chain and transaction commitments — hashing proportional to block contents), and full-block serialization now run via `spawn_blocking_in_current_span`, with panics propagated via `resume_unwind` (same convention as `tx_validation`).
- **`decode` span**: `SignBlock::decode` now times `ProposedBlock` deserialization, closing the last un-instrumented sync segment of the request path.

Verified against a local multi-validator run: the `rpc` span's self-time drops to ~0% (fully attributed), the offloaded work still reports under `validate_block` (the helper carries the span across the thread hop), and the uncontended `acquire_validation_permit` adds no measurable latency. Behavior note: under sustained validation overload, submissions now queue (and eventually hit the request timeout) instead of silently degrading block signing — backpressure lands on submitters, which already handle it.

## Changelog

```toml
changelog = "none"
reason    = "Internal change only."
```