### PR TITLE
chore: run Docker runtime as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*
+# Unprivileged runtime user. `/data` is created here so a first-use named
+# volume mounted at `/data` inherits this ownership (Docker copies the image
+# directory into a new named volume). Without that, the volume is root:root
+# and the process cannot write.
+RUN groupadd --gid 10001 miden && \
+    useradd --uid 10001 --gid miden --no-create-home --home-dir /nonexistent \
+        --shell /usr/sbin/nologin miden && \
+    mkdir -p /data && \
+    chown miden:miden /data
 
 FROM runtime-base AS runtime-common
 ARG BIN
@@ -150,6 +159,7 @@ LABEL org.opencontainers.image.created=$CREATED \
 # Use exec to replace the shell so the binary runs as PID 1.
 ENV MIDEN_BIN=${BIN}
 CMD ["/bin/sh", "-c", "exec /usr/local/bin/$MIDEN_BIN"]
+USER miden
 
 # Command-line tools do not listen on a port.
 FROM runtime-common AS runtime-tool


### PR DESCRIPTION
## Summary

Closes #2492.

Runtime images currently start as root. This adds an unprivileged `miden` user (uid/gid 10001) and sets `USER miden` on `runtime-common`, so `runtime` and `runtime-tool` inherit it.

`/data` is created and owned by that user in the image so a first-use named volume mounted at `/data` inherits the ownership. Without that, Docker creates the volume as root:root and the process cannot write. Builder stages, `COPY`, and `CMD` are unchanged.

Existing volumes that were written as root need `chown -R 10001:10001` or to be recreated. New volumes are unaffected. If maintainers want an automatic migration for those volumes, I can add it as a follow-up.

## Changelog

```toml
[[entry]]
scope       = "node"
impact      = "changed"
description = "Docker runtime images now run as a non-root `miden` user (uid 10001)."
```