### PR TITLE
Distinguish grpc user errors from system errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,6 +4264,7 @@ dependencies = [
 name = "miden-node-grpc-error-macro"
 version = "0.16.0-rc.1"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.119",
 ]
@@ -4340,7 +4341,6 @@ dependencies = [
  "tonic-reflection",
  "tonic-web",
  "tower",
- "tower-http",
  "tracing",
  "url",
 ]
@@ -4478,7 +4478,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-reflection",
- "tower-http",
  "tracing",
  "url",
 ]

--- a/bin/ntx-builder/Cargo.toml
+++ b/bin/ntx-builder/Cargo.toml
@@ -36,7 +36,6 @@ tokio                  = { features = ["macros", "net", "rt-multi-thread"], work
 tokio-stream           = { features = ["net"], workspace = true }
 tonic                  = { workspace = true }
 tonic-reflection       = { workspace = true }
-tower-http             = { workspace = true }
 tracing                = { workspace = true }
 url                    = { workspace = true }
 

--- a/bin/ntx-builder/src/server.rs
+++ b/bin/ntx-builder/src/server.rs
@@ -3,11 +3,10 @@ use miden_node_proto::server::ntx_builder_api;
 use miden_node_proto_build::ntx_builder_api_descriptor;
 use miden_node_utils::panic::{CatchPanicLayer, catch_panic_layer_fn};
 use miden_node_utils::shutdown::CancellationToken;
-use miden_node_utils::tracing::grpc::grpc_trace_fn;
+use miden_node_utils::tracing::grpc::grpc_trace_layer;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic_reflection::server;
-use tower_http::trace::TraceLayer;
 
 use crate::LOG_TARGET;
 use crate::db::NtxDbReader;
@@ -57,7 +56,7 @@ impl NtxBuilderRpcServer {
 
         tonic::transport::Server::builder()
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
-            .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
+            .layer(grpc_trace_layer())
             .add_service(api_service)
             .add_service(reflection_service)
             .serve_with_incoming_shutdown(

--- a/bin/ntx-builder/src/server/get_network_note_status.rs
+++ b/bin/ntx-builder/src/server/get_network_note_status.rs
@@ -26,7 +26,7 @@ impl grpc::server::ntx_builder_api::GetNetworkNoteStatus for NtxBuilderRpcServer
         fields (
             note.id = %note_id,
         ),
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/bin/ntx-builder/src/server/get_network_note_status.rs
+++ b/bin/ntx-builder/src/server/get_network_note_status.rs
@@ -26,7 +26,7 @@ impl grpc::server::ntx_builder_api::GetNetworkNoteStatus for NtxBuilderRpcServer
         fields (
             note.id = %note_id,
         ),
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/bin/remote-prover/Cargo.toml
+++ b/bin/remote-prover/Cargo.toml
@@ -31,7 +31,7 @@ tonic                  = { default-features = false, features = ["codegen", "rou
 tonic-health           = { workspace = true }
 tonic-reflection       = { workspace = true }
 tonic-web              = { workspace = true }
-tower-http             = { features = ["trace"], workspace = true }
+tower-http             = { features = ["catch-panic"], workspace = true }
 tracing                = { workspace = true }
 
 [dev-dependencies]

--- a/bin/remote-prover/src/server/mod.rs
+++ b/bin/remote-prover/src/server/mod.rs
@@ -6,14 +6,13 @@ use miden_node_utils::cors::cors_for_grpc_web_layer;
 use miden_node_utils::logging::OpenTelemetry;
 use miden_node_utils::panic::catch_panic_layer_fn;
 use miden_node_utils::shutdown::CancellationToken;
-use miden_node_utils::tracing::grpc::grpc_trace_fn;
+use miden_node_utils::tracing::grpc::grpc_trace_layer;
 use proof_kind::ProofKind;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic_web::GrpcWebLayer;
 use tower_http::catch_panic::CatchPanicLayer;
-use tower_http::trace::TraceLayer;
 
 use crate::LOG_TARGET;
 use crate::server::service::ProverService;
@@ -109,7 +108,7 @@ impl Server {
             .accept_http1(true)
             .timeout(self.timeout)
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
-            .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
+            .layer(grpc_trace_layer())
             .layer(cors_for_grpc_web_layer())
             .layer(GrpcWebLayer::new())
             .add_service(prover_service)

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -15,7 +15,7 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
     #[miden_instrument(
         target = COMPONENT,
         name = "remote_prover.prove",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -15,7 +15,7 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
     #[miden_instrument(
         target = COMPONENT,
         name = "remote_prover.prove",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/bin/remote-prover/src/server/prover.rs
+++ b/bin/remote-prover/src/server/prover.rs
@@ -71,7 +71,7 @@ trait ProveRequest: Send + Sync {
     #[miden_instrument(
         target=COMPONENT,
         name="prove",
-        grpc_err,
+        err(fault_only),
     )]
     fn prove_request(&self, request: proto::ProofRequest) -> Result<proto::Proof, tonic::Status> {
         let input = Self::decode_request(request)?;
@@ -80,7 +80,7 @@ trait ProveRequest: Send + Sync {
 
     #[miden_instrument(
         target=COMPONENT,
-        grpc_err,
+        err(fault_only),
     )]
     fn decode_request(request: proto::ProofRequest) -> Result<Self::Input, tonic::Status> {
         use miden_protocol::utils::serde::Deserializable;

--- a/bin/remote-prover/src/server/prover.rs
+++ b/bin/remote-prover/src/server/prover.rs
@@ -71,7 +71,7 @@ trait ProveRequest: Send + Sync {
     #[miden_instrument(
         target=COMPONENT,
         name="prove",
-        err,
+        grpc_err,
     )]
     fn prove_request(&self, request: proto::ProofRequest) -> Result<proto::Proof, tonic::Status> {
         let input = Self::decode_request(request)?;
@@ -80,7 +80,7 @@ trait ProveRequest: Send + Sync {
 
     #[miden_instrument(
         target=COMPONENT,
-        err,
+        grpc_err,
     )]
     fn decode_request(request: proto::ProofRequest) -> Result<Self::Input, tonic::Status> {
         use miden_protocol::utils::serde::Deserializable;

--- a/bin/remote-prover/src/server/service.rs
+++ b/bin/remote-prover/src/server/service.rs
@@ -27,7 +27,7 @@ impl ProverService {
 
     #[miden_instrument(
         target=COMPONENT,
-        grpc_err,
+        err(fault_only),
     )]
     pub(super) fn acquire_permit(&self) -> Result<OwnedSemaphorePermit, tonic::Status> {
         Arc::clone(&self.permits)

--- a/bin/remote-prover/src/server/service.rs
+++ b/bin/remote-prover/src/server/service.rs
@@ -27,7 +27,7 @@ impl ProverService {
 
     #[miden_instrument(
         target=COMPONENT,
-        err,
+        grpc_err,
     )]
     pub(super) fn acquire_permit(&self) -> Result<OwnedSemaphorePermit, tonic::Status> {
         Arc::clone(&self.permits)

--- a/bin/validator/Cargo.toml
+++ b/bin/validator/Cargo.toml
@@ -51,7 +51,7 @@ tokio-stream           = { features = ["net"], workspace = true }
 toml                   = { workspace = true }
 tonic                  = { default-features = true, features = ["transport"], workspace = true }
 tonic-reflection       = { workspace = true }
-tower-http             = { features = ["util"], workspace = true }
+tower-http             = { features = ["catch-panic"], workspace = true }
 tracing                = { workspace = true }
 zeroize                = { workspace = true }
 

--- a/bin/validator/src/server/mod.rs
+++ b/bin/validator/src/server/mod.rs
@@ -7,11 +7,10 @@ use miden_node_store::BlockStore;
 use miden_node_utils::clap::GrpcOptions;
 use miden_node_utils::panic::catch_panic_layer_fn;
 use miden_node_utils::shutdown::CancellationToken;
-use miden_node_utils::tracing::grpc::grpc_trace_fn;
+use miden_node_utils::tracing::grpc::grpc_trace_layer;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::catch_panic::CatchPanicLayer;
-use tower_http::trace::TraceLayer;
 
 use crate::db::{ValidatorDbReader, ValidatorDbWriter};
 use crate::{
@@ -153,7 +152,7 @@ impl ValidatorServer {
         // Build the gRPC server with the API service and trace layer.
         tonic::transport::Server::builder()
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
-            .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
+            .layer(grpc_trace_layer())
             .timeout(self.grpc_options.request_timeout)
             .add_service(validator_api::service(service))
             .add_service(reflection_service)

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -48,7 +48,7 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
     #[miden_instrument(
         target = COMPONENT,
         name = "validator.block_subscription",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -48,7 +48,7 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
     #[miden_instrument(
         target = COMPONENT,
         name = "validator.block_subscription",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/bin/validator/src/server/validator_service/get_transaction_encryption_key.rs
+++ b/bin/validator/src/server/validator_service/get_transaction_encryption_key.rs
@@ -21,7 +21,7 @@ impl grpc::server::validator_api::GetTransactionEncryptionKey for ValidatorServi
     #[miden_instrument(
         target = COMPONENT,
         name = "get_transaction_encryption_key",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/bin/validator/src/server/validator_service/get_transaction_encryption_key.rs
+++ b/bin/validator/src/server/validator_service/get_transaction_encryption_key.rs
@@ -21,7 +21,7 @@ impl grpc::server::validator_api::GetTransactionEncryptionKey for ValidatorServi
     #[miden_instrument(
         target = COMPONENT,
         name = "get_transaction_encryption_key",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -23,7 +23,7 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
     #[miden_instrument(
         target = COMPONENT,
         name = "submit_proven_transaction",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -23,7 +23,7 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
     #[miden_instrument(
         target = COMPONENT,
         name = "submit_proven_transaction",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -62,15 +62,18 @@ pub enum MempoolSubmissionError {
     #[error(
         "transaction expired at block height {expired_at} but the block height limit was {limit}"
     )]
+    #[grpc(failed_precondition)]
     Expired {
         expired_at: BlockNumber,
         limit: BlockNumber,
     },
 
     #[error("transaction conflicts with current mempool state")]
+    #[grpc(failed_precondition)]
     StateConflict(#[source] StateConflict),
 
     #[error("the mempool is at capacity")]
+    #[grpc(resource_exhausted)]
     CapacityExceeded,
 
     #[error("mempool lock is poisoned")]

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -311,7 +311,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_proven_tx",
-        err,
+        grpc_err,
     )]
     pub async fn submit_proven_tx(
         &self,
@@ -344,7 +344,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_authenticated_tx",
-        err,
+        grpc_err,
     )]
     #[expect(clippy::let_and_return, reason = "required to lengthen arc lifetime")]
     pub async fn submit_authenticated_tx(
@@ -363,7 +363,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_proven_tx_batch",
-        err,
+        grpc_err,
     )]
     pub async fn submit_proven_tx_batch(
         &self,
@@ -395,7 +395,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_authenticated_tx_batch",
-        err,
+        grpc_err,
     )]
     #[expect(clippy::let_and_return)]
     pub async fn submit_authenticated_tx_batch(

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -311,7 +311,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_proven_tx",
-        grpc_err,
+        err(fault_only),
     )]
     pub async fn submit_proven_tx(
         &self,
@@ -344,7 +344,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_authenticated_tx",
-        grpc_err,
+        err(fault_only),
     )]
     #[expect(clippy::let_and_return, reason = "required to lengthen arc lifetime")]
     pub async fn submit_authenticated_tx(
@@ -363,7 +363,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_proven_tx_batch",
-        grpc_err,
+        err(fault_only),
     )]
     pub async fn submit_proven_tx_batch(
         &self,
@@ -395,7 +395,7 @@ impl BlockProducerApi {
     #[miden_instrument(
         target = COMPONENT,
         name = "block_producer.api.submit_authenticated_tx_batch",
-        grpc_err,
+        err(fault_only),
     )]
     #[expect(clippy::let_and_return)]
     pub async fn submit_authenticated_tx_batch(

--- a/crates/grpc-error-macro/Cargo.toml
+++ b/crates/grpc-error-macro/Cargo.toml
@@ -20,5 +20,6 @@ proc-macro = true
 test       = false
 
 [dependencies]
-quote = { workspace = true }
-syn   = { features = ["full"], workspace = true }
+proc-macro2 = { workspace = true }
+quote       = { workspace = true }
+syn         = { features = ["full"], workspace = true }

--- a/crates/grpc-error-macro/src/lib.rs
+++ b/crates/grpc-error-macro/src/lib.rs
@@ -34,8 +34,10 @@ use syn::{Data, DeriveInput, Fields, Ident, parse_macro_input};
 ///
 /// # Attributes
 ///
-/// - `#[grpc(internal)]` - Marks a variant as an internal error (will map to
-///   `tonic::Code::Internal`)
+/// - `#[grpc(<code>)]` - Sets the variant's gRPC status code: `internal`, `invalid_argument`,
+///   `not_found`, `failed_precondition` or `resource_exhausted`. Variants without the attribute
+///   map to `invalid_argument`. Internal variants collapse into a shared `Internal` companion
+///   variant and their message is masked as `"Internal error"`.
 ///
 /// # Generated Code
 ///
@@ -64,6 +66,7 @@ pub fn derive_grpc_error(input: TokenStream) -> TokenStream {
     // Build the GrpcError enum variants
     let mut grpc_variants = Vec::new();
     let mut api_error_arms = Vec::new();
+    let mut tonic_code_arms = Vec::new();
 
     // Always add Internal variant (standard practice for gRPC errors)
     grpc_variants.push(quote! {
@@ -75,45 +78,43 @@ pub fn derive_grpc_error(input: TokenStream) -> TokenStream {
     for variant in variants {
         let variant_name = &variant.ident;
 
-        // Check if this variant is marked as internal
-        let is_internal = variant.attrs.iter().any(|attr| {
-            attr.path().is_ident("grpc")
-                && attr.parse_args::<Ident>().is_ok_and(|i| i == "internal")
-        });
+        // Parse the variant's `#[grpc(<code>)]` attribute; absent means `invalid_argument`.
+        let code = match variant_grpc_code(variant) {
+            Ok(code) => code,
+            Err(error) => return error.to_compile_error().into(),
+        };
 
         // Extract doc comments
         let docs: Vec<_> =
             variant.attrs.iter().filter(|attr| attr.path().is_ident("doc")).collect();
 
-        if is_internal {
-            // Map to Internal variant
-            let pattern = match &variant.fields {
-                Fields::Unit => quote! { #name::#variant_name },
-                Fields::Unnamed(_) => quote! { #name::#variant_name(..) },
-                Fields::Named(_) => quote! { #name::#variant_name { .. } },
-            };
+        let pattern = match &variant.fields {
+            Fields::Unit => quote! { #name::#variant_name },
+            Fields::Unnamed(_) => quote! { #name::#variant_name(..) },
+            Fields::Named(_) => quote! { #name::#variant_name { .. } },
+        };
 
-            api_error_arms.push(quote! {
-                #pattern => #grpc_name::Internal
-            });
-        } else {
+        if let Some(tonic_code) = code.tonic_code_ident() {
             // Create a corresponding variant in GrpcError enum
             grpc_variants.push(quote! {
                 #(#docs)*
                 #variant_name = #discriminant
             });
 
-            let pattern = match &variant.fields {
-                Fields::Unit => quote! { #name::#variant_name },
-                Fields::Unnamed(_) => quote! { #name::#variant_name(..) },
-                Fields::Named(_) => quote! { #name::#variant_name { .. } },
-            };
-
             api_error_arms.push(quote! {
                 #pattern => #grpc_name::#variant_name
             });
 
+            tonic_code_arms.push(quote! {
+                Self::#variant_name => tonic::Code::#tonic_code
+            });
+
             discriminant += 1;
+        } else {
+            // Map to Internal variant
+            api_error_arms.push(quote! {
+                #pattern => #grpc_name::Internal
+            });
         }
     }
 
@@ -137,10 +138,9 @@ pub fn derive_grpc_error(input: TokenStream) -> TokenStream {
 
             /// Returns the appropriate tonic code for this error.
             pub fn tonic_code(&self) -> tonic::Code {
-                if self.is_internal() {
-                    tonic::Code::Internal
-                } else {
-                    tonic::Code::InvalidArgument
+                match self {
+                    Self::Internal => tonic::Code::Internal,
+                    #(#tonic_code_arms,)*
                 }
             }
         }
@@ -174,7 +174,68 @@ pub fn derive_grpc_error(input: TokenStream) -> TokenStream {
                 )
             }
         }
+
+        impl ::miden_node_utils::tracing::GrpcFault for #name {
+            fn is_server_fault(&self) -> bool {
+                ::miden_node_utils::tracing::is_server_fault_code(self.api_error().tonic_code())
+            }
+        }
     };
 
     TokenStream::from(expanded)
+}
+
+/// The gRPC code assigned to an error variant via `#[grpc(<code>)]`.
+#[derive(Clone, Copy)]
+enum GrpcVariantCode {
+    Internal,
+    InvalidArgument,
+    NotFound,
+    FailedPrecondition,
+    ResourceExhausted,
+}
+
+impl GrpcVariantCode {
+    /// The identifier of the corresponding `tonic::Code` variant.
+    ///
+    /// `None` for internal errors, which collapse into the companion enum's `Internal` variant.
+    fn tonic_code_ident(self) -> Option<Ident> {
+        let name = match self {
+            Self::Internal => return None,
+            Self::InvalidArgument => "InvalidArgument",
+            Self::NotFound => "NotFound",
+            Self::FailedPrecondition => "FailedPrecondition",
+            Self::ResourceExhausted => "ResourceExhausted",
+        };
+        Some(Ident::new(name, proc_macro2::Span::call_site()))
+    }
+}
+
+/// Parses a variant's `#[grpc(<code>)]` attribute; a variant without one maps to
+/// `invalid_argument`.
+fn variant_grpc_code(variant: &syn::Variant) -> syn::Result<GrpcVariantCode> {
+    let mut code = GrpcVariantCode::InvalidArgument;
+    for attr in &variant.attrs {
+        if !attr.path().is_ident("grpc") {
+            continue;
+        }
+        let ident: Ident = attr.parse_args()?;
+        code = match ident.to_string().as_str() {
+            "internal" => GrpcVariantCode::Internal,
+            "invalid_argument" => GrpcVariantCode::InvalidArgument,
+            "not_found" => GrpcVariantCode::NotFound,
+            "failed_precondition" => GrpcVariantCode::FailedPrecondition,
+            "resource_exhausted" => GrpcVariantCode::ResourceExhausted,
+            other => {
+                return Err(syn::Error::new_spanned(
+                    &ident,
+                    format!(
+                        "unsupported gRPC code `{other}`; use one of: internal, \
+                         invalid_argument, not_found, failed_precondition, resource_exhausted"
+                    ),
+                ));
+            },
+        };
+    }
+    Ok(code)
 }

--- a/crates/proto/src/errors/test_macro.rs
+++ b/crates/proto/src/errors/test_macro.rs
@@ -22,6 +22,18 @@ pub enum TestError {
 
     #[error("client error 3")]
     ClientError3,
+
+    #[error("not found")]
+    #[grpc(not_found)]
+    NotFoundError,
+
+    #[error("failed precondition")]
+    #[grpc(failed_precondition)]
+    PreconditionError,
+
+    #[error("resource exhausted")]
+    #[grpc(resource_exhausted)]
+    ExhaustedError,
 }
 
 #[cfg(test)]
@@ -65,5 +77,36 @@ mod tests {
         let client_status: tonic::Status = TestError::ClientError1.into();
         assert_eq!(client_status.code(), tonic::Code::InvalidArgument);
         assert_eq!(client_status.message(), "client error 1");
+    }
+
+    #[test]
+    fn test_explicit_grpc_codes() {
+        // Explicitly coded variants keep their own companion variant and discriminant but map to
+        // the requested tonic code with an unmasked message.
+        assert_eq!(TestErrorGrpcError::NotFoundError.api_code(), 4);
+        assert_eq!(TestErrorGrpcError::PreconditionError.api_code(), 5);
+        assert_eq!(TestErrorGrpcError::ExhaustedError.api_code(), 6);
+
+        let status: tonic::Status = TestError::NotFoundError.into();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+        assert_eq!(status.message(), "not found");
+
+        let status: tonic::Status = TestError::PreconditionError.into();
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+
+        let status: tonic::Status = TestError::ExhaustedError.into();
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn test_grpc_fault_classification() {
+        use miden_node_utils::tracing::GrpcFault;
+
+        // Only internal errors indicate a node fault; client-caused codes do not.
+        assert!(TestError::InternalError1.is_server_fault());
+        assert!(!TestError::ClientError1.is_server_fault());
+        assert!(!TestError::NotFoundError.is_server_fault());
+        assert!(!TestError::PreconditionError.is_server_fault());
+        assert!(!TestError::ExhaustedError.is_server_fault());
     }
 }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -39,7 +39,6 @@ tonic-health              = { workspace = true }
 tonic-reflection          = { workspace = true }
 tonic-web                 = { workspace = true }
 tower                     = { workspace = true }
-tower-http                = { features = ["trace"], workspace = true }
 tracing                   = { workspace = true }
 url                       = { workspace = true }
 

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -32,7 +32,7 @@ impl proto::server::rpc_api::GetAccount for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_account",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -32,7 +32,7 @@ impl proto::server::rpc_api::GetAccount for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_account",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_block_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_by_number.rs
@@ -25,7 +25,7 @@ impl proto::server::rpc_api::GetBlockByNumber for RpcService {
         fields(
             block.number = %request.block_num,
         ),
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_block_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_by_number.rs
@@ -25,7 +25,7 @@ impl proto::server::rpc_api::GetBlockByNumber for RpcService {
         fields(
             block.number = %request.block_num,
         ),
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_block_header_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_header_by_number.rs
@@ -25,7 +25,7 @@ impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
         fields(
             block.number = %request.block_num(),
         ),
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_block_header_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_header_by_number.rs
@@ -25,7 +25,7 @@ impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
         fields(
             block.number = %request.block_num(),
         ),
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_limits.rs
+++ b/crates/rpc/src/server/api/get_limits.rs
@@ -21,7 +21,7 @@ impl proto::server::rpc_api::GetLimits for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_limits",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_limits.rs
+++ b/crates/rpc/src/server/api/get_limits.rs
@@ -21,7 +21,7 @@ impl proto::server::rpc_api::GetLimits for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_limits",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -29,7 +29,7 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_network_note_status",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -29,7 +29,7 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_network_note_status",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -24,7 +24,7 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_note_script_by_root",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -24,7 +24,7 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_note_script_by_root",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_notes_by_id.rs
+++ b/crates/rpc/src/server/api/get_notes_by_id.rs
@@ -28,7 +28,7 @@ impl proto::server::rpc_api::GetNotesById for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_notes_by_id",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_notes_by_id.rs
+++ b/crates/rpc/src/server/api/get_notes_by_id.rs
@@ -28,7 +28,7 @@ impl proto::server::rpc_api::GetNotesById for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_notes_by_id",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_transaction_encryption_key.rs
+++ b/crates/rpc/src/server/api/get_transaction_encryption_key.rs
@@ -21,7 +21,7 @@ impl proto::server::rpc_api::GetTransactionEncryptionKey for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_transaction_encryption_key",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/get_transaction_encryption_key.rs
+++ b/crates/rpc/src/server/api/get_transaction_encryption_key.rs
@@ -21,7 +21,7 @@ impl proto::server::rpc_api::GetTransactionEncryptionKey for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "get_transaction_encryption_key",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -22,7 +22,7 @@ impl proto::server::rpc_api::Status for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "status",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/status.rs
+++ b/crates/rpc/src/server/api/status.rs
@@ -22,7 +22,7 @@ impl proto::server::rpc_api::Status for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "status",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -36,7 +36,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "submit_proven_tx",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -36,7 +36,7 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "submit_proven_tx",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -29,7 +29,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "submit_proven_tx_batch",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -29,7 +29,7 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "submit_proven_tx_batch",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -31,7 +31,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         fields(
             block.from = %input,
         ),
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -31,7 +31,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         fields(
             block.from = %input,
         ),
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -32,7 +32,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         fields(
             block.from = %input,
         ),
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -32,7 +32,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         fields(
             block.from = %input,
         ),
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_account_storage_maps.rs
+++ b/crates/rpc/src/server/api/sync_account_storage_maps.rs
@@ -27,7 +27,7 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_account_storage_maps",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_account_storage_maps.rs
+++ b/crates/rpc/src/server/api/sync_account_storage_maps.rs
@@ -27,7 +27,7 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_account_storage_maps",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_account_vault.rs
+++ b/crates/rpc/src/server/api/sync_account_vault.rs
@@ -28,7 +28,7 @@ impl proto::server::rpc_api::SyncAccountVault for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_account_vault",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_account_vault.rs
+++ b/crates/rpc/src/server/api/sync_account_vault.rs
@@ -28,7 +28,7 @@ impl proto::server::rpc_api::SyncAccountVault for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_account_vault",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_chain_mmr.rs
+++ b/crates/rpc/src/server/api/sync_chain_mmr.rs
@@ -28,7 +28,7 @@ impl proto::server::rpc_api::SyncChainMmr for RpcService {
             current_client_block_height = %request.current_client_block_height,
             finality_level = %request.finality_level().as_str_name(),
         ),
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_chain_mmr.rs
+++ b/crates/rpc/src/server/api/sync_chain_mmr.rs
@@ -28,7 +28,7 @@ impl proto::server::rpc_api::SyncChainMmr for RpcService {
             current_client_block_height = %request.current_client_block_height,
             finality_level = %request.finality_level().as_str_name(),
         ),
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_notes.rs
+++ b/crates/rpc/src/server/api/sync_notes.rs
@@ -25,7 +25,7 @@ impl proto::server::rpc_api::SyncNotes for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_notes",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_notes.rs
+++ b/crates/rpc/src/server/api/sync_notes.rs
@@ -25,7 +25,7 @@ impl proto::server::rpc_api::SyncNotes for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_notes",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -30,7 +30,7 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_nullifiers",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -30,7 +30,7 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_nullifiers",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_transactions.rs
+++ b/crates/rpc/src/server/api/sync_transactions.rs
@@ -32,7 +32,7 @@ impl proto::server::rpc_api::SyncTransactions for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_transactions",
-        err,
+        grpc_err,
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/api/sync_transactions.rs
+++ b/crates/rpc/src/server/api/sync_transactions.rs
@@ -32,7 +32,7 @@ impl proto::server::rpc_api::SyncTransactions for RpcService {
     #[miden_instrument(
         target = COMPONENT,
         name = "sync_transactions",
-        grpc_err,
+        err(fault_only),
     )]
     async fn handle(
         &self,

--- a/crates/rpc/src/server/mod.rs
+++ b/crates/rpc/src/server/mod.rs
@@ -20,15 +20,13 @@ use miden_node_utils::grpc;
 use miden_node_utils::panic::{CatchPanicLayer, catch_panic_layer_fn};
 use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::tasks::Tasks;
-use miden_node_utils::tracing::grpc::grpc_trace_fn;
+use miden_node_utils::tracing::grpc::grpc_trace_layer;
 use rand::RngExt;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::metadata::AsciiMetadataValue;
 use tonic_reflection::server;
 use tonic_web::GrpcWebLayer;
-use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, SharedClassifier};
-use tower_http::trace::TraceLayer;
 use tracing::info;
 
 use crate::LOG_TARGET;
@@ -328,17 +326,7 @@ impl Rpc {
             .accept_http1(true)
             .timeout(self.grpc_options.request_timeout)
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
-            .layer(
-                TraceLayer::new(SharedClassifier::new(
-                    GrpcErrorsAsFailures::new()
-                        .with_success(GrpcCode::InvalidArgument)
-                        .with_success(GrpcCode::NotFound)
-                        .with_success(GrpcCode::ResourceExhausted)
-                        .with_success(GrpcCode::Unimplemented)
-                        .with_success(GrpcCode::Unknown),
-                ))
-                .make_span_with(grpc_trace_fn),
-            )
+            .layer(grpc_trace_layer())
             .layer(HealthCheckLayer)
             .layer(cors_for_grpc_web_layer())
             // Note: must wrap the accept layer so grpc-web callers receive grpc-web-compatible
@@ -474,7 +462,7 @@ impl SequencerInternal {
         // and is expected to be network-isolated.
         tonic::transport::Server::builder()
             .layer(CatchPanicLayer::custom(catch_panic_layer_fn))
-            .layer(TraceLayer::new_for_grpc().make_span_with(grpc_trace_fn))
+            .layer(grpc_trace_layer())
             .timeout(self.grpc_options.request_timeout)
             .add_service(sequencer_api::service(service))
             .serve_with_incoming_shutdown(

--- a/crates/tracing-macro/src/lib.rs
+++ b/crates/tracing-macro/src/lib.rs
@@ -106,12 +106,12 @@ pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = TokenStream2::from(attr);
     let mut function = parse_macro_input!(item as ItemFn);
     let fields = collect_recorded_fields(&function);
-    let (args, grpc_err) = match merge_inferred_fields(attr, &fields) {
+    let (args, fault_level) = match merge_inferred_fields(attr, &fields) {
         Ok(args) => args,
         Err(error) => return error.into_compile_error().into(),
     };
-    if grpc_err {
-        apply_grpc_err(&mut function);
+    if let Some(level) = fault_level {
+        apply_fault_only_err(&mut function, &level);
     }
     let statements = &function.block.stmts;
     let block: Block = parse_quote! {{
@@ -132,19 +132,22 @@ pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
     expanded.into()
 }
 
-fn merge_inferred_fields(attr: TokenStream2, fields: &[FieldPath]) -> Result<(TokenStream2, bool)> {
+fn merge_inferred_fields(
+    attr: TokenStream2,
+    fields: &[FieldPath],
+) -> Result<(TokenStream2, Option<TokenStream2>)> {
     validate_explicit_fields(&attr)?;
 
     let mut args = split_top_level_args(attr);
     reject_skip_directives(&args)?;
-    let grpc_err = extract_grpc_err_directive(&mut args)?;
+    let fault_level = extract_err_directive(&mut args)?;
 
     // Function arguments often contain large or sensitive values. Always skip them so spans only
     // contain fields explicitly declared by the caller or inferred from `miden_span_record!`.
     args.push(quote! { skip_all });
 
     if fields.is_empty() {
-        return Ok((quote! { #(#args),* }, grpc_err));
+        return Ok((quote! { #(#args),* }, fault_level));
     }
 
     let inferred_fields = quote! { #(#fields = ::tracing::field::Empty),* };
@@ -172,38 +175,39 @@ fn merge_inferred_fields(attr: TokenStream2, fields: &[FieldPath]) -> Result<(To
         .collect::<Vec<_>>();
 
     if merged_existing_fields {
-        Ok((quote! { #(#args),* }, grpc_err))
+        Ok((quote! { #(#args),* }, fault_level))
     } else {
-        Ok((quote! { #(#args,)* fields(#inferred_fields) }, grpc_err))
+        Ok((quote! { #(#args,)* fields(#inferred_fields) }, fault_level))
     }
 }
 
 /// Rewrites the function body so a returned `Err` is classified via
-/// `miden_node_utils::tracing::record_grpc_error` from inside the instrumented span: node faults
-/// mark the span with `OTel` error status (like `err` would), while client-caused failures do not —
+/// `miden_node_utils::tracing::record_classified_error` from inside the instrumented span: node
+/// faults are logged at `level` (`ERROR` unless overridden) and mark the span with `OTel` error
+/// status (like `err` would), while client-caused failures are logged at debug level and do not —
 /// rejecting a bad request is the node behaving correctly, not an application error.
 ///
 /// `#[async_trait]` methods are expanded before this macro runs, leaving a non-async fn whose
 /// body is `Box::pin(async move { ... })`; the classification is applied inside that async block
 /// so it runs within the instrumented span.
-fn apply_grpc_err(function: &mut ItemFn) {
-    fn classified(body: &TokenStream2) -> Block {
+fn apply_fault_only_err(function: &mut ItemFn, level: &TokenStream2) {
+    fn classified(body: &TokenStream2, level: &TokenStream2) -> Block {
         parse_quote! {{
             #[allow(clippy::redundant_async_block, clippy::redundant_closure_call)]
             let __miden_instrument_result = #body;
             if let Err(err) = &__miden_instrument_result {
-                ::miden_node_utils::tracing::record_grpc_error(err);
+                ::miden_node_utils::tracing::record_classified_error(err, #level);
             }
             __miden_instrument_result
         }}
     }
 
-    fn wrap_async(statements: &[Stmt]) -> Block {
-        classified(&quote! { async move { #(#statements)* }.await })
+    fn wrap_async(statements: &[Stmt], level: &TokenStream2) -> Block {
+        classified(&quote! { async move { #(#statements)* }.await }, level)
     }
 
     if function.sig.asyncness.is_some() {
-        let wrapped = wrap_async(&function.block.stmts);
+        let wrapped = wrap_async(&function.block.stmts, level);
         *function.block = wrapped;
         return;
     }
@@ -212,49 +216,173 @@ fn apply_grpc_err(function: &mut ItemFn) {
         && call.args.len() == 1
         && let Some(Expr::Async(async_block)) = call.args.first_mut()
     {
-        let wrapped = wrap_async(&async_block.block.stmts);
+        let wrapped = wrap_async(&async_block.block.stmts, level);
         async_block.block = wrapped;
         return;
     }
 
     let statements = &function.block.stmts;
-    let wrapped = classified(&quote! { (move || { #(#statements)* })() });
+    let wrapped = classified(&quote! { (move || { #(#statements)* })() }, level);
     *function.block = wrapped;
 }
 
-/// Removes the `grpc_err` directive from the argument list, returning whether it was present.
+/// Handles the `err` directive, extracting `fault_only` mode when present.
 ///
-/// `grpc_err` is a `miden_instrument` extension, not a `tracing::instrument` argument, so it must
-/// not be forwarded. It replaces `err`: combining the two would double-report the error.
-fn extract_grpc_err_directive(args: &mut Vec<TokenStream2>) -> Result<bool> {
-    let is_bare_ident = |arg: &TokenStream2, name: &str| {
-        let mut tokens = arg.clone().into_iter();
-        matches!(tokens.next(), Some(TokenTree::Ident(ident)) if ident == name)
-            && tokens.next().is_none()
-    };
+/// `fault_only` is a `miden_instrument` extension to `tracing::instrument`'s `err` directive: the
+/// returned `Err` is classified instead of unconditionally reported, so only node faults mark the
+/// span as failed. An optional `level = "..."` tunes the level of the fault-side event (`ERROR` by
+/// default); client-caused failures are always logged at debug level regardless.
+///
+/// Since `tracing::instrument` would reject `fault_only`, the whole `err(...)` argument is removed
+/// from the forwarded list and this returns the level tokens (e.g. `::tracing::Level::WARN`) to
+/// emit fault events at. Plain `err` and tracing's own modes are forwarded untouched, but their
+/// option idents are validated here so a typo like `err(faultonly)` fails with a targeted message
+/// rather than a tracing error pointing at expanded code.
+fn extract_err_directive(args: &mut Vec<TokenStream2>) -> Result<Option<TokenStream2>> {
+    let mut fault_level = None;
+    let mut seen_err: Option<TokenStream2> = None;
+    let mut retained = Vec::with_capacity(args.len());
 
-    let mut grpc_err = false;
-    args.retain(|arg| {
-        let found = is_bare_ident(arg, "grpc_err");
-        grpc_err |= found;
-        !found
-    });
+    for arg in args.drain(..) {
+        let Some(directive) = err_directive_options(&arg) else {
+            retained.push(arg);
+            continue;
+        };
+        if let Some(previous) = &seen_err {
+            let mut error =
+                syn::Error::new_spanned(&arg, "duplicate `err` directive; only one is allowed");
+            error.combine(syn::Error::new_spanned(previous, "first `err` directive here"));
+            return Err(error);
+        }
+        seen_err = Some(arg.clone());
 
-    if grpc_err {
-        for arg in args.iter() {
-            let Some(TokenTree::Ident(ident)) = arg.clone().into_iter().next() else {
-                continue;
-            };
-            if ident == "err" {
-                return Err(syn::Error::new_spanned(
-                    arg,
-                    "`err` cannot be combined with `grpc_err`",
-                ));
-            }
+        match directive {
+            // Bare `err`: tracing's unconditional error reporting, forwarded as-is.
+            ErrDirective::Bare => retained.push(arg),
+            ErrDirective::Options(options) => {
+                if options.iter().any(|option| is_bare_ident(option, "fault_only")) {
+                    fault_level = Some(parse_fault_only_options(&options)?);
+                } else {
+                    validate_forwarded_err_options(&options)?;
+                    retained.push(arg);
+                }
+            },
         }
     }
 
-    Ok(grpc_err)
+    *args = retained;
+    Ok(fault_level)
+}
+
+/// An `err` directive argument: bare `err` or `err(...)` with its comma-separated options.
+enum ErrDirective {
+    Bare,
+    Options(Vec<TokenStream2>),
+}
+
+/// Parses the argument as an `err` directive, returning `None` if it is some other argument.
+fn err_directive_options(arg: &TokenStream2) -> Option<ErrDirective> {
+    let mut tokens = arg.clone().into_iter();
+    match tokens.next() {
+        Some(TokenTree::Ident(ident)) if ident == "err" => {},
+        _ => return None,
+    }
+
+    match tokens.next() {
+        None => Some(ErrDirective::Bare),
+        Some(TokenTree::Group(group))
+            if group.delimiter() == Delimiter::Parenthesis && tokens.next().is_none() =>
+        {
+            Some(ErrDirective::Options(split_top_level_args(group.stream())))
+        },
+        _ => None,
+    }
+}
+
+fn is_bare_ident(arg: &TokenStream2, name: &str) -> bool {
+    let mut tokens = arg.clone().into_iter();
+    matches!(tokens.next(), Some(TokenTree::Ident(ident)) if ident == name)
+        && tokens.next().is_none()
+}
+
+/// Parses the options of an `err(fault_only, ...)` directive into the fault event's level tokens.
+fn parse_fault_only_options(options: &[TokenStream2]) -> Result<TokenStream2> {
+    let mut level = quote! { ::tracing::Level::ERROR };
+
+    for option in options {
+        if is_bare_ident(option, "fault_only") {
+            continue;
+        }
+
+        let name_value: syn::MetaNameValue = syn::parse2(option.clone()).map_err(|_| {
+            syn::Error::new_spanned(
+                option,
+                "unsupported `err(fault_only)` option; only `level = \"...\"` can be combined \
+                 with `fault_only`",
+            )
+        })?;
+        if !name_value.path.is_ident("level") {
+            return Err(syn::Error::new_spanned(
+                option,
+                "unsupported `err(fault_only)` option; only `level = \"...\"` can be combined \
+                 with `fault_only`",
+            ));
+        }
+
+        let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(value), .. }) = &name_value.value
+        else {
+            return Err(syn::Error::new_spanned(
+                &name_value.value,
+                "`level` must be a string literal: one of \"trace\", \"debug\", \"info\", \
+                 \"warn\" or \"error\"",
+            ));
+        };
+        level = match value.value().to_ascii_lowercase().as_str() {
+            "trace" => quote! { ::tracing::Level::TRACE },
+            "debug" => quote! { ::tracing::Level::DEBUG },
+            "info" => quote! { ::tracing::Level::INFO },
+            "warn" => quote! { ::tracing::Level::WARN },
+            "error" => quote! { ::tracing::Level::ERROR },
+            unknown => {
+                return Err(syn::Error::new_spanned(
+                    value,
+                    format!(
+                        "unknown level \"{unknown}\"; expected one of \"trace\", \"debug\", \
+                         \"info\", \"warn\" or \"error\""
+                    ),
+                ));
+            },
+        };
+    }
+
+    Ok(level)
+}
+
+/// Validates the options of an `err(...)` directive that is forwarded to `tracing::instrument`.
+///
+/// Forwarded options are parsed by `tracing::instrument` itself; this only rejects idents outside
+/// its `err` grammar (`Debug`, `Display`, `level = ...`) so near-misses of `fault_only` fail here
+/// with a message that mentions it.
+fn validate_forwarded_err_options(options: &[TokenStream2]) -> Result<()> {
+    for option in options {
+        let mut tokens = option.clone().into_iter();
+        let first = tokens.next();
+        let is_mode = matches!(
+            &first,
+            Some(TokenTree::Ident(ident)) if ident == "Debug" || ident == "Display"
+        ) && tokens.next().is_none();
+        let is_level = matches!(&first, Some(TokenTree::Ident(ident)) if ident == "level");
+
+        if !is_mode && !is_level {
+            return Err(syn::Error::new_spanned(
+                option,
+                "unsupported `err` option; expected `fault_only`, `Debug`, `Display` or `level = \
+                 \"...\"`",
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn reject_skip_directives(args: &[TokenStream2]) -> Result<()> {

--- a/crates/tracing-macro/src/lib.rs
+++ b/crates/tracing-macro/src/lib.rs
@@ -7,7 +7,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Dot;
 use syn::visit::Visit;
-use syn::{Block, Expr, Ident, ItemFn, Macro, Result, Token, parse_macro_input, parse_quote};
+use syn::{Block, Expr, Ident, ItemFn, Macro, Result, Stmt, Token, parse_macro_input, parse_quote};
 
 const ALLOWED_FIELD_NAMES: &[&str] = &[
     "account.id",
@@ -106,10 +106,13 @@ pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = TokenStream2::from(attr);
     let mut function = parse_macro_input!(item as ItemFn);
     let fields = collect_recorded_fields(&function);
-    let args = match merge_inferred_fields(attr, &fields) {
+    let (args, grpc_err) = match merge_inferred_fields(attr, &fields) {
         Ok(args) => args,
         Err(error) => return error.into_compile_error().into(),
     };
+    if grpc_err {
+        apply_grpc_err(&mut function);
+    }
     let statements = &function.block.stmts;
     let block: Block = parse_quote! {{
         #[allow(unused_macros)]
@@ -129,18 +132,19 @@ pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
     expanded.into()
 }
 
-fn merge_inferred_fields(attr: TokenStream2, fields: &[FieldPath]) -> Result<TokenStream2> {
+fn merge_inferred_fields(attr: TokenStream2, fields: &[FieldPath]) -> Result<(TokenStream2, bool)> {
     validate_explicit_fields(&attr)?;
 
     let mut args = split_top_level_args(attr);
     reject_skip_directives(&args)?;
+    let grpc_err = extract_grpc_err_directive(&mut args)?;
 
     // Function arguments often contain large or sensitive values. Always skip them so spans only
     // contain fields explicitly declared by the caller or inferred from `miden_span_record!`.
     args.push(quote! { skip_all });
 
     if fields.is_empty() {
-        return Ok(quote! { #(#args),* });
+        return Ok((quote! { #(#args),* }, grpc_err));
     }
 
     let inferred_fields = quote! { #(#fields = ::tracing::field::Empty),* };
@@ -168,10 +172,89 @@ fn merge_inferred_fields(attr: TokenStream2, fields: &[FieldPath]) -> Result<Tok
         .collect::<Vec<_>>();
 
     if merged_existing_fields {
-        Ok(quote! { #(#args),* })
+        Ok((quote! { #(#args),* }, grpc_err))
     } else {
-        Ok(quote! { #(#args,)* fields(#inferred_fields) })
+        Ok((quote! { #(#args,)* fields(#inferred_fields) }, grpc_err))
     }
+}
+
+/// Rewrites the function body so a returned `Err` is classified via
+/// `miden_node_utils::tracing::record_grpc_error` from inside the instrumented span: node faults
+/// mark the span with `OTel` error status (like `err` would), while client-caused failures do not —
+/// rejecting a bad request is the node behaving correctly, not an application error.
+///
+/// `#[async_trait]` methods are expanded before this macro runs, leaving a non-async fn whose
+/// body is `Box::pin(async move { ... })`; the classification is applied inside that async block
+/// so it runs within the instrumented span.
+fn apply_grpc_err(function: &mut ItemFn) {
+    fn classified(body: &TokenStream2) -> Block {
+        parse_quote! {{
+            #[allow(clippy::redundant_async_block, clippy::redundant_closure_call)]
+            let __miden_instrument_result = #body;
+            if let Err(err) = &__miden_instrument_result {
+                ::miden_node_utils::tracing::record_grpc_error(err);
+            }
+            __miden_instrument_result
+        }}
+    }
+
+    fn wrap_async(statements: &[Stmt]) -> Block {
+        classified(&quote! { async move { #(#statements)* }.await })
+    }
+
+    if function.sig.asyncness.is_some() {
+        let wrapped = wrap_async(&function.block.stmts);
+        *function.block = wrapped;
+        return;
+    }
+
+    if let Some(Stmt::Expr(Expr::Call(call), _)) = function.block.stmts.last_mut()
+        && call.args.len() == 1
+        && let Some(Expr::Async(async_block)) = call.args.first_mut()
+    {
+        let wrapped = wrap_async(&async_block.block.stmts);
+        async_block.block = wrapped;
+        return;
+    }
+
+    let statements = &function.block.stmts;
+    let wrapped = classified(&quote! { (move || { #(#statements)* })() });
+    *function.block = wrapped;
+}
+
+/// Removes the `grpc_err` directive from the argument list, returning whether it was present.
+///
+/// `grpc_err` is a `miden_instrument` extension, not a `tracing::instrument` argument, so it must
+/// not be forwarded. It replaces `err`: combining the two would double-report the error.
+fn extract_grpc_err_directive(args: &mut Vec<TokenStream2>) -> Result<bool> {
+    let is_bare_ident = |arg: &TokenStream2, name: &str| {
+        let mut tokens = arg.clone().into_iter();
+        matches!(tokens.next(), Some(TokenTree::Ident(ident)) if ident == name)
+            && tokens.next().is_none()
+    };
+
+    let mut grpc_err = false;
+    args.retain(|arg| {
+        let found = is_bare_ident(arg, "grpc_err");
+        grpc_err |= found;
+        !found
+    });
+
+    if grpc_err {
+        for arg in args.iter() {
+            let Some(TokenTree::Ident(ident)) = arg.clone().into_iter().next() else {
+                continue;
+            };
+            if ident == "err" {
+                return Err(syn::Error::new_spanned(
+                    arg,
+                    "`err` cannot be combined with `grpc_err`",
+                ));
+            }
+        }
+    }
+
+    Ok(grpc_err)
 }
 
 fn reject_skip_directives(args: &[TokenStream2]) -> Result<()> {

--- a/crates/tracing-macro/src/lib.rs
+++ b/crates/tracing-macro/src/lib.rs
@@ -101,6 +101,35 @@ const ALLOWED_FIELD_NAMES: &[&str] = &[
     "workers.count",
 ];
 
+/// A drop-in replacement for `tracing::instrument` enforcing the node's telemetry conventions.
+///
+/// Differences from `tracing::instrument`:
+///
+/// - Function arguments are never recorded: `skip_all` is always applied, and explicit `skip` /
+///   `skip_all` directives are rejected. Span fields must instead be declared with `fields(...)`
+///   or recorded later in the body with `miden_span_record!`; either way the field names are
+///   validated against the node's allowed span field names, and recorded fields are inferred and
+///   pre-declared as empty on the span.
+/// - The `err` directive gains a `fault_only` mode for request handlers:
+///
+///   ```ignore
+///   #[miden_instrument(
+///       target = COMPONENT,
+///       name = "block_producer.api.submit_proven_tx",
+///       err(fault_only),
+///   )]
+///   ```
+///
+///   Where plain `err` unconditionally reports a returned `Err`, `err(fault_only)` classifies it
+///   via the `GrpcFault` trait (`miden_node_utils::tracing`): node faults are logged at `ERROR`
+///   with the full error report and mark the span with `OTel` error status, while client-caused
+///   failures are logged at debug level and leave the span status untouched — rejecting a bad
+///   request is the node behaving correctly, not an application error. An optional
+///   `level = "..."` (`"trace"` through `"error"`) tunes the level of the fault-side event only,
+///   e.g. `err(fault_only, level = "warn")`; span error status always follows the classification
+///   regardless of level.
+///
+/// All other arguments are forwarded to `tracing::instrument` unchanged.
 #[proc_macro_attribute]
 pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = TokenStream2::from(attr);

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -44,7 +44,7 @@ tokio                    = { features = ["macros", "rt", "signal", "time"], work
 tokio-util               = { workspace = true }
 tonic                    = { default-features = true, workspace = true }
 tower                    = { workspace = true }
-tower-http               = { features = ["catch-panic"], workspace = true }
+tower-http               = { features = ["catch-panic", "trace"], workspace = true }
 tower_governor           = { version = "0.8" }
 tracing                  = { workspace = true }
 tracing-forest           = { features = ["chrono"], optional = true, version = "0.3" }

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -163,18 +163,26 @@ impl GrpcFault for tonic::Status {
 
 /// Records a request-handling error on the current span.
 ///
-/// Called by `miden_instrument`'s `grpc_err` directive. Node faults are logged at error level and
-/// mark the span with `OTel` error status, matching the plain `err` directive; client-caused
-/// failures are logged at debug level and leave the span status untouched, since rejecting a bad
-/// request is the node behaving correctly.
-pub fn record_grpc_error<E>(err: &E)
+/// Called by `miden_instrument`'s `err(fault_only)` directive. Node faults are logged at
+/// `fault_level` (`ERROR` unless the directive says `level = "..."`) and mark the span with `OTel`
+/// error status regardless of that level — the level tunes event verbosity, while span status
+/// always follows the fault classification. Client-caused failures are logged at debug level and
+/// leave the span status untouched, since rejecting a bad request is the node behaving correctly.
+pub fn record_classified_error<E>(err: &E, fault_level: tracing::Level)
 where
     E: GrpcFault + std::error::Error,
 {
     use crate::ErrorReport;
 
     if err.is_server_fault() {
-        tracing::error!(error = err.as_report());
+        // `tracing::event!` requires a const level, so dispatch to the per-level macros.
+        match fault_level {
+            tracing::Level::ERROR => tracing::error!(error = err.as_report()),
+            tracing::Level::WARN => tracing::warn!(error = err.as_report()),
+            tracing::Level::INFO => tracing::info!(error = err.as_report()),
+            tracing::Level::DEBUG => tracing::debug!(error = err.as_report()),
+            tracing::Level::TRACE => tracing::trace!(error = err.as_report()),
+        }
         tracing::Span::current().set_error(err);
     } else {
         tracing::debug!(error = err.as_report());
@@ -370,7 +378,7 @@ mod tests {
 
     /// The trace layer's classifier decides which responses mark the request span as an error; it
     /// must agree with [`is_server_fault_code`], which drives the same decision for handler spans
-    /// via `grpc_err`.
+    /// via `err(fault_only)`.
     #[test]
     fn classifier_agrees_with_fault_classification() {
         // 0..=16 covers every gRPC status code.

--- a/crates/utils/src/tracing/grpc.rs
+++ b/crates/utils/src/tracing/grpc.rs
@@ -1,6 +1,20 @@
+use std::time::Duration;
+
 use http::header::HeaderName;
 use tower_governor::key_extractor::{KeyExtractor, SmartIpKeyExtractor};
+use tower_http::classify::{GrpcCode, GrpcErrorsAsFailures, GrpcFailureClass, SharedClassifier};
+use tower_http::trace::{DefaultOnBodyChunk, DefaultOnRequest, TraceLayer};
 use tracing::field;
+
+use super::ErrorSpanExt;
+
+/// The span field holding the numeric gRPC status code of the response, following the
+/// [OTel RPC semantic conventions](https://opentelemetry.io/docs/specs/semconv/rpc/grpc/).
+///
+/// Always recorded on request root spans: `0` (OK) on success, the actual code on failure. This
+/// lets queries distinguish request outcomes without relying on the span's error status, which is
+/// reserved for node faults (see [`is_server_fault_code`]).
+const GRPC_STATUS_CODE_FIELD: &str = "rpc.grpc.status_code";
 
 /// Returns a [`trace_fn`](tonic::transport::server::Server) implementation for gRPC requests
 /// which adds open-telemetry information to the span.
@@ -27,6 +41,7 @@ pub fn grpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
         rpc.system = field::Empty,
         rpc.request.size = field::Empty,
         rpc.response.size = field::Empty,
+        rpc.grpc.status_code = field::Empty,
         server.address = field::Empty,
         server.port = field::Empty,
         client.address = field::Empty,
@@ -108,6 +123,184 @@ pub fn grpc_trace_fn<T>(request: &http::Request<T>) -> tracing::Span {
     span
 }
 
+/// Returns whether a gRPC status code indicates a fault in the node, as opposed to a failure
+/// caused by the request itself.
+///
+/// Client-caused failures (invalid arguments, failed preconditions, exhausted quotas, ...) are
+/// *successful rejections* and must not mark spans with `OTel` error status, otherwise client noise
+/// becomes indistinguishable from node failures in error-based alerting.
+///
+/// The set mirrors the [OTel gRPC semantic conventions] for server spans, except that
+/// `UNIMPLEMENTED` is treated as client-caused: on a public API, calls to unknown methods are
+/// client noise, not a node fault.
+///
+/// [OTel gRPC semantic conventions]: https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
+pub fn is_server_fault_code(code: tonic::Code) -> bool {
+    matches!(
+        code,
+        tonic::Code::Unknown
+            | tonic::Code::DeadlineExceeded
+            | tonic::Code::Internal
+            | tonic::Code::Unavailable
+            | tonic::Code::DataLoss
+    )
+}
+
+/// Classifies errors into node faults vs client-caused failures for telemetry purposes.
+///
+/// Implemented by [`tonic::Status`] and by error enums deriving
+/// `miden_node_proto::errors::GrpcError`.
+pub trait GrpcFault {
+    /// Returns whether this error indicates a fault in the node rather than a bad request.
+    fn is_server_fault(&self) -> bool;
+}
+
+impl GrpcFault for tonic::Status {
+    fn is_server_fault(&self) -> bool {
+        is_server_fault_code(self.code())
+    }
+}
+
+/// Records a request-handling error on the current span.
+///
+/// Called by `miden_instrument`'s `grpc_err` directive. Node faults are logged at error level and
+/// mark the span with `OTel` error status, matching the plain `err` directive; client-caused
+/// failures are logged at debug level and leave the span status untouched, since rejecting a bad
+/// request is the node behaving correctly.
+pub fn record_grpc_error<E>(err: &E)
+where
+    E: GrpcFault + std::error::Error,
+{
+    use crate::ErrorReport;
+
+    if err.is_server_fault() {
+        tracing::error!(error = err.as_report());
+        tracing::Span::current().set_error(err);
+    } else {
+        tracing::debug!(error = err.as_report());
+    }
+}
+
+/// Returns the [`TraceLayer`] for gRPC servers.
+///
+/// - Creates the per-request root span via [`grpc_trace_fn`].
+/// - Records `rpc.grpc.status_code` on every request span — `0` (OK) on success, the actual code
+///   on failure — so request outcomes are always queryable.
+/// - Marks the span with `OTel` error status only for codes indicating a node fault (see
+///   [`is_server_fault_code`]); client-caused failures keep the span status unset.
+pub fn grpc_trace_layer() -> TraceLayer<
+    SharedClassifier<GrpcErrorsAsFailures>,
+    GrpcMakeSpan,
+    DefaultOnRequest,
+    GrpcOnResponse,
+    DefaultOnBodyChunk,
+    GrpcOnEos,
+    GrpcOnFailure,
+> {
+    TraceLayer::new(SharedClassifier::new(grpc_fault_classifier()))
+        .make_span_with(GrpcMakeSpan)
+        .on_response(GrpcOnResponse)
+        .on_eos(GrpcOnEos)
+        .on_failure(GrpcOnFailure)
+}
+
+/// Returns the response classifier used by [`grpc_trace_layer`].
+///
+/// The complement of [`is_server_fault_code`]: client-caused codes are classified as successes so
+/// they never reach [`GrpcOnFailure`].
+fn grpc_fault_classifier() -> GrpcErrorsAsFailures {
+    GrpcErrorsAsFailures::new()
+        .with_success(GrpcCode::Cancelled)
+        .with_success(GrpcCode::InvalidArgument)
+        .with_success(GrpcCode::NotFound)
+        .with_success(GrpcCode::AlreadyExists)
+        .with_success(GrpcCode::PermissionDenied)
+        .with_success(GrpcCode::ResourceExhausted)
+        .with_success(GrpcCode::FailedPrecondition)
+        .with_success(GrpcCode::Aborted)
+        .with_success(GrpcCode::OutOfRange)
+        .with_success(GrpcCode::Unimplemented)
+        .with_success(GrpcCode::Unauthenticated)
+}
+
+/// [`tower_http::trace::MakeSpan`] implementation wrapping [`grpc_trace_fn`].
+#[derive(Clone, Copy, Debug)]
+pub struct GrpcMakeSpan;
+
+impl<B> tower_http::trace::MakeSpan<B> for GrpcMakeSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        grpc_trace_fn(request)
+    }
+}
+
+/// Records the gRPC status code carried in the response headers (tonic sends error statuses as
+/// "trailers-only" responses, i.e. in the headers).
+///
+/// When the header is absent the status arrives in the trailers instead; `OK` is recorded
+/// provisionally so the field is always present, and [`GrpcOnEos`] / [`GrpcOnFailure`] overwrite
+/// it with the actual code once known.
+#[derive(Clone, Copy, Debug)]
+pub struct GrpcOnResponse;
+
+impl<B> tower_http::trace::OnResponse<B> for GrpcOnResponse {
+    fn on_response(self, response: &http::Response<B>, _latency: Duration, span: &tracing::Span) {
+        let code = grpc_status_from_headers(response.headers()).unwrap_or(0);
+        span.record(GRPC_STATUS_CODE_FIELD, code);
+    }
+}
+
+/// Records the gRPC status code from the response trailers at end-of-stream.
+#[derive(Clone, Copy, Debug)]
+pub struct GrpcOnEos;
+
+impl tower_http::trace::OnEos for GrpcOnEos {
+    fn on_eos(
+        self,
+        trailers: Option<&http::HeaderMap>,
+        _stream_duration: Duration,
+        span: &tracing::Span,
+    ) {
+        if let Some(code) = trailers.and_then(grpc_status_from_headers) {
+            span.record(GRPC_STATUS_CODE_FIELD, code);
+        }
+    }
+}
+
+/// Marks the request span as failed.
+///
+/// Only invoked for classifications indicating a node fault (see [`grpc_trace_layer`]);
+/// client-caused failures never reach this.
+#[derive(Clone, Debug)]
+pub struct GrpcOnFailure;
+
+impl tower_http::trace::OnFailure<GrpcFailureClass> for GrpcOnFailure {
+    fn on_failure(
+        &mut self,
+        classification: GrpcFailureClass,
+        latency: Duration,
+        span: &tracing::Span,
+    ) {
+        let code = match &classification {
+            GrpcFailureClass::Code(code) => code.get(),
+            // Transport-level failure without a gRPC status; map to `UNKNOWN`.
+            GrpcFailureClass::Error(_) => tonic::Code::Unknown as i32,
+        };
+        span.record(GRPC_STATUS_CODE_FIELD, code);
+        tracing_opentelemetry::OpenTelemetrySpanExt::set_status(
+            span,
+            opentelemetry::trace::Status::Error {
+                description: classification.to_string().into(),
+            },
+        );
+        tracing::error!(classification = %classification, latency = ?latency, "request failed");
+    }
+}
+
+/// Parses the numeric `grpc-status` code from a header or trailer map.
+fn grpc_status_from_headers(headers: &http::HeaderMap) -> Option<i32> {
+    headers.get("grpc-status")?.to_str().ok()?.parse().ok()
+}
+
 /// Injects open-telemetry remote context into traces.
 #[derive(Copy, Clone)]
 pub struct OtelInterceptor;
@@ -156,6 +349,44 @@ impl opentelemetry::propagation::Injector for MetadataInjector<'_> {
             && let Ok(val) = tonic::metadata::MetadataValue::try_from(&value)
         {
             self.0.insert(key, val);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_http::classify::{ClassifiedResponse, ClassifyResponse};
+
+    use super::*;
+
+    #[test]
+    fn parses_grpc_status_header() {
+        let mut headers = http::HeaderMap::new();
+        assert_eq!(grpc_status_from_headers(&headers), None);
+
+        headers.insert("grpc-status", "3".parse().unwrap());
+        assert_eq!(grpc_status_from_headers(&headers), Some(3));
+    }
+
+    /// The trace layer's classifier decides which responses mark the request span as an error; it
+    /// must agree with [`is_server_fault_code`], which drives the same decision for handler spans
+    /// via `grpc_err`.
+    #[test]
+    fn classifier_agrees_with_fault_classification() {
+        // 0..=16 covers every gRPC status code.
+        for code in 0..=16i32 {
+            let response = http::Response::builder()
+                .header("grpc-status", code.to_string())
+                .body(())
+                .unwrap();
+
+            let classified_as_failure = matches!(
+                grpc_fault_classifier().classify_response(&response),
+                ClassifiedResponse::Ready(Err(_))
+            );
+            let is_fault = code != 0 && is_server_fault_code(tonic::Code::from(code));
+
+            assert_eq!(classified_as_failure, is_fault, "gRPC code {code}");
         }
     }
 }

--- a/crates/utils/src/tracing/mod.rs
+++ b/crates/utils/src/tracing/mod.rs
@@ -1,6 +1,6 @@
 pub mod grpc;
 mod span_ext;
 
-pub use grpc::{GrpcFault, is_server_fault_code, record_grpc_error};
+pub use grpc::{GrpcFault, is_server_fault_code, record_classified_error};
 pub use miden_node_tracing_macro::{miden_instrument, miden_span_record};
 pub use span_ext::ErrorSpanExt;

--- a/crates/utils/src/tracing/mod.rs
+++ b/crates/utils/src/tracing/mod.rs
@@ -1,5 +1,6 @@
 pub mod grpc;
 mod span_ext;
 
+pub use grpc::{GrpcFault, is_server_fault_code, record_grpc_error};
 pub use miden_node_tracing_macro::{miden_instrument, miden_span_record};
 pub use span_ext::ErrorSpanExt;

--- a/crates/utils/tests/tracing_macros.rs
+++ b/crates/utils/tests/tracing_macros.rs
@@ -186,26 +186,47 @@ fn multiple_span_record_macros_can_record_fields_after_span_creation() {
     assert_eq!(recorded.get("transaction.id").as_deref(), Some("multi-call-tx"));
 }
 
-#[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_client_fault", grpc_err)]
-async fn grpc_err_client_fault() -> Result<(), tonic::Status> {
+#[miden_instrument(
+    target = "miden-node-utils-test",
+    name = "fault_only_client_fault",
+    err(fault_only)
+)]
+async fn fault_only_client_fault() -> Result<(), tonic::Status> {
     Err(tonic::Status::invalid_argument("bad request"))
 }
 
-#[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_server_fault", grpc_err)]
-async fn grpc_err_server_fault() -> Result<(), tonic::Status> {
+#[miden_instrument(
+    target = "miden-node-utils-test",
+    name = "fault_only_server_fault",
+    err(fault_only)
+)]
+async fn fault_only_server_fault() -> Result<(), tonic::Status> {
     Err(tonic::Status::internal("node fault"))
 }
 
+#[miden_instrument(
+    target = "miden-node-utils-test",
+    name = "fault_only_warn_level",
+    err(fault_only, level = "warn")
+)]
+async fn fault_only_warn_level(fail_with: tonic::Status) -> Result<(), tonic::Status> {
+    Err(fail_with)
+}
+
 #[tonic::async_trait]
-trait GrpcErrHandler {
+trait FaultOnlyErrHandler {
     async fn handle(&self, fail: bool) -> Result<(), tonic::Status>;
 }
 
 struct AsyncTraitHandler;
 
 #[tonic::async_trait]
-impl GrpcErrHandler for AsyncTraitHandler {
-    #[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_async_trait", grpc_err)]
+impl FaultOnlyErrHandler for AsyncTraitHandler {
+    #[miden_instrument(
+        target = "miden-node-utils-test",
+        name = "fault_only_async_trait",
+        err(fault_only)
+    )]
     async fn handle(&self, fail: bool) -> Result<(), tonic::Status> {
         if fail {
             return Err(tonic::Status::internal("node fault"));
@@ -215,30 +236,47 @@ impl GrpcErrHandler for AsyncTraitHandler {
 }
 
 #[tokio::test]
-async fn grpc_err_client_faults_are_not_error_events() {
+async fn fault_only_client_faults_are_not_error_events() {
     let events = RecordedEventLevels::default();
     let subscriber = tracing_subscriber::registry().with(events.clone());
     let _guard = tracing::subscriber::set_default(subscriber);
 
-    grpc_err_client_fault().await.unwrap_err();
+    fault_only_client_fault().await.unwrap_err();
 
     assert!(events.contains(tracing::Level::DEBUG));
     assert!(!events.contains(tracing::Level::ERROR));
 }
 
 #[tokio::test]
-async fn grpc_err_server_faults_are_error_events() {
+async fn fault_only_server_faults_are_error_events() {
     let events = RecordedEventLevels::default();
     let subscriber = tracing_subscriber::registry().with(events.clone());
     let _guard = tracing::subscriber::set_default(subscriber);
 
-    grpc_err_server_fault().await.unwrap_err();
+    fault_only_server_fault().await.unwrap_err();
 
     assert!(events.contains(tracing::Level::ERROR));
 }
 
-#[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_sync", grpc_err)]
-fn grpc_err_sync(fail: bool) -> Result<(), tonic::Status> {
+#[tokio::test]
+async fn fault_only_level_applies_to_server_faults_only() {
+    let events = RecordedEventLevels::default();
+    let subscriber = tracing_subscriber::registry().with(events.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    fault_only_warn_level(tonic::Status::internal("node fault")).await.unwrap_err();
+    assert!(events.contains(tracing::Level::WARN));
+    assert!(!events.contains(tracing::Level::ERROR));
+
+    fault_only_warn_level(tonic::Status::invalid_argument("bad request"))
+        .await
+        .unwrap_err();
+    assert!(events.contains(tracing::Level::DEBUG));
+    assert!(!events.contains(tracing::Level::ERROR));
+}
+
+#[miden_instrument(target = "miden-node-utils-test", name = "fault_only_sync", err(fault_only))]
+fn fault_only_sync(fail: bool) -> Result<(), tonic::Status> {
     if fail {
         return Err(tonic::Status::internal("node fault"));
     }
@@ -246,20 +284,20 @@ fn grpc_err_sync(fail: bool) -> Result<(), tonic::Status> {
 }
 
 #[test]
-fn grpc_err_classifies_sync_functions() {
+fn fault_only_classifies_sync_functions() {
     let events = RecordedEventLevels::default();
     let subscriber = tracing_subscriber::registry().with(events.clone());
     let _guard = tracing::subscriber::set_default(subscriber);
 
-    grpc_err_sync(false).unwrap();
+    fault_only_sync(false).unwrap();
     assert!(!events.contains(tracing::Level::ERROR));
 
-    grpc_err_sync(true).unwrap_err();
+    fault_only_sync(true).unwrap_err();
     assert!(events.contains(tracing::Level::ERROR));
 }
 
 #[tokio::test]
-async fn grpc_err_classifies_async_trait_methods() {
+async fn fault_only_classifies_async_trait_methods() {
     let events = RecordedEventLevels::default();
     let subscriber = tracing_subscriber::registry().with(events.clone());
     let _guard = tracing::subscriber::set_default(subscriber);
@@ -280,5 +318,8 @@ fn ui_tests() {
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip_all.rs");
     tests.compile_fail("tests/ui/tracing_macros/outside_miden_instrument.rs");
-    tests.compile_fail("tests/ui/tracing_macros/grpc_err_with_err.rs");
+    tests.compile_fail("tests/ui/tracing_macros/err_duplicate.rs");
+    tests.compile_fail("tests/ui/tracing_macros/err_fault_only_unknown_option.rs");
+    tests.compile_fail("tests/ui/tracing_macros/err_fault_only_invalid_level.rs");
+    tests.compile_fail("tests/ui/tracing_macros/err_unknown_mode.rs");
 }

--- a/crates/utils/tests/tracing_macros.rs
+++ b/crates/utils/tests/tracing_macros.rs
@@ -49,6 +49,25 @@ impl Visit for FieldVisitor {
     }
 }
 
+#[derive(Clone, Default)]
+struct RecordedEventLevels(Arc<Mutex<Vec<tracing::Level>>>);
+
+impl RecordedEventLevels {
+    fn contains(&self, level: tracing::Level) -> bool {
+        self.0.lock().unwrap().contains(&level)
+    }
+}
+
+impl<S> Layer<S> for RecordedEventLevels
+where
+    S: Subscriber,
+    for<'a> S: LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        self.0.lock().unwrap().push(*event.metadata().level());
+    }
+}
+
 #[miden_instrument(target = "miden-node-utils-test", name = "records_delayed_fields")]
 fn records_inferred_fields() {
     let parsed_value = 42;
@@ -167,6 +186,91 @@ fn multiple_span_record_macros_can_record_fields_after_span_creation() {
     assert_eq!(recorded.get("transaction.id").as_deref(), Some("multi-call-tx"));
 }
 
+#[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_client_fault", grpc_err)]
+async fn grpc_err_client_fault() -> Result<(), tonic::Status> {
+    Err(tonic::Status::invalid_argument("bad request"))
+}
+
+#[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_server_fault", grpc_err)]
+async fn grpc_err_server_fault() -> Result<(), tonic::Status> {
+    Err(tonic::Status::internal("node fault"))
+}
+
+#[tonic::async_trait]
+trait GrpcErrHandler {
+    async fn handle(&self, fail: bool) -> Result<(), tonic::Status>;
+}
+
+struct AsyncTraitHandler;
+
+#[tonic::async_trait]
+impl GrpcErrHandler for AsyncTraitHandler {
+    #[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_async_trait", grpc_err)]
+    async fn handle(&self, fail: bool) -> Result<(), tonic::Status> {
+        if fail {
+            return Err(tonic::Status::internal("node fault"));
+        }
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn grpc_err_client_faults_are_not_error_events() {
+    let events = RecordedEventLevels::default();
+    let subscriber = tracing_subscriber::registry().with(events.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    grpc_err_client_fault().await.unwrap_err();
+
+    assert!(events.contains(tracing::Level::DEBUG));
+    assert!(!events.contains(tracing::Level::ERROR));
+}
+
+#[tokio::test]
+async fn grpc_err_server_faults_are_error_events() {
+    let events = RecordedEventLevels::default();
+    let subscriber = tracing_subscriber::registry().with(events.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    grpc_err_server_fault().await.unwrap_err();
+
+    assert!(events.contains(tracing::Level::ERROR));
+}
+
+#[miden_instrument(target = "miden-node-utils-test", name = "grpc_err_sync", grpc_err)]
+fn grpc_err_sync(fail: bool) -> Result<(), tonic::Status> {
+    if fail {
+        return Err(tonic::Status::internal("node fault"));
+    }
+    Ok(())
+}
+
+#[test]
+fn grpc_err_classifies_sync_functions() {
+    let events = RecordedEventLevels::default();
+    let subscriber = tracing_subscriber::registry().with(events.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    grpc_err_sync(false).unwrap();
+    assert!(!events.contains(tracing::Level::ERROR));
+
+    grpc_err_sync(true).unwrap_err();
+    assert!(events.contains(tracing::Level::ERROR));
+}
+
+#[tokio::test]
+async fn grpc_err_classifies_async_trait_methods() {
+    let events = RecordedEventLevels::default();
+    let subscriber = tracing_subscriber::registry().with(events.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    AsyncTraitHandler.handle(false).await.unwrap();
+    assert!(!events.contains(tracing::Level::ERROR));
+
+    AsyncTraitHandler.handle(true).await.unwrap_err();
+    assert!(events.contains(tracing::Level::ERROR));
+}
+
 #[test]
 fn ui_tests() {
     let tests = trybuild::TestCases::new();
@@ -176,4 +280,5 @@ fn ui_tests() {
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip_all.rs");
     tests.compile_fail("tests/ui/tracing_macros/outside_miden_instrument.rs");
+    tests.compile_fail("tests/ui/tracing_macros/grpc_err_with_err.rs");
 }

--- a/crates/utils/tests/ui/tracing_macros/err_duplicate.rs
+++ b/crates/utils/tests/ui/tracing_macros/err_duplicate.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::miden_instrument;
+
+#[miden_instrument(target = "test", name = "duplicate_err", err, err(fault_only))]
+async fn duplicate_err() -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/err_duplicate.stderr
+++ b/crates/utils/tests/ui/tracing_macros/err_duplicate.stderr
@@ -1,0 +1,11 @@
+error: duplicate `err` directive; only one is allowed
+ --> tests/ui/tracing_macros/err_duplicate.rs:3:66
+  |
+3 | #[miden_instrument(target = "test", name = "duplicate_err", err, err(fault_only))]
+  |                                                                  ^^^^^^^^^^^^^^^
+
+error: first `err` directive here
+ --> tests/ui/tracing_macros/err_duplicate.rs:3:61
+  |
+3 | #[miden_instrument(target = "test", name = "duplicate_err", err, err(fault_only))]
+  |                                                             ^^^

--- a/crates/utils/tests/ui/tracing_macros/err_fault_only_invalid_level.rs
+++ b/crates/utils/tests/ui/tracing_macros/err_fault_only_invalid_level.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::miden_instrument;
+
+#[miden_instrument(target = "test", name = "invalid_level", err(fault_only, level = "loud"))]
+async fn invalid_level() -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/err_fault_only_invalid_level.stderr
+++ b/crates/utils/tests/ui/tracing_macros/err_fault_only_invalid_level.stderr
@@ -1,0 +1,5 @@
+error: unknown level "loud"; expected one of "trace", "debug", "info", "warn" or "error"
+ --> tests/ui/tracing_macros/err_fault_only_invalid_level.rs:3:85
+  |
+3 | #[miden_instrument(target = "test", name = "invalid_level", err(fault_only, level = "loud"))]
+  |                                                                                     ^^^^^^

--- a/crates/utils/tests/ui/tracing_macros/err_fault_only_unknown_option.rs
+++ b/crates/utils/tests/ui/tracing_macros/err_fault_only_unknown_option.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::miden_instrument;
+
+#[miden_instrument(target = "test", name = "unknown_option", err(fault_only, Debug))]
+async fn unknown_option() -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/err_fault_only_unknown_option.stderr
+++ b/crates/utils/tests/ui/tracing_macros/err_fault_only_unknown_option.stderr
@@ -1,0 +1,5 @@
+error: unsupported `err(fault_only)` option; only `level = "..."` can be combined with `fault_only`
+ --> tests/ui/tracing_macros/err_fault_only_unknown_option.rs:3:78
+  |
+3 | #[miden_instrument(target = "test", name = "unknown_option", err(fault_only, Debug))]
+  |                                                                              ^^^^^

--- a/crates/utils/tests/ui/tracing_macros/err_unknown_mode.rs
+++ b/crates/utils/tests/ui/tracing_macros/err_unknown_mode.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::miden_instrument;
+
+#[miden_instrument(target = "test", name = "unknown_mode", err(faultonly))]
+async fn unknown_mode() -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/err_unknown_mode.stderr
+++ b/crates/utils/tests/ui/tracing_macros/err_unknown_mode.stderr
@@ -1,0 +1,5 @@
+error: unsupported `err` option; expected `fault_only`, `Debug`, `Display` or `level = "..."`
+ --> tests/ui/tracing_macros/err_unknown_mode.rs:3:64
+  |
+3 | #[miden_instrument(target = "test", name = "unknown_mode", err(faultonly))]
+  |                                                                ^^^^^^^^^

--- a/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.rs
+++ b/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::miden_instrument;
+
+#[miden_instrument(target = "test", name = "both_directives", err, grpc_err)]
+async fn both_directives() -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.rs
+++ b/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.rs
@@ -1,8 +1,0 @@
-use miden_node_utils::tracing::miden_instrument;
-
-#[miden_instrument(target = "test", name = "both_directives", err, grpc_err)]
-async fn both_directives() -> Result<(), std::io::Error> {
-    Ok(())
-}
-
-fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.stderr
+++ b/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.stderr
@@ -1,0 +1,5 @@
+error: `err` cannot be combined with `grpc_err`
+ --> tests/ui/tracing_macros/grpc_err_with_err.rs:3:63
+  |
+3 | #[miden_instrument(target = "test", name = "both_directives", err, grpc_err)]
+  |                                                               ^^^

--- a/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.stderr
+++ b/crates/utils/tests/ui/tracing_macros/grpc_err_with_err.stderr
@@ -1,5 +1,0 @@
-error: `err` cannot be combined with `grpc_err`
- --> tests/ui/tracing_macros/grpc_err_with_err.rs:3:63
-  |
-3 | #[miden_instrument(target = "test", name = "both_directives", err, grpc_err)]
-  |                                                               ^^^


### PR DESCRIPTION
## Summary

Closes #2507.

Why:
- User-caused RPC failures (invalid proofs, malformed/stale transactions, mempool rejections) were recorded identically to internal faults: the span got OTel `error` status, making client noise indistinguishable from node failures in Honeycomb. This floods error-based alerts (the "High Failure Rate" trigger had to exclude `rpc.Api` root spans as a stopgap) and pollutes error-rate views during incident debugging.

How:
- Request root spans now always record `rpc.grpc.status_code` (OTel RPC semconv): `0` on success, the actual code on failure. Implemented via `grpc_trace_layer()` (`crates/utils/src/tracing/grpc.rs`), adopted by all gRPC servers (rpc, internal sequencer, validator, ntx-builder, remote-prover).
- Spans are error-marked only for codes indicating a node fault (`UNKNOWN`, `DEADLINE_EXCEEDED`, `INTERNAL`, `UNAVAILABLE`, `DATA_LOSS`); client-caused codes are successful rejections. This replaces the previous per-server classifier stopgaps — notably, `UNKNOWN` counts as an error again.
- Handler and submit-path spans switch from the plain `err` instrument directive to a new `fault_only` mode: `err(fault_only)`. It applies the same classification via a `GrpcFault` trait (implemented for `tonic::Status`, auto-derived by the `GrpcError` macro): node faults log at ERROR with the full error report and mark the span as failed, while client failures log at DEBUG and leave span status untouched. An optional `level` tunes the fault-side event's verbosity (e.g. `err(fault_only, level = "warn")`) without affecting span status, which always follows the fault classification.
- The `GrpcError` derive now supports `#[grpc(failed_precondition)]`, `#[grpc(resource_exhausted)]` and `#[grpc(not_found)]`. Mempool rejections use them: expired transactions and state conflicts return `FAILED_PRECONDITION`, capacity exhaustion returns `RESOURCE_EXHAUSTED` (previously all `INVALID_ARGUMENT`). The API-level error detail bytes are unchanged.

Resulting query semantics:
- "users are failing to submit" → `rpc.grpc.status_code != 0` on `rpc.Api` spans
- "the node is misbehaving" → `error exists` (meaningful again)
- "mempool is saturated" → `rpc.grpc.status_code = 8` (RESOURCE_EXHAUSTED)

Follow-up (infrastructure repo): drop the `rpc.service != rpc.Api` filter from the "High Failure Rate" trigger; switch "Transaction Submission Failures" from `error exists` to `rpc.grpc.status_code != 0`.

## Changelog

```toml
[[entry]]
scope  = "rpc"
impact = "changed"
description   = "Transaction submissions rejected because they expired or conflict with mempool state now return `FAILED_PRECONDITION` (previously `INVALID_ARGUMENT`), and submissions rejected because the mempool is at capacity now return `RESOURCE_EXHAUSTED` (previously `INVALID_ARGUMENT`). The API-level error detail codes are unchanged."
```
```toml
[[entry]]
scope  = "node"
impact = "added"
description   = "gRPC request spans now always record `rpc.grpc.status_code`, and only node faults (INTERNAL, UNKNOWN, UNAVAILABLE, DEADLINE_EXCEEDED, DATA_LOSS) mark telemetry spans with error status; client-caused failures no longer appear as errors in traces."
```