### PR TITLE
chore: remove RPC limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,7 +4425,6 @@ dependencies = [
  "bytes",
  "clap",
  "fs-err",
- "governor",
  "http 1.5.0",
  "http-body-util",
  "humantime",

--- a/bin/benchmark/README.md
+++ b/bin/benchmark/README.md
@@ -219,10 +219,6 @@ nohup miden-node sequencer \
   --batch.workers                             16 \
   --mempool.tx-capacity                       1000000 \
   --rpc.grpc.timeout                          24h \
-  --rpc.grpc.max-connection-age               24h \
-  --rpc.rate-limit.burst-size                 100000 \
-  --rpc.rate-limit.replenish-per-second       100000 \
-  --rpc.rate-limit.max-concurrent-connections 1000000 \
   > logs/node.log 2>&1 &
 
 nohup miden-ntx-builder start \

--- a/bin/node/src/commands/modes.rs
+++ b/bin/node/src/commands/modes.rs
@@ -15,7 +15,7 @@ use miden_node_proto::clients::{
 };
 use miden_node_rpc::{PreAuthSubmission, Rpc, RpcMode, SequencerInternal, ValidatorClients};
 use miden_node_store::{BlockWriter, ProofWriter, State, WriterTask};
-use miden_node_utils::clap::{GrpcOptionsInternal, duration_to_human_readable_string};
+use miden_node_utils::clap::duration_to_human_readable_string;
 use miden_node_utils::formatting::format_endpoint;
 use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
@@ -96,7 +96,7 @@ impl SequencerCommand {
             state,
             mode: RpcMode::sequencer(block_producer.clone(), validator_clients),
             ntx_builder: Some(ntx_builder_client),
-            grpc_options: runtime.external_grpc_options,
+            grpc_options: runtime.grpc_options,
             network_tx_auth,
         };
         let mut tasks = Tasks::new();
@@ -131,7 +131,7 @@ impl SequencerCommand {
             let sequencer_internal = SequencerInternal {
                 listener: bind_rpc(internal_listen).await?,
                 block_producer,
-                grpc_options: GrpcOptionsInternal::from(runtime.external_grpc_options),
+                grpc_options: runtime.grpc_options,
             };
             tasks.spawn("sequencer internal server", sequencer_internal.serve(shutdown.clone()));
         }
@@ -306,7 +306,7 @@ impl FullNodeCommand {
                 proof_writer,
             ),
             ntx_builder: None,
-            grpc_options: runtime.external_grpc_options,
+            grpc_options: runtime.grpc_options,
             network_tx_auth,
         };
         let mut tasks = Tasks::new();

--- a/bin/node/src/commands/rpc.rs
+++ b/bin/node/src/commands/rpc.rs
@@ -1,9 +1,8 @@
 use std::net::SocketAddr;
-use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
 use anyhow::Context;
-use miden_node_utils::clap::{GrpcOptionsExternal, duration_to_human_readable_string};
+use miden_node_utils::clap::duration_to_human_readable_string;
 use tonic::metadata::AsciiMetadataValue;
 use url::Url;
 
@@ -27,21 +26,11 @@ pub struct RpcOptions {
 
     #[command(flatten)]
     pub grpc: GrpcOptions,
-
-    #[command(flatten)]
-    pub rate_limit: RpcRateLimitOptions,
 }
 
 impl RpcOptions {
-    pub(super) fn external_grpc_options(&self) -> GrpcOptionsExternal {
-        GrpcOptionsExternal {
-            request_timeout: self.grpc.timeout,
-            max_connection_age: self.grpc.max_connection_age,
-            max_connection_age_grace: self.grpc.max_connection_age_grace,
-            burst_size: self.rate_limit.burst_size,
-            replenish_n_per_second_per_ip: self.rate_limit.replenish_per_second,
-            max_concurrent_connections: self.rate_limit.max_concurrent_connections,
-        }
+    pub(super) fn grpc_options(&self) -> miden_node_utils::clap::GrpcOptions {
+        miden_node_utils::clap::GrpcOptions { request_timeout: self.grpc.timeout }
     }
 
     pub(super) fn network_tx_auth(&self) -> anyhow::Result<Option<AsciiMetadataValue>> {
@@ -68,61 +57,6 @@ pub struct GrpcOptions {
         help_heading = super::section::RPC_CONFIGURATION_HELP_HEADING
     )]
     pub timeout: Duration,
-
-    /// Maximum duration of an RPC connection before the server drops it irrespective of activity.
-    #[arg(
-        long = "rpc.grpc.max-connection-age",
-        env = "MIDEN_NODE_RPC_GRPC_MAX_CONNECTION_AGE",
-        default_value = duration_to_human_readable_string(Duration::from_mins(30)),
-        value_parser = humantime::parse_duration,
-        value_name = "DURATION",
-        help_heading = super::section::RPC_CONFIGURATION_HELP_HEADING
-    )]
-    pub max_connection_age: Duration,
-
-    /// Grace period for an RPC connection to shut down after reaching its maximum age.
-    #[arg(
-        long = "rpc.grpc.max-connection-age-grace",
-        env = "MIDEN_NODE_RPC_GRPC_MAX_CONNECTION_AGE_GRACE",
-        default_value = duration_to_human_readable_string(Duration::from_secs(10)),
-        value_parser = humantime::parse_duration,
-        value_name = "DURATION",
-        help_heading = super::section::RPC_CONFIGURATION_HELP_HEADING
-    )]
-    pub max_connection_age_grace: Duration,
-}
-
-#[derive(clap::Args, Clone, Debug)]
-pub struct RpcRateLimitOptions {
-    /// Number of RPC request credits available per IP before replenishment.
-    #[arg(
-        long = "rpc.rate-limit.burst-size",
-        env = "MIDEN_NODE_RPC_RATE_LIMIT_BURST_SIZE",
-        default_value_t = NonZeroU32::new(128).unwrap(),
-        value_name = "NUM",
-        help_heading = super::section::RPC_RATE_LIMITING_HELP_HEADING
-    )]
-    pub burst_size: NonZeroU32,
-
-    /// Number of RPC request credits replenished per second per IP.
-    #[arg(
-        long = "rpc.rate-limit.replenish-per-second",
-        env = "MIDEN_NODE_RPC_RATE_LIMIT_REPLENISH_PER_SECOND",
-        default_value_t = NonZeroU64::new(16).unwrap(),
-        value_name = "NUM",
-        help_heading = super::section::RPC_RATE_LIMITING_HELP_HEADING
-    )]
-    pub replenish_per_second: NonZeroU64,
-
-    /// Maximum number of concurrent RPC connections accepted by the server.
-    #[arg(
-        long = "rpc.rate-limit.max-concurrent-connections",
-        env = "MIDEN_NODE_RPC_RATE_LIMIT_MAX_CONCURRENT_CONNECTIONS",
-        default_value_t = 1_000,
-        value_name = "NUM",
-        help_heading = super::section::RPC_RATE_LIMITING_HELP_HEADING
-    )]
-    pub max_concurrent_connections: u64,
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/bin/node/src/commands/runtime.rs
+++ b/bin/node/src/commands/runtime.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use miden_node_store::DatabaseOptions;
-use miden_node_utils::clap::{GrpcOptionsExternal, StorageOptions};
+use miden_node_utils::clap::{GrpcOptions, StorageOptions};
 
 use super::ENV_DATA_DIRECTORY;
 use super::rpc::RpcOptions;
@@ -27,7 +27,7 @@ impl RuntimeOptions {
             data_directory: self.data_directory.clone(),
             rpc_listen: self.rpc.listen,
             database_options: store.sqlite.database_options(),
-            external_grpc_options: self.rpc.external_grpc_options(),
+            grpc_options: self.rpc.grpc_options(),
             storage_options: store.storage.clone().into(),
         }
     }
@@ -38,6 +38,6 @@ pub(super) struct RuntimeConfig {
     pub data_directory: PathBuf,
     pub rpc_listen: SocketAddr,
     pub database_options: DatabaseOptions,
-    pub external_grpc_options: GrpcOptionsExternal,
+    pub grpc_options: GrpcOptions,
     pub storage_options: StorageOptions,
 }

--- a/bin/node/src/commands/section.rs
+++ b/bin/node/src/commands/section.rs
@@ -6,29 +6,16 @@
 //! help output for the sections that need extra context.
 
 pub(crate) const RPC_CONFIGURATION_HELP_HEADING: &str = "RPC configuration";
-pub(crate) const RPC_RATE_LIMITING_HELP_HEADING: &str = "RPC rate limiting";
 pub(crate) const BLOCK_PRODUCTION_HELP_HEADING: &str = "Block production";
 pub(crate) const STORE_CONFIGURATION_HELP_HEADING: &str = "Store configuration";
-
-const RPC_RATE_LIMITING_HELP_DESCRIPTION: &str = concat!(
-    "      Rate limits are applied per client IP using a bucket system.\n",
-    "      \n",
-    "      Each client's bucket has a maximum capacity which is configured by `rpc.rate-limit.burst-size`,\n",
-    "      and replenishes credits as per `rpc.rate-limit.replenish-per-second`.\n",
-    "      \n",
-    "      Each client IP can therefore burst requests up to this capacity before being rate limited\n",
-    "      to the replenishment rate.\n\n",
-);
 
 const STORE_CONFIGURATION_HELP_DESCRIPTION: &str = concat!(
     "      Defaults are reasonable for most use cases. Only change these settings if you understand\n",
     "      the storage and performance tradeoffs.\n\n",
 );
 
-const HELP_SECTION_DESCRIPTIONS: &[(&str, &str)] = &[
-    (RPC_RATE_LIMITING_HELP_HEADING, RPC_RATE_LIMITING_HELP_DESCRIPTION),
-    (STORE_CONFIGURATION_HELP_HEADING, STORE_CONFIGURATION_HELP_DESCRIPTION),
-];
+const HELP_SECTION_DESCRIPTIONS: &[(&str, &str)] =
+    &[(STORE_CONFIGURATION_HELP_HEADING, STORE_CONFIGURATION_HELP_DESCRIPTION)];
 
 /// Inserts explanatory text below clap-generated help section headings.
 pub(crate) fn inject_section_descriptions(mut help: String) -> String {
@@ -45,7 +32,7 @@ pub(crate) fn inject_section_descriptions(mut help: String) -> String {
 mod tests {
     use clap::CommandFactory;
 
-    use super::{RPC_RATE_LIMITING_HELP_HEADING, STORE_CONFIGURATION_HELP_HEADING};
+    use super::STORE_CONFIGURATION_HELP_HEADING;
     use crate::Cli;
 
     fn subcommand_help_headings(command: &str) -> Vec<String> {
@@ -64,12 +51,10 @@ mod tests {
     fn assert_injectable_section_headings(command: &str) {
         let headings = subcommand_help_headings(command);
 
-        for heading in [RPC_RATE_LIMITING_HELP_HEADING, STORE_CONFIGURATION_HELP_HEADING] {
-            assert!(
-                headings.iter().any(|candidate| candidate == heading),
-                "{command} is missing the {heading} heading targeted by help injection"
-            );
-        }
+        assert!(
+            headings.iter().any(|candidate| candidate == STORE_CONFIGURATION_HELP_HEADING),
+            "{command} is missing the {STORE_CONFIGURATION_HELP_HEADING} heading targeted by help injection"
+        );
     }
 
     #[test]

--- a/bin/validator/src/commands/mod.rs
+++ b/bin/validator/src/commands/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use base64::Engine;
 use clap::Parser;
-use miden_node_utils::clap::GrpcOptionsInternal;
+use miden_node_utils::clap::GrpcOptions;
 use miden_node_utils::logging::OpenTelemetry;
 use miden_node_utils::shutdown::CancellationToken;
 use miden_protocol::crypto::dsa::ecdsa_k256_keccak::{PublicKey, SigningKey};
@@ -200,7 +200,7 @@ pub enum ValidatorCommand {
         admin_listen: Option<std::net::SocketAddr>,
 
         #[command(flatten)]
-        grpc_options: GrpcOptionsInternal,
+        grpc_options: GrpcOptions,
 
         /// Maximum number of SQLite connections in the validator database connection pool.
         #[arg(

--- a/bin/validator/src/commands/start.rs
+++ b/bin/validator/src/commands/start.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context;
-use miden_node_utils::clap::GrpcOptionsInternal;
+use miden_node_utils::clap::GrpcOptions;
 use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
 use miden_validator::{
@@ -27,7 +27,7 @@ pub(crate) struct ValidatorKeys {
 pub async fn start(
     address: SocketAddr,
     admin_address: Option<SocketAddr>,
-    grpc_options: GrpcOptionsInternal,
+    grpc_options: GrpcOptions,
     keys: ValidatorKeys,
     data_directory: PathBuf,
     sqlite_connection_pool_size: NonZeroUsize,

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use miden_node_proto::server::validator_api;
 use miden_node_proto_build::validator_api_descriptor;
 use miden_node_store::BlockStore;
-use miden_node_utils::clap::GrpcOptionsInternal;
+use miden_node_utils::clap::GrpcOptions;
 use miden_node_utils::panic::catch_panic_layer_fn;
 use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tracing::grpc::grpc_trace_fn;
@@ -40,7 +40,7 @@ pub struct ValidatorServer {
     /// gRPC server options for internal services (timeouts, connection caps).
     ///
     /// If the handler takes longer than this duration, the server cancels the call.
-    pub grpc_options: GrpcOptionsInternal,
+    pub grpc_options: GrpcOptions,
 
     /// The signer used to sign blocks.
     pub signer: ValidatorSigner,

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -14,7 +14,7 @@ use miden_node_proto::clients::{
 use miden_node_proto::server::{rpc_api, sequencer_api};
 use miden_node_proto_build::rpc_api_descriptor;
 use miden_node_store::state::{BlockWriter, ProofWriter, State};
-use miden_node_utils::clap::{GrpcOptionsExternal, GrpcOptionsInternal};
+use miden_node_utils::clap::GrpcOptions;
 use miden_node_utils::cors::cors_for_grpc_web_layer;
 use miden_node_utils::grpc;
 use miden_node_utils::panic::{CatchPanicLayer, catch_panic_layer_fn};
@@ -48,7 +48,7 @@ pub struct Rpc {
     pub state: Arc<State>,
     pub mode: RpcMode,
     pub ntx_builder: Option<NtxBuilderClient>,
-    pub grpc_options: GrpcOptionsExternal,
+    pub grpc_options: GrpcOptions,
     pub network_tx_auth: Option<AsciiMetadataValue>,
 }
 
@@ -326,8 +326,6 @@ impl Rpc {
 
         let rpc = tonic::transport::Server::builder()
             .accept_http1(true)
-            .max_connection_age(self.grpc_options.max_connection_age)
-            .max_connection_age_grace(self.grpc_options.max_connection_age_grace)
             .timeout(self.grpc_options.request_timeout)
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
             .layer(
@@ -343,11 +341,9 @@ impl Rpc {
             )
             .layer(HealthCheckLayer)
             .layer(cors_for_grpc_web_layer())
-            // Note: must wrap the accept/rate-limit layers so grpc-web callers receive
-            // grpc-web-compatible error responses instead of opaque transport failures.
+            // Note: must wrap the accept layer so grpc-web callers receive grpc-web-compatible
+            // error responses instead of opaque transport failures.
             .layer(GrpcWebLayer::new())
-            .layer(grpc::rate_limit_concurrent_connections(self.grpc_options))
-            .layer(grpc::rate_limit_per_ip(self.grpc_options)?)
             // Resolve the (load-balancer-aware) client IP once here so handlers can read it from
             // request extensions instead of re-deriving it from headers.
             .layer(grpc::ResolveClientIpLayer)
@@ -453,7 +449,7 @@ pub struct SequencerInternal {
     /// The in-process block producer API submissions are forwarded to.
     pub block_producer: BlockProducerApi,
     /// gRPC server options for internal services (timeouts).
-    pub grpc_options: GrpcOptionsInternal,
+    pub grpc_options: GrpcOptions,
 }
 
 impl SequencerInternal {
@@ -474,8 +470,8 @@ impl SequencerInternal {
 
         let service = SequencerInternalService { block_producer: self.block_producer };
 
-        // Note: deliberately no accept-header / rate-limit / auth layers; this is a private,
-        // trusted interface and is expected to be network-isolated.
+        // Note: deliberately no accept-header / auth layers; this is a private, trusted interface
+        // and is expected to be network-isolated.
         tonic::transport::Server::builder()
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
             .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -1,5 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr};
-use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -22,7 +21,7 @@ use miden_node_proto::generated::{self as proto};
 use miden_node_proto::server::{ntx_builder_api, rpc_api, validator_api};
 use miden_node_store::genesis::config::GenesisConfig;
 use miden_node_store::state::State;
-use miden_node_utils::clap::GrpcOptionsExternal;
+use miden_node_utils::clap::GrpcOptions;
 use miden_node_utils::limiter::{
     QueryParamAccountIdLimit,
     QueryParamLimiter,
@@ -241,81 +240,6 @@ async fn rpc_server_accepts_requests_without_accept_header() {
 
     // Assert that the server did not reject our request.
     assert!(response.is_ok());
-}
-
-#[tokio::test]
-async fn rpc_rate_limits_per_ip() {
-    let grpc_options = GrpcOptionsExternal {
-        burst_size: NonZeroU32::new(8).unwrap(),
-        replenish_n_per_second_per_ip: NonZeroU64::new(1).unwrap(),
-        ..GrpcOptionsExternal::test()
-    };
-    let (_, rpc_addr, _store) = start_rpc_with_options(grpc_options).await;
-
-    let url = rpc_addr.to_string();
-    let url = Url::parse(format!("http://{}", &url).as_str()).unwrap();
-    let mut rpc_client = connect_rpc(url.clone(), Some(IpAddr::V4(Ipv4Addr::LOCALHOST))).await;
-
-    let mut results = Vec::new();
-    let mut last_error = None;
-    for _ in 0..256 {
-        let result = send_request(&mut rpc_client).await;
-        if let Err(err) = &result {
-            last_error = Some(err.code());
-        }
-        results.push(result);
-    }
-
-    assert!(results.iter().any(std::result::Result::is_ok));
-    assert!(
-        last_error.is_some_and(|code| code == tonic::Code::ResourceExhausted),
-        "expected rate limit error but got: {last_error:?}"
-    );
-}
-
-#[tokio::test]
-async fn rpc_connection_timeout_grace_does_not_panic() {
-    let tonic_timeout_panics = Arc::new(AtomicUsize::new(0));
-    let tonic_timeout_panics_hook = Arc::clone(&tonic_timeout_panics);
-    let default_panic_hook = std::panic::take_hook();
-
-    std::panic::set_hook(Box::new(move |info| {
-        let panic_payload = info
-            .payload()
-            .downcast_ref::<&str>()
-            .copied()
-            .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str));
-
-        if panic_payload
-            .is_some_and(|payload| payload.contains("async fn resumed after completion"))
-        {
-            tonic_timeout_panics_hook.fetch_add(1, Ordering::SeqCst);
-        }
-    }));
-
-    let grpc_options = GrpcOptionsExternal {
-        max_connection_age: Duration::from_millis(20),
-        max_connection_age_grace: Duration::from_millis(20),
-        ..GrpcOptionsExternal::test()
-    };
-    let (mut rpc_client, rpc_addr, _store) = start_rpc_with_options(grpc_options).await;
-
-    let initial_response = send_request(&mut rpc_client).await;
-    tokio::time::sleep(Duration::from_millis(150)).await;
-
-    let url = Url::parse(&format!("http://{rpc_addr}")).unwrap();
-    let mut fresh_rpc_client = connect_rpc(url, None).await;
-    let fresh_response = send_request(&mut fresh_rpc_client).await;
-
-    std::panic::set_hook(default_panic_hook);
-    initial_response.expect("initial RPC request should succeed");
-    fresh_response
-        .expect("RPC server should keep serving fresh connections after timing out an old one");
-    assert_eq!(
-        tonic_timeout_panics.load(Ordering::SeqCst),
-        0,
-        "tonic connection timeout should not panic after max_connection_age"
-    );
 }
 
 #[tokio::test]
@@ -1085,13 +1009,10 @@ async fn send_request(
     rpc_client.get_block_header_by_number(request).await
 }
 
-async fn connect_rpc(url: Url, local_address: Option<IpAddr>) -> RpcClient {
-    let mut endpoint = tonic::transport::Endpoint::from_shared(url.to_string())
+async fn connect_rpc(url: Url) -> RpcClient {
+    let endpoint = tonic::transport::Endpoint::from_shared(url.to_string())
         .expect("Url type always results in valid endpoint")
         .timeout(REQUEST_TIMEOUT);
-    if let Some(local_address) = local_address {
-        endpoint = endpoint.local_address(Some(local_address));
-    }
     let channel = endpoint.connect().await.expect("Failed to build channel");
     let interceptor = Interceptor::default();
     RpcClient::with_interceptor(channel, interceptor)
@@ -1100,12 +1021,7 @@ async fn connect_rpc(url: Url, local_address: Option<IpAddr>) -> RpcClient {
 /// Binds a socket on an available port, runs the RPC server on it, and returns a client to talk to
 /// the server, along with the socket address.
 async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TestStore) {
-    start_rpc_with_options(GrpcOptionsExternal::test()).await
-}
-
-async fn start_rpc_with_options(
-    grpc_options: GrpcOptionsExternal,
-) -> (RpcClient, std::net::SocketAddr, TestStore) {
+    let grpc_options = GrpcOptions::test();
     let store = TestStore::start().await;
     let block_producer_dir = new_tempdir();
     TestStore::bootstrap(&block_producer_dir);
@@ -1148,7 +1064,7 @@ async fn start_rpc_with_options(
     let url = rpc_addr.to_string();
     // SAFETY: The rpc_addr is always valid as it is created from a `SocketAddr`.
     let url = Url::parse(format!("http://{}", &url).as_str()).unwrap();
-    let rpc_client = connect_rpc(url, None).await;
+    let rpc_client = connect_rpc(url).await;
 
     (rpc_client, rpc_addr, store)
 }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -28,7 +28,6 @@ backon                   = { workspace = true }
 bytes                    = { version = "1.10" }
 clap                     = { workspace = true }
 fs-err                   = { workspace = true }
-governor                 = { version = "0.10" }
 http                     = { workspace = true }
 http-body-util           = { version = "0.1" }
 humantime                = { workspace = true }
@@ -44,7 +43,7 @@ thiserror                = { workspace = true }
 tokio                    = { features = ["macros", "rt", "signal", "time"], workspace = true }
 tokio-util               = { workspace = true }
 tonic                    = { default-features = true, workspace = true }
-tower                    = { features = ["limit"], workspace = true }
+tower                    = { workspace = true }
 tower-http               = { features = ["catch-panic"], workspace = true }
 tower_governor           = { version = "0.8" }
 tracing                  = { workspace = true }

--- a/crates/utils/src/clap.rs
+++ b/crates/utils/src/clap.rs
@@ -1,6 +1,5 @@
 //! Public module for share clap pieces to reduce duplication
 
-use std::num::{NonZeroU32, NonZeroU64};
 use std::time::Duration;
 
 #[cfg(feature = "rocksdb")]
@@ -10,11 +9,6 @@ pub use rocksdb::*;
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const TEST_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
-const DEFAULT_MAX_CONNECTION_AGE: Duration = Duration::from_mins(30);
-const DEFAULT_MAX_CONNECTION_AGE_GRACE: Duration = Duration::from_secs(10);
-const DEFAULT_REPLENISH_N_PER_SECOND_PER_IP: NonZeroU64 = NonZeroU64::new(16).unwrap();
-const DEFAULT_BURST_SIZE: NonZeroU32 = NonZeroU32::new(128).unwrap();
-const DEFAULT_MAX_CONCURRENT_CONNECTIONS: u64 = 1_000;
 
 // Formats a Duration into a human-readable string for display in clap help text and yields a
 // &'static str by _leaking_ the string deliberately.
@@ -23,7 +17,7 @@ pub fn duration_to_human_readable_string(duration: Duration) -> &'static str {
 }
 
 #[derive(clap::Args, Copy, Clone, Debug, PartialEq, Eq)]
-pub struct GrpcOptionsInternal {
+pub struct GrpcOptions {
     /// Maximum duration a gRPC request is allocated before being dropped by the server.
     ///
     /// This may occur if the server is overloaded or due to an internal bug.
@@ -36,118 +30,15 @@ pub struct GrpcOptionsInternal {
     pub request_timeout: Duration,
 }
 
-impl Default for GrpcOptionsInternal {
+impl Default for GrpcOptions {
     fn default() -> Self {
         Self { request_timeout: DEFAULT_REQUEST_TIMEOUT }
     }
 }
 
-impl From<GrpcOptionsExternal> for GrpcOptionsInternal {
-    fn from(value: GrpcOptionsExternal) -> Self {
-        let GrpcOptionsExternal { request_timeout, .. } = value;
-        Self { request_timeout }
-    }
-}
-
-impl GrpcOptionsInternal {
+impl GrpcOptions {
     pub fn test() -> Self {
-        GrpcOptionsExternal::test().into()
-    }
-    pub fn bench() -> Self {
-        GrpcOptionsExternal::bench().into()
-    }
-}
-
-#[derive(clap::Args, Copy, Clone, Debug, PartialEq, Eq)]
-pub struct GrpcOptionsExternal {
-    /// Maximum duration a gRPC request is allocated before being dropped by the server.
-    ///
-    /// This may occur if the server is overloaded or due to an internal bug.
-    #[arg(
-        long = "grpc.timeout",
-        default_value = duration_to_human_readable_string(DEFAULT_REQUEST_TIMEOUT),
-        value_parser = humantime::parse_duration,
-        value_name = "DURATION"
-    )]
-    pub request_timeout: Duration,
-
-    /// Maximum duration of a connection before we drop it on the server side irrespective of
-    /// activity.
-    #[arg(
-        long = "grpc.max_connection_age",
-        default_value = duration_to_human_readable_string(DEFAULT_MAX_CONNECTION_AGE),
-        value_parser = humantime::parse_duration,
-        value_name = "MAX_CONNECTION_AGE"
-    )]
-    pub max_connection_age: Duration,
-
-    /// Maximum duration for a connection to shut down gracefully after reaching the maximum age
-    /// before the server forcefully closes it.
-    #[arg(
-        long = "grpc.max_connection_age_grace",
-        default_value = duration_to_human_readable_string(DEFAULT_MAX_CONNECTION_AGE_GRACE),
-        value_parser = humantime::parse_duration,
-        value_name = "MAX_CONNECTION_AGE_GRACE"
-    )]
-    pub max_connection_age_grace: Duration,
-
-    /// Number of connections to be served before the "API tokens" need to be replenished per IP
-    /// address.
-    #[arg(
-        long = "grpc.burst_size",
-        default_value_t = DEFAULT_BURST_SIZE,
-        value_name = "BURST_SIZE"
-    )]
-    pub burst_size: NonZeroU32,
-
-    /// Number of request credits replenished per second per IP.
-    #[arg(
-        long = "grpc.replenish_n_per_second",
-        default_value_t = DEFAULT_REPLENISH_N_PER_SECOND_PER_IP,
-        value_name = "DEFAULT_REPLENISH_N_PER_SECOND"
-    )]
-    pub replenish_n_per_second_per_ip: NonZeroU64,
-
-    /// Maximum number of concurrent connections accepted by the server.
-    #[arg(
-        long = "grpc.max_concurrent_connections",
-        default_value_t = DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-        value_name = "MAX_CONCURRENT_CONNECTIONS"
-    )]
-    pub max_concurrent_connections: u64,
-}
-
-impl Default for GrpcOptionsExternal {
-    fn default() -> Self {
-        Self {
-            request_timeout: DEFAULT_REQUEST_TIMEOUT,
-            max_connection_age: DEFAULT_MAX_CONNECTION_AGE,
-            max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
-            burst_size: DEFAULT_BURST_SIZE,
-            replenish_n_per_second_per_ip: DEFAULT_REPLENISH_N_PER_SECOND_PER_IP,
-            max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-        }
-    }
-}
-
-impl GrpcOptionsExternal {
-    pub fn test() -> Self {
-        Self {
-            request_timeout: TEST_REQUEST_TIMEOUT,
-            ..Default::default()
-        }
-    }
-
-    /// Return a gRPC config for benchmarking.
-    pub fn bench() -> Self {
-        Self {
-            request_timeout: Duration::from_hours(24),
-            max_connection_age: Duration::from_hours(24),
-            max_connection_age_grace: DEFAULT_MAX_CONNECTION_AGE_GRACE,
-            burst_size: NonZeroU32::new(100_000).unwrap(),
-            replenish_n_per_second_per_ip: NonZeroU64::new(100_000).unwrap(),
-            max_concurrent_connections: u64::MAX,
-        }
+        Self { request_timeout: TEST_REQUEST_TIMEOUT }
     }
 }
 

--- a/crates/utils/src/grpc/layers.rs
+++ b/crates/utils/src/grpc/layers.rs
@@ -1,59 +1,9 @@
 use std::net::{IpAddr, SocketAddr};
 use std::task::{Context as TaskContext, Poll};
-use std::time::Duration;
 
-use anyhow::{Context, ensure};
-use governor::middleware::StateInformationMiddleware;
-use tower::limit::GlobalConcurrencyLimitLayer;
 use tower::{Layer, Service};
 use tower_governor::GovernorError;
-use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::key_extractor::{KeyExtractor, SmartIpKeyExtractor};
-
-use crate::clap::GrpcOptionsExternal;
-
-/// Builds a global concurrency limit layer using the configured semaphore.
-pub fn rate_limit_concurrent_connections(
-    grpc_options: GrpcOptionsExternal,
-) -> GlobalConcurrencyLimitLayer {
-    tower::limit::GlobalConcurrencyLimitLayer::new(grpc_options.max_concurrent_connections as usize)
-}
-
-/// Creates a per-IP rate limit layer using the configured governor settings.
-pub fn rate_limit_per_ip(
-    grpc_options: GrpcOptionsExternal,
-) -> anyhow::Result<
-    tower_governor::GovernorLayer<GrpcIpExtractor, StateInformationMiddleware, tonic::body::Body>,
-> {
-    let nanos_per_replenish = Duration::from_secs(1)
-        .as_nanos()
-        .checked_div(u128::from(grpc_options.replenish_n_per_second_per_ip.get()))
-        .unwrap_or_default();
-    ensure!(
-        nanos_per_replenish > 0,
-        "grpc.replenish_n_per_second must be less than or equal to 1e9"
-    );
-    let replenish_period = Duration::from_nanos(
-        u64::try_from(nanos_per_replenish).context("invalid gRPC rate limit configuration")?,
-    );
-    let config = GovernorConfigBuilder::default()
-        .key_extractor(GrpcIpExtractor::default())
-        .period(replenish_period)
-        .burst_size(grpc_options.burst_size.into())
-        .use_headers()
-        .finish()
-        .context("invalid gRPC rate limit configuration")?;
-    let limiter = std::sync::Arc::clone(config.limiter());
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_mins(1));
-        loop {
-            interval.tick().await;
-            // avoid a DoS vector
-            limiter.retain_recent();
-        }
-    });
-    Ok(tower_governor::GovernorLayer::new(config))
-}
 
 /// The originating client IP, resolved by [`ResolveClientIpLayer`] and stored in a request's
 /// extensions.
@@ -76,8 +26,8 @@ impl ClientIp {
 ///
 /// IP resolution reuses [`GrpcIpExtractor`], so clients behind a load balancer or reverse proxy are
 /// identified by their forwarded IP (via `X-Forwarded-For` / `X-Real-Ip` / `Forwarded` headers),
-/// falling back to the peer address. Resolving once at the transport layer keeps this consistent
-/// with the per-IP rate limiter and lets handlers read the result instead of re-deriving it.
+/// falling back to the peer address. Resolving once at the transport layer lets handlers read the
+/// result instead of re-deriving it.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ResolveClientIpLayer;
 

--- a/docs/external/src/network-operator/overview.md
+++ b/docs/external/src/network-operator/overview.md
@@ -28,6 +28,16 @@ reach the sequencer.
 The network monitor observes the deployment from the outside. It can check RPC freshness, validator status, prover
 status, explorer and faucet availability, note transport, and end-to-end network transaction behavior.
 
+## Rate Limiting
+
+The node does not rate limit requests. RPC deployments scale horizontally behind a load balancer, so per-node limits
+would apply per instance rather than per deployment and would not provide meaningful protection. Impose rate limits at
+the infrastructure layer instead on the load balancer or reverse proxy fronting the public entry points.
+
+The node still protects itself against malformed or oversized requests through per-request limits: request timeouts,
+capped message sizes, and per-method parameter limits (see the RPC guide's Errors and Limits page). Slow subscription
+consumers are disconnected and temporarily banned by the node itself.
+
 ## Components and Roles
 
 ### Sequencer

--- a/docs/external/src/rpc/errors-and-limits.md
+++ b/docs/external/src/rpc/errors-and-limits.md
@@ -63,7 +63,8 @@ fall into the ordinary-gRPC-status bucket described above:
   network, and corrupt framing.
 - `FAILED_PRECONDITION` when the inputs were sealed against a key the validator does not hold. This is the one case a
   client can act on: re-fetch `GetTransactionEncryptionKey` and seal again. Treat it as non-retryable without
-  re-sealing, and back off rather than retrying in a tight loop, since the key fetch is itself rate limited.
+  re-sealing, and back off rather than retrying in a tight loop, since official endpoints may rate limit requests at the
+  infrastructure level.
 
 ## Request Limits
 

--- a/scripts/bench-local.sh
+++ b/scripts/bench-local.sh
@@ -184,11 +184,7 @@ start_bg node miden-node sequencer \
     --batch.interval                            500ms \
     --batch.workers                             4 \
     --mempool.tx-capacity                       100000 \
-    --rpc.grpc.timeout                          24h \
-    --rpc.grpc.max-connection-age               24h \
-    --rpc.rate-limit.burst-size                 100000 \
-    --rpc.rate-limit.replenish-per-second       100000 \
-    --rpc.rate-limit.max-concurrent-connections 1000000
+    --rpc.grpc.timeout                          24h
 wait_for_port "$RPC_PORT" node
 
 start_bg ntx-builder miden-ntx-builder start \


### PR DESCRIPTION
closes #2482 

## Summary

- Removes the per-IP rate limiter and the global concurrent-connection cap from the RPC server, along with the forced gRPC connection closure after a maximum connection age.
- Removes the corresponding CLI flags and env vars: `--rpc.rate-limit.burst-size, --rpc.rate-limit.replenish-per-second, --rpc.rate-limit.max-concurrent-connections, --rpc.grpc.max-connection-age, and --rpc.grpc.max-connection-age-grace`.
- Collapses `GrpcOptionsExternal`/`GrpcOptionsInternal` into a single `GrpcOptions`.
- Keeps the client-IP resolution layer (still used by the subscription slow-subscriber ban list) and the per-request protections (timeouts, parameter limits).
- Adds a "Rate Limiting" section to the network operator guide documenting that limits should be imposed at the load balancer / reverse proxy.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "rpc"
impact      = "removed"
description = "Removed node-level RPC rate limits (per-IP and max concurrent connections) and the max-connection-age closure, along with their CLI flags; rate limiting should be imposed at the load-balancer layer (see the operator guide)."
```
