### PR TITLE
fix(proto): pass the schema dir as a single protox include path

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -92,7 +92,7 @@ fn generate_file_descriptor(
         .and_then(OsStr::to_str)
         .ok_or_else(|| miette!("invalid file name for {grpc_service:?}"))?;
 
-    let file_descriptor = protox::compile([grpc_service], includes)?;
+    let file_descriptor = protox::compile([grpc_service], [includes])?;
     let file_descriptor = file_descriptor.encode_to_vec();
 
     let mut f = codegen::Function::new(format!("{file_name}_api_descriptor"));


### PR DESCRIPTION
## Problem

Building any crate that depends on `miden-node-proto-build` fails on Windows:

```text
error: failed to run custom build command for `miden-node-proto-build v0.16.0-rc.1`
  Error: file '...\node\proto\proto\remote_prover.proto' is not in any include path
```

Note the doubled `proto\proto` in the message — the schema directory is being consumed as something other than a single include path.

## Root cause

`&Path` implements `IntoIterator`, yielding one item per **path component**. `protox::compile` takes `includes: impl IntoIterator<Item = impl AsRef<Path>>`, so passing the `&Path` directly expands it into one include entry per component:

```text
includes actually seen by protox (10 entries):
  [0] "C:"
  [1] "\\"
  [2] "Users"
  ...
  [9] "proto"
```

This is an API misuse on every platform, not a Windows-specific bug — but it only *fails* on Windows, which is why CI never caught it:

```text
== windows-style path
   NOT RESOLVED -> protox reports 'is not in any include path'
== posix-style path
   RESOLVED via include "/" -> name "cargo/.../remote_prover.proto"

first component of each:
  windows: Some(Prefix(PrefixComponent { raw: "C:", parsed: Disk(67) }))
  posix  : Some(RootDir)
```

On POSIX the first component is `RootDir` (`/`), and an include of `/` happens to resolve any absolute path, so compilation succeeds by accident. On Windows the first component is `Prefix(Disk)`; stripping it leaves a `RootDir` component, and protox's `path_to_file_name` requires every remaining component to be `Normal`, so no include entry can resolve the file.

## Fix

Wrap the include in an array so it is passed as one directory:

```rust
-    let file_descriptor = protox::compile([grpc_service], includes)?;
+    let file_descriptor = protox::compile([grpc_service], [includes])?;
```

## Verification

On Windows, with the build script forced to re-run in both directions:

```text
baseline (next):  exit 101 — "file '...\proto\proto\remote_prover.proto' is not in any include path"
this branch:      exit 0   — Finished `dev` profile
```

No behaviour change on Linux: the accidental `/` include resolved the same files this explicit include resolves, so CI should stay green.

No new dependencies, `Cargo.lock` unchanged, one line in one build script.

## Changelog

```toml
[[entry]]
scope = "general"
impact = "fixed"
description = "Protobuf Rust bindings now compile on Windows"
```