### PR TITLE
feat(telemetry): enrich traces with service.version

### DIFF
--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -22,10 +22,19 @@ use crate::tracing::ErrorSpanExt;
 static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 
 /// Default OpenTelemetry resource attributes for this process.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ResourceConfig {
     service_name: Option<&'static str>,
     attributes: Vec<(&'static str, &'static str)>,
+}
+
+impl Default for ResourceConfig {
+    fn default() -> Self {
+        Self {
+            service_name: None,
+            attributes: vec![("service.version", env!("CARGO_PKG_VERSION"))],
+        }
+    }
 }
 
 impl ResourceConfig {
@@ -381,6 +390,10 @@ mod tests {
         );
 
         assert_eq!(resource_value(&resource, "service.name"), Some(Value::from("node")),);
+        assert_eq!(
+            resource_value(&resource, "service.version"),
+            Some(Value::from(env!("CARGO_PKG_VERSION"))),
+        );
         assert_eq!(resource_value(&resource, "service.namespace"), Some(Value::from("miden")),);
         assert_eq!(resource_value(&resource, "miden.node.role"), Some(Value::from("sequencer")),);
         assert_eq!(resource_value(&resource, "telemetry.sdk.language"), Some(Value::from("rust")),);
@@ -391,6 +404,7 @@ mod tests {
         let detected_resource = Resource::builder_empty()
             .with_attributes([
                 KeyValue::new("service.name", "custom-node"),
+                KeyValue::new("service.version", "custom-version"),
                 KeyValue::new("service.namespace", "custom-namespace"),
                 KeyValue::new("miden.node.role", "custom-role"),
             ])
@@ -405,6 +419,10 @@ mod tests {
         );
 
         assert_eq!(resource_value(&resource, "service.name"), Some(Value::from("custom-node")),);
+        assert_eq!(
+            resource_value(&resource, "service.version"),
+            Some(Value::from("custom-version")),
+        );
         assert_eq!(
             resource_value(&resource, "service.namespace"),
             Some(Value::from("custom-namespace")),


### PR DESCRIPTION
## Summary

Fixes #2490

Adds the OpenTelemetry `service.version` resource attribute to trace resources. The value is populated from `env!("CARGO_PKG_VERSION")`, matching the package/workspace version used by the node binaries.

---

## Changes

- Adds `service.version` to the default `ResourceConfig` attributes.
- Preserves existing resource merge precedence, so detected/environment resource attributes can override the default value.
- Adds test coverage for the default `service.version`.
- Adds test coverage confirming a detected `service.version` overrides the configured default.

---

## How to Test

```bash
git diff --check
cargo test -p miden-node-utils resource_ -- --nocapture
```

✅ 3 passed; 0 failed

---

## Checklist

- [x] Tests pass — 3/3
- [x] Follows Conventional Commits
- [x] Changes scoped to this feature only

---

## Risk & Impact

**Low.** Additive resource attribute — existing resource merge precedence is preserved, so any detected or environment-provided `service.version` continues to take priority over the new default.

**Type:** ✨ New feature
**Fixes:** #2490

## Changelog

```toml
[[entry]]
scope = "general"
impact = "added"
description = "Enriched traces with `service.version`"
```