### PR TITLE
Stop leaking test servers

### DIFF
--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -241,11 +241,18 @@ pub struct BlockProducerStatus {
 
 impl BlockProducerApi {
     /// Creates an API backed by a fresh mempool.
-    pub fn new(state: Arc<State>, chain_tip: BlockNumber, config: BlockProducerApiConfig) -> Self {
+    ///
+    /// The background mempool statistics updater runs until `shutdown` is cancelled.
+    pub fn new(
+        state: Arc<State>,
+        chain_tip: BlockNumber,
+        config: BlockProducerApiConfig,
+        shutdown: CancellationToken,
+    ) -> Self {
         Self::from_shared_mempool(
             Mempool::shared(chain_tip, config.mempool_config()),
             state,
-            CancellationToken::new(),
+            shutdown,
         )
     }
 

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -1110,7 +1110,7 @@ async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TestStore, TestServerG
             }
             .serve(shutdown)
             .await
-            .expect("Failed to start serving store");
+            .expect("Failed to start serving RPC");
         }
     });
     let url = rpc_addr.to_string();

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -558,12 +558,7 @@ async fn start_ntx_builder(
         .without_otel_context_injection()
         .connect_lazy::<NtxBuilderClient>();
 
-    (
-        client,
-        call_count,
-        last_accept,
-        TestServerGuard(shutdown),
-    )
+    (client, call_count, last_accept, TestServerGuard(shutdown))
 }
 
 fn dummy_client<T: GrpcClient>() -> T {
@@ -807,12 +802,7 @@ async fn start_validator(
         .without_otel_context_injection()
         .connect_lazy::<ValidatorClient>();
 
-    (
-        client,
-        call_count,
-        last_accept,
-        TestServerGuard(shutdown),
-    )
+    (client, call_count, last_accept, TestServerGuard(shutdown))
 }
 
 /// A fixed transaction encryption key response for forwarding tests. The values only need to
@@ -1128,12 +1118,7 @@ async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TestStore, TestServerG
     let url = Url::parse(format!("http://{}", &url).as_str()).unwrap();
     let rpc_client = connect_rpc(url).await;
 
-    (
-        rpc_client,
-        rpc_addr,
-        store,
-        TestServerGuard(shutdown),
-    )
+    (rpc_client, rpc_addr, store, TestServerGuard(shutdown))
 }
 
 #[tokio::test]

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -31,6 +31,7 @@ use miden_node_utils::limiter::{
     QueryParamStorageMapKeyTotalLimit,
     QueryParamStorageMapSlotLimit,
 };
+use miden_node_utils::shutdown::CancellationToken;
 use miden_protocol::Word;
 use miden_protocol::account::{
     Account,
@@ -80,6 +81,14 @@ struct TestStore {
     state: Arc<State>,
     genesis_commitment: Word,
     data_directory: std::path::PathBuf,
+}
+
+struct TestServerGuard(CancellationToken);
+
+impl Drop for TestServerGuard {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
 }
 
 impl TestStore {
@@ -222,7 +231,7 @@ fn assert_beyond_tip(status: &tonic::Status, endpoint: &str) {
 #[tokio::test]
 async fn rpc_server_accepts_requests_without_accept_header() {
     // Start the RPC.
-    let (_, rpc_addr, _store) = start_rpc().await;
+    let (_, rpc_addr, _store, _server) = start_rpc().await;
 
     // Override the client so that the ACCEPT header is not set.
     let mut rpc_client = {
@@ -245,7 +254,7 @@ async fn rpc_server_accepts_requests_without_accept_header() {
 #[tokio::test]
 async fn rpc_server_accepts_requests_with_accept_header() {
     // Start the RPC.
-    let (mut rpc_client, _, _store) = start_rpc().await;
+    let (mut rpc_client, _, _store, _server) = start_rpc().await;
 
     // Send any request to the RPC.
     let response = send_request(&mut rpc_client).await;
@@ -257,7 +266,7 @@ async fn rpc_server_accepts_requests_with_accept_header() {
 #[tokio::test]
 async fn rpc_server_rejects_requests_with_accept_header_invalid_version() {
     // Start the RPC.
-    let (_, rpc_addr, _store) = start_rpc().await;
+    let (_, rpc_addr, _store, _server) = start_rpc().await;
     // SAFETY: The rpc_addr is always valid as it is created from a `SocketAddr`.
     let url = Url::parse(format!("http://{rpc_addr}").as_str()).unwrap();
 
@@ -285,7 +294,7 @@ async fn rpc_server_rejects_requests_with_accept_header_invalid_version() {
 
 #[tokio::test]
 async fn rpc_uses_in_process_store_state() {
-    let (mut rpc_client, _, _store) = start_rpc().await;
+    let (mut rpc_client, _, _store, _server) = start_rpc().await;
     let response = send_request(&mut rpc_client).await;
     assert!(response.unwrap().into_inner().block_header.is_some());
 }
@@ -293,7 +302,7 @@ async fn rpc_uses_in_process_store_state() {
 #[tokio::test]
 async fn rpc_server_has_web_support() {
     // Start server
-    let (_, rpc_addr, _store) = start_rpc().await;
+    let (_, rpc_addr, _store, _server) = start_rpc().await;
 
     // Send a status request
     let client = reqwest::Client::new();
@@ -334,7 +343,7 @@ async fn rpc_server_has_web_support() {
 #[tokio::test]
 async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
     // Start the RPC.
-    let (_, rpc_addr, store) = start_rpc().await;
+    let (_, rpc_addr, store, _server) = start_rpc().await;
     let genesis = store.genesis_commitment();
 
     // Override the client so that the ACCEPT header is not set.
@@ -382,7 +391,7 @@ async fn rpc_server_rejects_proven_transactions_with_invalid_commitment() {
 #[tokio::test]
 async fn rpc_server_rejects_proven_transactions_with_invalid_reference_block() {
     // Start the RPC.
-    let (_, rpc_addr, store) = start_rpc().await;
+    let (_, rpc_addr, store, _server) = start_rpc().await;
     let genesis = store.genesis_commitment();
 
     // Override the client so that the ACCEPT header is not set.
@@ -510,7 +519,12 @@ impl ntx_builder_api::GetNetworkNoteStatus for FixedNtxBuilder {
 
 async fn start_ntx_builder(
     response: proto::rpc::GetNetworkNoteStatusResponse,
-) -> (NtxBuilderClient, Arc<AtomicUsize>, Arc<std::sync::Mutex<Option<String>>>) {
+) -> (
+    NtxBuilderClient,
+    Arc<AtomicUsize>,
+    Arc<std::sync::Mutex<Option<String>>>,
+    TestServerGuard,
+) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind ntx-builder");
     let addr = listener.local_addr().expect("Failed to get ntx-builder address");
     let call_count = Arc::new(AtomicUsize::new(0));
@@ -521,12 +535,19 @@ async fn start_ntx_builder(
         last_accept: Arc::clone(&last_accept),
     };
 
-    task::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_service(ntx_builder_api::service(service))
-            .serve_with_incoming(TcpListenerStream::new(listener))
-            .await
-            .expect("Failed to serve ntx-builder");
+    let shutdown = CancellationToken::new();
+    task::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            tonic::transport::Server::builder()
+                .add_service(ntx_builder_api::service(service))
+                .serve_with_incoming_shutdown(
+                    TcpListenerStream::new(listener),
+                    shutdown.cancelled_owned(),
+                )
+                .await
+                .expect("Failed to serve ntx-builder");
+        }
     });
 
     let client = Builder::new(Url::parse(&format!("http://{addr}")).unwrap())
@@ -537,7 +558,12 @@ async fn start_ntx_builder(
         .without_otel_context_injection()
         .connect_lazy::<NtxBuilderClient>();
 
-    (client, call_count, last_accept)
+    (
+        client,
+        call_count,
+        last_accept,
+        TestServerGuard(shutdown),
+    )
 }
 
 fn dummy_client<T: GrpcClient>() -> T {
@@ -553,7 +579,7 @@ fn dummy_client<T: GrpcClient>() -> T {
 async fn start_source_rpc(
     ntx_builder: NtxBuilderClient,
     validator: ValidatorClient,
-) -> (RpcClient, TestStore) {
+) -> (RpcClient, TestStore, TestServerGuard) {
     let store = TestStore::start().await;
     let block_producer_dir = new_tempdir();
     TestStore::bootstrap(&block_producer_dir);
@@ -562,26 +588,37 @@ async fn start_source_rpc(
 
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind source RPC");
     let addr = listener.local_addr().expect("Failed to get source RPC address");
+    let shutdown = CancellationToken::new();
 
-    task::spawn(async move {
-        let block_producer = BlockProducerApi::new(
-            block_producer_state,
-            0.into(),
-            BlockProducerApiConfig::default(),
-        );
-        let source_rpc = RpcService::new(
-            state,
-            RpcBackend::sequencer(block_producer, ValidatorClients::new(vec![validator]).unwrap()),
-            Some(ntx_builder),
-            NonZeroUsize::new(1_000_000).unwrap(),
-            None,
-        );
+    task::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            let block_producer = BlockProducerApi::new(
+                block_producer_state,
+                0.into(),
+                BlockProducerApiConfig::default(),
+                shutdown.clone(),
+            );
+            let source_rpc = RpcService::new(
+                state,
+                RpcBackend::sequencer(
+                    block_producer,
+                    ValidatorClients::new(vec![validator]).unwrap(),
+                ),
+                Some(ntx_builder),
+                NonZeroUsize::new(1_000_000).unwrap(),
+                None,
+            );
 
-        tonic::transport::Server::builder()
-            .add_service(rpc_api::service(source_rpc))
-            .serve_with_incoming(TcpListenerStream::new(listener))
-            .await
-            .expect("Failed to serve source RPC");
+            tonic::transport::Server::builder()
+                .add_service(rpc_api::service(source_rpc))
+                .serve_with_incoming_shutdown(
+                    TcpListenerStream::new(listener),
+                    shutdown.cancelled_owned(),
+                )
+                .await
+                .expect("Failed to serve source RPC");
+        }
     });
 
     let client = Builder::new(Url::parse(&format!("http://{addr}")).unwrap())
@@ -592,7 +629,7 @@ async fn start_source_rpc(
         .without_otel_context_injection()
         .connect_lazy::<RpcClient>();
 
-    (client, store)
+    (client, store, TestServerGuard(shutdown))
 }
 
 /// Stub validator gRPC service that serves a fixed transaction encryption key and rejects every
@@ -731,7 +768,12 @@ impl validator_api::BlockSubscription for FixedValidator {
 /// the stub's call counter and the last ACCEPT header it observed.
 async fn start_validator(
     encryption_key: proto::transaction::TransactionEncryptionKey,
-) -> (ValidatorClient, Arc<AtomicUsize>, Arc<std::sync::Mutex<Option<String>>>) {
+) -> (
+    ValidatorClient,
+    Arc<AtomicUsize>,
+    Arc<std::sync::Mutex<Option<String>>>,
+    TestServerGuard,
+) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind validator");
     let addr = listener.local_addr().expect("Failed to get validator address");
     let call_count = Arc::new(AtomicUsize::new(0));
@@ -742,12 +784,19 @@ async fn start_validator(
         last_accept: Arc::clone(&last_accept),
     };
 
-    task::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_service(validator_api::service(service))
-            .serve_with_incoming(TcpListenerStream::new(listener))
-            .await
-            .expect("Failed to serve validator");
+    let shutdown = CancellationToken::new();
+    task::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            tonic::transport::Server::builder()
+                .add_service(validator_api::service(service))
+                .serve_with_incoming_shutdown(
+                    TcpListenerStream::new(listener),
+                    shutdown.cancelled_owned(),
+                )
+                .await
+                .expect("Failed to serve validator");
+        }
     });
 
     let client = Builder::new(Url::parse(&format!("http://{addr}")).unwrap())
@@ -758,7 +807,12 @@ async fn start_validator(
         .without_otel_context_injection()
         .connect_lazy::<ValidatorClient>();
 
-    (client, call_count, last_accept)
+    (
+        client,
+        call_count,
+        last_accept,
+        TestServerGuard(shutdown),
+    )
 }
 
 /// A fixed transaction encryption key response for forwarding tests. The values only need to
@@ -784,7 +838,8 @@ fn test_encryption_key() -> proto::transaction::TransactionEncryptionKey {
 #[tokio::test]
 async fn full_node_with_validator_forwards_get_transaction_encryption_key() {
     let expected = test_encryption_key();
-    let (validator, validator_call_count, _last_accept) = start_validator(expected.clone()).await;
+    let (validator, validator_call_count, _last_accept, _validator_server) =
+        start_validator(expected.clone()).await;
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
         Arc::clone(&local_store.state),
@@ -823,8 +878,9 @@ async fn full_node_with_validator_forwards_get_transaction_encryption_key() {
 #[tokio::test]
 async fn full_node_forwards_get_transaction_encryption_key_to_source_rpc() {
     let expected = test_encryption_key();
-    let (validator, validator_call_count, _last_accept) = start_validator(expected.clone()).await;
-    let (source_rpc, _source_store) =
+    let (validator, validator_call_count, _last_accept, _validator_server) =
+        start_validator(expected.clone()).await;
+    let (source_rpc, _source_store, _source_server) =
         start_source_rpc(dummy_client::<NtxBuilderClient>(), validator).await;
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
@@ -848,8 +904,9 @@ async fn full_node_forwards_get_transaction_encryption_key_to_source_rpc() {
 #[tokio::test]
 async fn full_node_preserves_original_accept_metadata_when_forwarding_encryption_key() {
     let expected = test_encryption_key();
-    let (validator, _validator_call_count, last_accept) = start_validator(expected.clone()).await;
-    let (source_rpc, source_store) =
+    let (validator, _validator_call_count, last_accept, _validator_server) =
+        start_validator(expected.clone()).await;
+    let (source_rpc, source_store, _source_server) =
         start_source_rpc(dummy_client::<NtxBuilderClient>(), validator).await;
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
@@ -889,9 +946,9 @@ async fn full_node_forwards_get_network_note_status_to_source_rpc() {
         attempt_count: 7,
         last_attempt_block_num: Some(42),
     };
-    let (ntx_builder, ntx_builder_call_count, _last_accept) =
+    let (ntx_builder, ntx_builder_call_count, _last_accept, _ntx_builder_server) =
         start_ntx_builder(expected.clone()).await;
-    let (source_rpc, _source_store) =
+    let (source_rpc, _source_store, _source_server) =
         start_source_rpc(ntx_builder, dummy_client::<ValidatorClient>()).await;
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
@@ -920,9 +977,9 @@ async fn full_node_preserves_original_accept_metadata_when_forwarding() {
         attempt_count: 7,
         last_attempt_block_num: Some(42),
     };
-    let (ntx_builder, _ntx_builder_call_count, last_accept) =
+    let (ntx_builder, _ntx_builder_call_count, last_accept, _ntx_builder_server) =
         start_ntx_builder(expected.clone()).await;
-    let (source_rpc, source_store) =
+    let (source_rpc, source_store, _source_server) =
         start_source_rpc(ntx_builder, dummy_client::<ValidatorClient>()).await;
     let local_store = TestStore::start().await;
     let full_node = RpcService::new(
@@ -962,7 +1019,7 @@ async fn full_node_preserves_original_accept_metadata_when_forwarding() {
 #[tokio::test]
 async fn rpc_server_rejects_tx_submissions_without_genesis() {
     // Start the RPC.
-    let (_, rpc_addr, store) = start_rpc().await;
+    let (_, rpc_addr, store, _server) = start_rpc().await;
     let genesis = store.genesis_commitment();
 
     // Override the client so that the ACCEPT header is not set.
@@ -1020,7 +1077,7 @@ async fn connect_rpc(url: Url) -> RpcClient {
 
 /// Binds a socket on an available port, runs the RPC server on it, and returns a client to talk to
 /// the server, along with the socket address.
-async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TestStore) {
+async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TestStore, TestServerGuard) {
     let grpc_options = GrpcOptions::test();
     let store = TestStore::start().await;
     let block_producer_dir = new_tempdir();
@@ -1031,48 +1088,58 @@ async fn start_rpc() -> (RpcClient, std::net::SocketAddr, TestStore) {
     // Start the rpc component.
     let rpc_listener = TcpListener::bind("127.0.0.1:0").await.expect("Failed to bind rpc");
     let rpc_addr = rpc_listener.local_addr().expect("Failed to get rpc address");
-    task::spawn(async move {
-        // SAFETY: Using dummy validator URL for test - not actually contacted in this test
-        let validator_url = Url::parse("http://127.0.0.1:0").unwrap();
-        let block_producer = BlockProducerApi::new(
-            block_producer_state,
-            0.into(),
-            BlockProducerApiConfig::default(),
-        );
-        let validator = Builder::new(validator_url)
-            .without_tls()
-            .without_timeout()
-            .without_metadata_version()
-            .without_metadata_genesis()
-            .with_otel_context_injection()
-            .connect_lazy::<ValidatorClient>();
-        Rpc {
-            listener: rpc_listener,
-            state,
-            mode: RpcMode::sequencer(
-                block_producer,
-                ValidatorClients::new(vec![validator]).unwrap(),
-            ),
-            ntx_builder: None,
-            grpc_options,
-            network_tx_auth: None,
+    let shutdown = CancellationToken::new();
+    task::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            // SAFETY: Using dummy validator URL for test - not actually contacted in this test
+            let validator_url = Url::parse("http://127.0.0.1:0").unwrap();
+            let block_producer = BlockProducerApi::new(
+                block_producer_state,
+                0.into(),
+                BlockProducerApiConfig::default(),
+                shutdown.clone(),
+            );
+            let validator = Builder::new(validator_url)
+                .without_tls()
+                .without_timeout()
+                .without_metadata_version()
+                .without_metadata_genesis()
+                .with_otel_context_injection()
+                .connect_lazy::<ValidatorClient>();
+            Rpc {
+                listener: rpc_listener,
+                state,
+                mode: RpcMode::sequencer(
+                    block_producer,
+                    ValidatorClients::new(vec![validator]).unwrap(),
+                ),
+                ntx_builder: None,
+                grpc_options,
+                network_tx_auth: None,
+            }
+            .serve(shutdown)
+            .await
+            .expect("Failed to start serving store");
         }
-        .serve(miden_node_utils::shutdown::CancellationToken::new())
-        .await
-        .expect("Failed to start serving store");
     });
     let url = rpc_addr.to_string();
     // SAFETY: The rpc_addr is always valid as it is created from a `SocketAddr`.
     let url = Url::parse(format!("http://{}", &url).as_str()).unwrap();
     let rpc_client = connect_rpc(url).await;
 
-    (rpc_client, rpc_addr, store)
+    (
+        rpc_client,
+        rpc_addr,
+        store,
+        TestServerGuard(shutdown),
+    )
 }
 
 #[tokio::test]
 async fn get_limits_endpoint() {
     // Start the RPC and store
-    let (mut rpc_client, _rpc_addr, _store) = start_rpc().await;
+    let (mut rpc_client, _rpc_addr, _store, _server) = start_rpc().await;
 
     // Call the get_limits endpoint
     let response = rpc_client.get_limits(()).await.expect("get_limits should succeed");
@@ -1153,7 +1220,7 @@ async fn get_limits_endpoint() {
 
 #[tokio::test]
 async fn sync_chain_mmr_returns_delta() {
-    let (mut rpc_client, _rpc_addr, _store) = start_rpc().await;
+    let (mut rpc_client, _rpc_addr, _store, _server) = start_rpc().await;
 
     let request = proto::rpc::SyncChainMmrRequest {
         current_client_block_height: 0,
@@ -1209,7 +1276,7 @@ fn sync_chain_mmr_block_header_matches_chain_commitment() {
 /// the chain-tip check from the range-validity check.
 #[tokio::test]
 async fn sync_endpoints_reject_block_to_beyond_chain_tip() {
-    let (mut rpc_client, _rpc_addr, _store) = start_rpc().await;
+    let (mut rpc_client, _rpc_addr, _store, _server) = start_rpc().await;
 
     // A range ending one block past the genesis tip; otherwise valid (non-empty, start <= end).
     let block_range = || Some(proto::rpc::BlockRange { block_from: 0, block_to: 1 });


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Our RPC tests contain the block producer API, which internally spawns the mempool monitoring task. This task is never cancelled and leaks. Not the biggest deal, but since this is part of the public API of the block producer crate, I thought I'd fix it.

I'm also okay with dropping this PR as unnecessary fluff.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```
