### PR TITLE
Improve and fix mempool stats

### DIFF
--- a/bin/network-monitor/src/service_status.rs
+++ b/bin/network-monitor/src/service_status.rs
@@ -263,6 +263,8 @@ pub struct BlockProducerStatusDetails {
 /// Details about the block producer's mempool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MempoolStatusDetails {
+    /// Number of transactions that have not yet been committed.
+    pub uncommitted_transactions: u64,
     /// Number of transactions currently in the mempool waiting to be batched.
     pub unbatched_transactions: u64,
     /// Number of batches currently being proven.
@@ -311,6 +313,7 @@ impl From<BlockProducerStatus> for BlockProducerStatusDetails {
         // Mempool statistics are a message field, hence optional on the wire; a node version that
         // omits them must not bring the checker down.
         let mempool = value.mempool_stats.map(|stats| MempoolStatusDetails {
+            uncommitted_transactions: stats.uncommitted_transactions,
             unbatched_transactions: stats.unbatched_transactions,
             proposed_batches: stats.proposed_batches,
             proven_batches: stats.proven_batches,

--- a/bin/network-monitor/src/view/cards/rpc.rs
+++ b/bin/network-monitor/src/view/cards/rpc.rs
@@ -40,10 +40,12 @@ pub(in crate::view) fn render_rpc_status(details: &RpcStatusDetails) -> Markup {
                     div class="nested-status mempool-stats" {
                         strong { "Mempool stats:" }
                         @if let Some(mempool) = &block_producer.mempool {
+                            (metric_row("Uncommitted TXs:", &mempool.uncommitted_transactions.to_string()))
                             (metric_row("Unbatched TXs:", &mempool.unbatched_transactions.to_string()))
                             (metric_row("Proposed Batches:", &mempool.proposed_batches.to_string()))
                             (metric_row("Proven Batches:", &mempool.proven_batches.to_string()))
                         } @else {
+                            (metric_row("Uncommitted TXs:", "-"))
                             (metric_row("Unbatched TXs:", "-"))
                             (metric_row("Proposed Batches:", "-"))
                             (metric_row("Proven Batches:", "-"))

--- a/bin/network-monitor/src/view/mod.rs
+++ b/bin/network-monitor/src/view/mod.rs
@@ -314,6 +314,7 @@ mod tests {
                 status: Status::Healthy,
                 chain_tip: 42,
                 mempool: Some(MempoolStatusDetails {
+                    uncommitted_transactions: 4,
                     unbatched_transactions: 1,
                     proposed_batches: 2,
                     proven_batches: 3,

--- a/crates/block-producer/src/mempool/graph/batch.rs
+++ b/crates/block-producer/src/mempool/graph/batch.rs
@@ -160,10 +160,7 @@ impl BatchGraph {
     }
 
     pub fn proven_count(&self) -> usize {
-        self.proven
-            .keys()
-            .filter(|batch| !self.inner.is_selected(batch))
-            .count()
+        self.proven.keys().filter(|batch| !self.inner.is_selected(batch)).count()
     }
 
     pub fn proposed_count(&self) -> usize {

--- a/crates/block-producer/src/mempool/graph/batch.rs
+++ b/crates/block-producer/src/mempool/graph/batch.rs
@@ -160,13 +160,16 @@ impl BatchGraph {
     }
 
     pub fn proven_count(&self) -> usize {
-        self.proven.len()
+        self.proven
+            .keys()
+            .filter(|batch| !self.inner.is_selected(batch))
+            .count()
     }
 
     pub fn proposed_count(&self) -> usize {
         self.inner
             .node_count()
-            .checked_sub(self.proven_count())
+            .checked_sub(self.proven.len())
             .expect("proven batches cannot exceed total batches")
     }
 }

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -246,7 +246,7 @@ impl Mempool {
         &mut self,
         tx: Arc<AuthenticatedTransaction>,
     ) -> Result<BlockNumber, MempoolSubmissionError> {
-        if self.unbatched_transactions_count() >= self.config.tx_capacity.get() {
+        if self.uncommitted_transactions_count() >= self.config.tx_capacity.get() {
             return Err(MempoolSubmissionError::CapacityExceeded);
         }
 
@@ -283,7 +283,9 @@ impl Mempool {
     ) -> Result<BlockNumber, MempoolSubmissionError> {
         assert!(!txs.is_empty(), "Cannot have a batch with no transactions");
 
-        if self.unbatched_transactions_count() + txs.len() > self.config.tx_capacity.get() {
+        if self.uncommitted_transactions_count().saturating_add(txs.len())
+            > self.config.tx_capacity.get()
+        {
             return Err(MempoolSubmissionError::CapacityExceeded);
         }
 
@@ -583,6 +585,26 @@ impl Mempool {
     // STATS & INSPECTION
     // --------------------------------------------------------------------------------------------
 
+    /// Returns the latest block committed to the canonical chain.
+    pub fn committed_chain_tip(&self) -> BlockNumber {
+        self.committed_chain_tip
+    }
+
+    /// Returns the number of transactions that have not yet been committed.
+    pub fn uncommitted_transactions_count(&self) -> usize {
+        let committed_transactions = self
+            .committed_blocks
+            .iter()
+            .flat_map(|block| block.batches.iter())
+            .map(|batch| batch.transactions().as_slice().len())
+            .sum::<usize>();
+
+        self.transactions
+            .count()
+            .checked_sub(committed_transactions)
+            .expect("committed transactions must exist in the transaction graph")
+    }
+
     /// Returns the number of transactions currently waiting to be batched.
     pub fn unbatched_transactions_count(&self) -> usize {
         self.transactions.unselected_count()
@@ -602,14 +624,8 @@ impl Mempool {
     // --------------------------------------------------------------------------------------------
 
     fn telemetry(&self) -> MempoolTelemetry {
-        let committed_txs = self
-            .committed_blocks
-            .iter()
-            .flat_map(|block| block.batches.iter())
-            .map(|batch| batch.transactions().as_slice().len())
-            .sum::<usize>();
         MempoolTelemetry {
-            uncommitted_transactions: self.transactions.count() - committed_txs,
+            uncommitted_transactions: self.uncommitted_transactions_count(),
             unbatched_transactions: self.unbatched_transactions_count(),
             proposed_batches: self.proposed_batches_count(),
             proven_batches: self.proven_batches_count(),

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use assert_matches::assert_matches;
 use miden_protocol::Word;
 use miden_protocol::block::{BlockHeader, BlockNumber};
 use pretty_assertions::assert_eq;
@@ -47,6 +48,43 @@ impl Mempool {
 
         (uut.clone(), uut)
     }
+}
+
+#[test]
+fn capacity_counts_batched_uncommitted_transactions() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.tx_capacity = NonZeroUsize::new(1).unwrap();
+    let [first, second, _] = MockProvenTxBuilder::sequential();
+
+    uut.add_transaction(first).unwrap();
+    uut.select_any_batch().unwrap();
+
+    assert_eq!(uut.uncommitted_transactions_count(), 1);
+    assert_eq!(uut.unbatched_transactions_count(), 0);
+    assert_matches!(
+        uut.add_transaction(second),
+        Err(MempoolSubmissionError::CapacityExceeded)
+    );
+}
+
+#[test]
+fn retained_committed_transactions_do_not_consume_capacity() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.tx_capacity = NonZeroUsize::new(1).unwrap();
+    let [first, second, _] = MockProvenTxBuilder::sequential();
+
+    uut.add_transaction(first.clone()).unwrap();
+    uut.select_any_batch().unwrap();
+    uut.commit_batch(Arc::new(ProvenBatch::mocked_from_transactions([
+        first.raw_proven_transaction()
+    ])));
+    let block = uut.select_block();
+    let header = BlockHeader::mock(block.block_number, None, None, &[], Word::empty());
+    uut.commit_block(&header);
+
+    assert_eq!(uut.uncommitted_transactions_count(), 0);
+    assert_eq!(uut.transactions.count(), 1, "committed state should still be retained");
+    uut.add_transaction(second).unwrap();
 }
 
 #[test]

--- a/crates/block-producer/src/mempool/tests.rs
+++ b/crates/block-producer/src/mempool/tests.rs
@@ -61,10 +61,7 @@ fn capacity_counts_batched_uncommitted_transactions() {
 
     assert_eq!(uut.uncommitted_transactions_count(), 1);
     assert_eq!(uut.unbatched_transactions_count(), 0);
-    assert_matches!(
-        uut.add_transaction(second),
-        Err(MempoolSubmissionError::CapacityExceeded)
-    );
+    assert_matches!(uut.add_transaction(second), Err(MempoolSubmissionError::CapacityExceeded));
 }
 
 #[test]

--- a/crates/block-producer/src/mempool/tests/add_user_batch.rs
+++ b/crates/block-producer/src/mempool/tests/add_user_batch.rs
@@ -68,10 +68,7 @@ fn user_batch_capacity_counts_batched_uncommitted_transactions() {
     uut.add_transaction(conventional).unwrap();
     uut.select_any_batch().unwrap();
 
-    assert_matches!(
-        uut.add_user_batch(&user_batch),
-        Err(MempoolSubmissionError::CapacityExceeded)
-    );
+    assert_matches!(uut.add_user_batch(&user_batch), Err(MempoolSubmissionError::CapacityExceeded));
 }
 
 #[test]

--- a/crates/block-producer/src/mempool/tests/add_user_batch.rs
+++ b/crates/block-producer/src/mempool/tests/add_user_batch.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use assert_matches::assert_matches;
@@ -55,6 +56,22 @@ fn user_batch_respects_batch_budget() {
     let result = uut.add_user_batch(&user_batch_txs[..2]);
 
     assert_matches!(result, Err(MempoolSubmissionError::CapacityExceeded));
+}
+
+#[test]
+fn user_batch_capacity_counts_batched_uncommitted_transactions() {
+    let (mut uut, _) = Mempool::for_tests();
+    uut.config.tx_capacity = NonZeroUsize::new(1).unwrap();
+    let conventional = build_tx(MockProvenTxBuilder::with_account_index(300));
+    let user_batch = [build_tx(MockProvenTxBuilder::with_account_index(301))];
+
+    uut.add_transaction(conventional).unwrap();
+    uut.select_any_batch().unwrap();
+
+    assert_matches!(
+        uut.add_user_batch(&user_batch),
+        Err(MempoolSubmissionError::CapacityExceeded)
+    );
 }
 
 #[test]

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -448,6 +448,8 @@ impl BlockProducerApi {
 pub struct MempoolStats {
     /// The mempool's current view of the chain tip height.
     pub chain_tip: BlockNumber,
+    /// Number of transactions that have not yet been committed.
+    pub uncommitted_transactions: u64,
     /// Number of transactions currently in the mempool waiting to be batched.
     pub unbatched_transactions: u64,
     /// Number of batches currently being proven.
@@ -459,7 +461,8 @@ pub struct MempoolStats {
 impl MempoolStats {
     fn from_mempool(mempool: &Mempool) -> Self {
         Self {
-            chain_tip: mempool.chain_tip(),
+            chain_tip: mempool.committed_chain_tip(),
+            uncommitted_transactions: mempool.uncommitted_transactions_count() as u64,
             unbatched_transactions: mempool.unbatched_transactions_count() as u64,
             proposed_batches: mempool.proposed_batches_count() as u64,
             proven_batches: mempool.proven_batches_count() as u64,

--- a/crates/block-producer/src/server/tests.rs
+++ b/crates/block-producer/src/server/tests.rs
@@ -11,6 +11,11 @@ use miden_protocol::block::{BlockHeader, BlockNumber, ValidatorKeys};
 use miden_protocol::testing::random_secret_key::random_secret_key;
 use url::Url;
 
+use crate::domain::transaction::AuthenticatedTransaction;
+use crate::mempool::{Mempool, MempoolConfig};
+use crate::server::MempoolStats;
+use crate::test_utils::MockProvenTxBuilder;
+use crate::test_utils::batch::TransactionBatchConstructor;
 use crate::{
     DEFAULT_BATCH_WORKERS,
     DEFAULT_MAX_BATCHES_PER_BLOCK,
@@ -19,11 +24,6 @@ use crate::{
     DEFAULT_VALIDATOR_TIMEOUT,
     Sequencer,
 };
-use crate::domain::transaction::AuthenticatedTransaction;
-use crate::mempool::{Mempool, MempoolConfig};
-use crate::server::MempoolStats;
-use crate::test_utils::batch::TransactionBatchConstructor;
-use crate::test_utils::MockProvenTxBuilder;
 
 #[test]
 fn mempool_stats_track_uncommitted_work_and_the_canonical_tip() {

--- a/crates/block-producer/src/server/tests.rs
+++ b/crates/block-producer/src/server/tests.rs
@@ -1,10 +1,13 @@
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use std::time::Duration;
 
 use miden_node_store::GenesisState;
 use miden_node_store::state::State;
 use miden_node_utils::fee::test_fee_params;
-use miden_protocol::block::{BlockNumber, ValidatorKeys};
+use miden_protocol::Word;
+use miden_protocol::batch::ProvenBatch;
+use miden_protocol::block::{BlockHeader, BlockNumber, ValidatorKeys};
 use miden_protocol::testing::random_secret_key::random_secret_key;
 use url::Url;
 
@@ -16,6 +19,55 @@ use crate::{
     DEFAULT_VALIDATOR_TIMEOUT,
     Sequencer,
 };
+use crate::domain::transaction::AuthenticatedTransaction;
+use crate::mempool::{Mempool, MempoolConfig};
+use crate::server::MempoolStats;
+use crate::test_utils::batch::TransactionBatchConstructor;
+use crate::test_utils::MockProvenTxBuilder;
+
+#[test]
+fn mempool_stats_track_uncommitted_work_and_the_canonical_tip() {
+    let shared = Mempool::shared(BlockNumber::GENESIS, MempoolConfig::default());
+    let mut mempool = shared.lock().unwrap();
+    let tx = Arc::new(AuthenticatedTransaction::from_inner(
+        MockProvenTxBuilder::with_account_index(100).build(),
+    ));
+
+    mempool.add_transaction(Arc::clone(&tx)).unwrap();
+    let stats = MempoolStats::from_mempool(&mempool);
+    assert_eq!(stats.chain_tip, BlockNumber::GENESIS);
+    assert_eq!(stats.uncommitted_transactions, 1);
+    assert_eq!(stats.unbatched_transactions, 1);
+    assert_eq!(stats.proposed_batches, 0);
+    assert_eq!(stats.proven_batches, 0);
+
+    mempool.select_any_batch().unwrap();
+    let stats = MempoolStats::from_mempool(&mempool);
+    assert_eq!(stats.uncommitted_transactions, 1);
+    assert_eq!(stats.unbatched_transactions, 0);
+    assert_eq!(stats.proposed_batches, 1);
+    assert_eq!(stats.proven_batches, 0);
+
+    mempool.commit_batch(Arc::new(ProvenBatch::mocked_from_transactions([
+        tx.raw_proven_transaction()
+    ])));
+    let stats = MempoolStats::from_mempool(&mempool);
+    assert_eq!(stats.proposed_batches, 0);
+    assert_eq!(stats.proven_batches, 1);
+
+    let block = mempool.select_block();
+    let stats = MempoolStats::from_mempool(&mempool);
+    assert_eq!(stats.chain_tip, BlockNumber::GENESIS);
+    assert_eq!(stats.uncommitted_transactions, 1);
+    assert_eq!(stats.proven_batches, 0);
+
+    let header = BlockHeader::mock(block.block_number, None, None, &[], Word::empty());
+    mempool.commit_block(&header);
+    let stats = MempoolStats::from_mempool(&mempool);
+    assert_eq!(stats.chain_tip, BlockNumber::GENESIS.child());
+    assert_eq!(stats.uncommitted_transactions, 0);
+    assert_eq!(stats.proven_batches, 0);
+}
 
 #[tokio::test]
 async fn block_producer_starts_with_store_state() {

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -76,5 +76,6 @@ fn block_producer_mempool_stats_to_proto(stats: MempoolStats) -> proto::rpc::Mem
         unbatched_transactions: stats.unbatched_transactions,
         proposed_batches: stats.proposed_batches,
         proven_batches: stats.proven_batches,
+        uncommitted_transactions: stats.uncommitted_transactions,
     }
 }

--- a/proto/proto/rpc.proto
+++ b/proto/proto/rpc.proto
@@ -210,6 +210,9 @@ message MempoolStats {
 
     // Number of proven batches waiting for block inclusion.
     uint64 proven_batches = 3;
+
+    // Number of transactions that have not yet been committed.
+    uint64 uncommitted_transactions = 4;
 }
 
 // GET BLOCK HEADER BY NUMBER


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Small fixes to the mempool stats. I noticed that our mempool stats constantly indicated a larger number than was likely on testnet. Initially suspected a blocked or stuck set of batches, but it turned out we included locally retained (committed) blocks in our "live" stats - so batch and transaction count were always higher than reality.

I fixed this, plus some other small inconsistencies. In addition, the monitor now includes the number of uncommitted transactions in its mempool view.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "network-monitor"
impact      = "added"
description = "Mempool now tracks uncommitted transaction count"

[[entry]]
scope       = "node"
impact      = "fixed"
description = "Mempool now correctly includes transactions in uncommitted batches in its capacity check"

[[entry]]
scope       = "node"
impact      = "fixed"
description = "Mempool chain tip no longer includes the pending block"

[[entry]]
scope       = "node"
impact      = "added"
description = "Mempool now tracks uncommitted transaction count"

[[entry]]
scope       = "node"
impact      = "fixed"
description = "Mempool no longer includes recently committed blocks in its stats"
```
