### PR TITLE
Add canonical tracing attribute encoding

### DIFF
--- a/crates/tracing-macro/src/lib.rs
+++ b/crates/tracing-macro/src/lib.rs
@@ -7,7 +7,19 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Dot;
 use syn::visit::Visit;
-use syn::{Block, Expr, Ident, ItemFn, Macro, Result, Token, parse_macro_input, parse_quote};
+use syn::{
+    Attribute,
+    Block,
+    Expr,
+    Ident,
+    ItemFn,
+    Macro,
+    Meta,
+    Result,
+    Token,
+    parse_macro_input,
+    parse_quote,
+};
 
 const ALLOWED_FIELD_NAMES: &[&str] = &[
     "account.id",
@@ -101,9 +113,15 @@ const ALLOWED_FIELD_NAMES: &[&str] = &[
     "workers.count",
 ];
 
+/// Instruments a function using registered tracing fields.
+///
+/// Append `#[nonstandard]` to a field value to permit a name outside the field registry.
 #[proc_macro_attribute]
 pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let attr = TokenStream2::from(attr);
+    let attr = match rewrite_explicit_fields(TokenStream2::from(attr)) {
+        Ok(attr) => attr,
+        Err(error) => return error.into_compile_error().into(),
+    };
     let mut function = parse_macro_input!(item as ItemFn);
     let fields = collect_recorded_fields(&function);
     let args = match merge_inferred_fields(attr, &fields) {
@@ -130,8 +148,6 @@ pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn merge_inferred_fields(attr: TokenStream2, fields: &[FieldPath]) -> Result<TokenStream2> {
-    validate_explicit_fields(&attr)?;
-
     let mut args = split_top_level_args(attr);
     reject_skip_directives(&args)?;
 
@@ -193,14 +209,23 @@ fn reject_skip_directives(args: &[TokenStream2]) -> Result<()> {
     Ok(())
 }
 
-fn validate_explicit_fields(attr: &TokenStream2) -> Result<()> {
-    for arg in split_top_level_args(attr.clone()) {
-        if let Some(group) = fields_group(&arg) {
-            syn::parse2::<InstrumentFields>(group.stream())?;
-        }
-    }
+fn rewrite_explicit_fields(attr: TokenStream2) -> Result<TokenStream2> {
+    let args = split_top_level_args(attr)
+        .into_iter()
+        .map(|arg| {
+            if let Some(group) = fields_group(&arg) {
+                let fields = syn::parse2::<InstrumentFields>(group.stream())?;
+                let fields = fields.fields.iter().map(RecordField::instrument_tokens);
+                let mut rewritten = Group::new(Delimiter::Parenthesis, quote! { #(#fields),* });
+                rewritten.set_span(group.span());
+                Ok(quote! { fields #rewritten })
+            } else {
+                Ok(arg)
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
 
-    Ok(())
+    Ok(quote! { #(#args),* })
 }
 
 fn split_top_level_args(tokens: TokenStream2) -> Vec<TokenStream2> {
@@ -250,6 +275,9 @@ fn ends_with_comma(tokens: &TokenStream2) -> bool {
     )
 }
 
+/// Records fields on the current `miden_instrument` span.
+///
+/// Append `#[nonstandard]` to a field value to permit a name outside the field registry.
 #[proc_macro]
 pub fn miden_span_record(input: TokenStream) -> TokenStream {
     let records = parse_macro_input!(input as RecordFields);
@@ -336,6 +364,7 @@ impl<const VALUE_REQUIRED: bool> Parse for Fields<VALUE_REQUIRED> {
 }
 
 struct RecordField {
+    shorthand_formatter: Option<Formatter>,
     path: FieldPath,
     value: Option<RecordValue>,
 }
@@ -348,15 +377,31 @@ impl RecordField {
             Formatter::parse_optional(input)?
         };
         let path = input.parse()?;
-        validate_field_name(&path)?;
-        let value = if value_required || shorthand_formatter.is_none() && input.peek(Token![=]) {
-            input.parse::<Token![=]>()?;
-            Some(input.parse()?)
-        } else {
-            None
-        };
+        let value: Option<RecordValue> =
+            if value_required || shorthand_formatter.is_none() && input.peek(Token![=]) {
+                input.parse::<Token![=]>()?;
+                Some(input.parse()?)
+            } else {
+                None
+            };
+        if value.as_ref().is_none_or(|value| !value.nonstandard) {
+            validate_field_name(&path)?;
+        }
 
-        Ok(Self { path, value })
+        Ok(Self { shorthand_formatter, path, value })
+    }
+
+    fn instrument_tokens(&self) -> TokenStream2 {
+        let path = &self.path;
+        if let Some(value) = &self.value {
+            let value = value.instrument_tokens();
+            quote! { #path = #value }
+        } else if let Some(formatter) = self.shorthand_formatter {
+            let formatter = formatter.tokens();
+            quote! { #formatter #path }
+        } else {
+            quote! { #path }
+        }
     }
 }
 
@@ -401,6 +446,7 @@ impl ToTokens for FieldPath {
 struct RecordValue {
     formatter: Formatter,
     expr: Expr,
+    nonstandard: bool,
 }
 
 impl RecordValue {
@@ -413,17 +459,37 @@ impl RecordValue {
             Formatter::Plain => quote! { &#expr },
         }
     }
+
+    fn instrument_tokens(&self) -> TokenStream2 {
+        let formatter = self.formatter.tokens();
+        let expr = &self.expr;
+        quote! { #formatter #expr }
+    }
 }
 
 impl Parse for RecordValue {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let formatter = Formatter::parse_optional(input)?.unwrap_or(Formatter::Plain);
         let expr = input.parse()?;
+        let attributes = input.call(Attribute::parse_outer)?;
+        let nonstandard = match attributes.as_slice() {
+            [] => false,
+            [attribute] if matches!(&attribute.meta, Meta::Path(path) if path.is_ident("nonstandard")) => {
+                true
+            },
+            [attribute, ..] => {
+                return Err(syn::Error::new_spanned(
+                    attribute,
+                    "only `#[nonstandard]` is supported after a tracing field value",
+                ));
+            },
+        };
 
-        Ok(Self { formatter, expr })
+        Ok(Self { formatter, expr, nonstandard })
     }
 }
 
+#[derive(Clone, Copy)]
 enum Formatter {
     Display,
     Debug,
@@ -431,6 +497,14 @@ enum Formatter {
 }
 
 impl Formatter {
+    fn tokens(self) -> TokenStream2 {
+        match self {
+            Self::Display => quote! { % },
+            Self::Debug => quote! { ? },
+            Self::Plain => TokenStream2::new(),
+        }
+    }
+
     fn parse_optional(input: ParseStream<'_>) -> Result<Option<Self>> {
         if input.peek(Token![%]) {
             input.parse::<Token![%]>()?;

--- a/crates/utils/src/tracing/attribute.rs
+++ b/crates/utils/src/tracing/attribute.rs
@@ -20,33 +20,18 @@ const BOOLEAN_FIELD_NAMES: &[&str] = &[
 ];
 
 const NUMBER_FIELD_NAMES: &[&str] = &[
-    "account.assets.count",
-    "account.crashes.count",
     "account.id.length",
-    "account.ids.count",
     "account.index",
-    "account.storage.map.entries.count",
     "asset.amount",
-    "batch.account_updates.count",
     "batch.expiration_height",
     "batch.expires_at",
-    "batch.input_notes.count",
-    "batch.output_notes.count",
     "batch.reference_block.number",
     "batch.size",
-    "block.batches.count",
-    "block.batches.output_notes.count",
-    "block.erased_note_proofs.count",
-    "block.erased_notes.count",
     "block.from",
-    "block.nullifiers.count",
     "block.number",
-    "block.output_notes.count",
     "block.protocol.version",
     "block.size",
     "block.timestamp",
-    "block.transactions.count",
-    "block.updated_accounts.count",
     "block_range.from",
     "block_range.to",
     "counter.failures.consecutive",
@@ -73,14 +58,7 @@ const NUMBER_FIELD_NAMES: &[&str] = &[
     "mempool.output_notes",
     "mempool.transactions.unbatched",
     "mempool.transactions.uncommitted",
-    "migration.count",
-    "note.tags.count",
-    "notes.count",
-    "notes.deferred.count",
-    "notes.failed.count",
-    "notes.oversized.count",
-    "notes.rejected.count",
-    "nullifiers.count",
+    "note.tag",
     "ntx_builder.max_cycles",
     "ntx_builder.tx_expiration_delta",
     "port",
@@ -89,7 +67,6 @@ const NUMBER_FIELD_NAMES: &[&str] = &[
     "pow.target",
     "pow.target.leading_zero_bits",
     "prefix_len",
-    "prefixes.count",
     "proof_size",
     "prover.capacity",
     "prover.port",
@@ -112,19 +89,11 @@ const NUMBER_FIELD_NAMES: &[&str] = &[
     "tip.stale_duration_secs",
     "transaction.expiration_delta",
     "transaction.expires_at",
-    "transaction.input_notes.count",
-    "transaction.output_notes.count",
     "transaction.reference_block.number",
     "transaction.submitted_at",
-    "transactions.count",
-    "transactions.input_notes.count",
-    "transactions.output_notes.count",
-    "transactions.unauthenticated_notes.count",
-    "validators.count",
     "worker.status.raw",
     "workers.active",
     "workers.capacity",
-    "workers.count",
 ];
 
 const STRING_FIELD_NAMES: &[&str] = &[
@@ -175,15 +144,16 @@ const STRING_FIELD_NAMES: &[&str] = &[
 
 /// Converts a value into its canonical tracing attribute representation.
 ///
-/// Implementations decide the allowed field names, the attribute's primitive type, and its
+/// Implementations decide the allowed scalar field names, the attribute's primitive type, and its
 /// formatting, allowing tracing macros to use one name and representation consistently at every
-/// recording site.
+/// recording site. Collection implementations derive their field names by appending `s` to these
+/// scalar names.
 pub trait RecordAttribute {
-    /// Field names which may record this value as a scalar attribute.
+    /// Scalar field names associated with this value's type.
     const FIELD_NAMES: &'static [&'static str];
 
-    /// Field names which may record a collection of this value.
-    const LIST_FIELD_NAMES: &'static [&'static str] = &[];
+    /// Whether the final component of each field name must have an `s` suffix.
+    const PLURALIZE_FIELD_NAMES: bool = false;
 
     /// Returns the value that is passed to `tracing`.
     fn record_attribute(&self) -> impl Value + '_;
@@ -194,15 +164,37 @@ pub trait RecordAttribute {
 /// This is public because it is referenced by the tracing proc macros. Callers should use the
 /// macros rather than invoking it directly.
 #[doc(hidden)]
-pub const fn field_name_allowed(field_names: &[&str], field_name: &str) -> bool {
+pub const fn field_name_allowed(field_names: &[&str], field_name: &str, pluralize: bool) -> bool {
     let mut index = 0;
     while index < field_names.len() {
-        if str_eq(field_names[index], field_name) {
+        let allowed = if pluralize {
+            str_eq_with_s_suffix(field_names[index], field_name)
+        } else {
+            str_eq(field_names[index], field_name)
+        };
+        if allowed {
             return true;
         }
         index += 1;
     }
     false
+}
+
+const fn str_eq_with_s_suffix(singular: &str, plural: &str) -> bool {
+    let singular = singular.as_bytes();
+    let plural = plural.as_bytes();
+    if plural.len() != singular.len() + 1 || plural[singular.len()] != b's' {
+        return false;
+    }
+
+    let mut index = 0;
+    while index < singular.len() {
+        if singular[index] != plural[index] {
+            return false;
+        }
+        index += 1;
+    }
+    true
 }
 
 const fn str_eq(left: &str, right: &str) -> bool {
@@ -232,11 +224,10 @@ pub fn record_attribute<T: RecordAttribute + ?Sized>(value: &T) -> impl Value + 
 }
 
 macro_rules! impl_scalar_attribute {
-    ($field_names:expr, $list_field_names:expr; $($ty:ty),* $(,)?) => {
+    ($field_names:expr; $($ty:ty),* $(,)?) => {
         $(
             impl RecordAttribute for $ty {
                 const FIELD_NAMES: &'static [&'static str] = $field_names;
-                const LIST_FIELD_NAMES: &'static [&'static str] = $list_field_names;
 
                 fn record_attribute(&self) -> impl Value + '_ {
                     *self
@@ -246,10 +237,9 @@ macro_rules! impl_scalar_attribute {
     };
 }
 
-impl_scalar_attribute!(BOOLEAN_FIELD_NAMES, &[]; bool);
+impl_scalar_attribute!(BOOLEAN_FIELD_NAMES; bool);
 impl_scalar_attribute!(
-    NUMBER_FIELD_NAMES,
-    &[];
+    NUMBER_FIELD_NAMES;
     f32,
     f64,
     i8,
@@ -264,7 +254,7 @@ impl_scalar_attribute!(
     u128,
     usize,
 );
-impl_scalar_attribute!(NUMBER_FIELD_NAMES, &["note.tags", "prefixes"]; u32);
+impl_scalar_attribute!(NUMBER_FIELD_NAMES; u32);
 
 impl RecordAttribute for str {
     const FIELD_NAMES: &'static [&'static str] = STRING_FIELD_NAMES;
@@ -284,7 +274,7 @@ impl RecordAttribute for String {
 
 impl<T: RecordAttribute + ?Sized> RecordAttribute for &T {
     const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
-    const LIST_FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+    const PLURALIZE_FIELD_NAMES: bool = T::PLURALIZE_FIELD_NAMES;
 
     fn record_attribute(&self) -> impl Value + '_ {
         (*self).record_attribute()
@@ -293,7 +283,7 @@ impl<T: RecordAttribute + ?Sized> RecordAttribute for &T {
 
 impl<T: RecordAttribute> RecordAttribute for Option<T> {
     const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
-    const LIST_FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+    const PLURALIZE_FIELD_NAMES: bool = T::PLURALIZE_FIELD_NAMES;
 
     fn record_attribute(&self) -> impl Value + '_ {
         self.as_ref().map(RecordAttribute::record_attribute)
@@ -342,10 +332,9 @@ impl RecordAttribute for BlockNumber {
 }
 
 macro_rules! impl_display_attribute {
-    ($ty:ty, $field_names:expr, $list_field_names:expr $(,)?) => {
+    ($ty:ty, $field_names:expr $(,)?) => {
         impl RecordAttribute for $ty {
             const FIELD_NAMES: &'static [&'static str] = $field_names;
-            const LIST_FIELD_NAMES: &'static [&'static str] = $list_field_names;
 
             fn record_attribute(&self) -> impl Value + '_ {
                 tracing::field::display(self)
@@ -364,19 +353,14 @@ impl_display_attribute!(
         "wallet.account.id.new",
         "wallet.account.id.old",
     ],
-    &["account.ids"],
 );
-impl_display_attribute!(AccountIdPrefix, &["account.id.network_prefix"], &[]);
-impl_display_attribute!(StorageMapKey, &["account.storage.map.key"], &[]);
-impl_display_attribute!(StorageSlotName, &["account.storage.slot"], &[]);
-impl_display_attribute!(BatchId, &["batch.id"], &["block.batch.ids"]);
-impl_display_attribute!(NoteId, &["note.id"], &["notes.ids"]);
-impl_display_attribute!(Nullifier, &["note.nullifier"], &["nullifiers"]);
-impl_display_attribute!(
-    TransactionId,
-    &["transaction.id"],
-    &["block.transactions.ids", "transactions.ids"],
-);
+impl_display_attribute!(AccountIdPrefix, &["account.id.network_prefix"]);
+impl_display_attribute!(StorageMapKey, &["account.storage.map.key"]);
+impl_display_attribute!(StorageSlotName, &["account.storage.slot"]);
+impl_display_attribute!(BatchId, &["batch.id", "block.batch.id"]);
+impl_display_attribute!(NoteId, &["note.id"]);
+impl_display_attribute!(Nullifier, &["note.nullifier"]);
+impl_display_attribute!(TransactionId, &["block.transaction.id", "transaction.id"]);
 impl_display_attribute!(
     Word,
     &[
@@ -397,7 +381,6 @@ impl_display_attribute!(
         "script.root",
         "transaction.reference_block.commitment",
     ],
-    &[],
 );
 
 /// Formats a slice as one string-valued tracing attribute.
@@ -422,7 +405,8 @@ impl<T: Display> Display for AttributeList<'_, T> {
 }
 
 impl<T: Display + RecordAttribute> RecordAttribute for [T] {
-    const FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+    const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
+    const PLURALIZE_FIELD_NAMES: bool = true;
 
     fn record_attribute(&self) -> impl Value + '_ {
         tracing::field::display(AttributeList(self))
@@ -430,7 +414,8 @@ impl<T: Display + RecordAttribute> RecordAttribute for [T] {
 }
 
 impl<T: Display + RecordAttribute, const N: usize> RecordAttribute for [T; N] {
-    const FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+    const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
+    const PLURALIZE_FIELD_NAMES: bool = true;
 
     fn record_attribute(&self) -> impl Value + '_ {
         self.as_slice().record_attribute()
@@ -438,7 +423,8 @@ impl<T: Display + RecordAttribute, const N: usize> RecordAttribute for [T; N] {
 }
 
 impl<T: Display + RecordAttribute> RecordAttribute for Vec<T> {
-    const FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+    const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
+    const PLURALIZE_FIELD_NAMES: bool = true;
 
     fn record_attribute(&self) -> impl Value + '_ {
         self.as_slice().record_attribute()
@@ -470,9 +456,25 @@ mod tests {
 
     #[test]
     fn field_names_are_specific_to_the_attribute_type() {
-        assert!(field_name_allowed(AccountId::FIELD_NAMES, "account.id"));
-        assert!(!field_name_allowed(AccountId::FIELD_NAMES, "block.number"));
-        assert!(field_name_allowed(<[AccountId]>::FIELD_NAMES, "account.ids"));
-        assert!(!field_name_allowed(<[AccountId]>::FIELD_NAMES, "account.id"));
+        assert!(field_name_allowed(
+            AccountId::FIELD_NAMES,
+            "account.id",
+            AccountId::PLURALIZE_FIELD_NAMES,
+        ));
+        assert!(!field_name_allowed(
+            AccountId::FIELD_NAMES,
+            "account.ids",
+            AccountId::PLURALIZE_FIELD_NAMES,
+        ));
+        assert!(field_name_allowed(
+            <[AccountId]>::FIELD_NAMES,
+            "account.ids",
+            <[AccountId]>::PLURALIZE_FIELD_NAMES,
+        ));
+        assert!(!field_name_allowed(
+            <[AccountId]>::FIELD_NAMES,
+            "account.id",
+            <[AccountId]>::PLURALIZE_FIELD_NAMES,
+        ));
     }
 }

--- a/crates/utils/src/tracing/attribute.rs
+++ b/crates/utils/src/tracing/attribute.rs
@@ -1,0 +1,478 @@
+use std::fmt::{self, Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use miden_protocol::Word;
+use miden_protocol::account::{AccountId, AccountIdPrefix, StorageMapKey, StorageSlotName};
+use miden_protocol::batch::BatchId;
+use miden_protocol::block::BlockNumber;
+use miden_protocol::note::{NoteId, Nullifier};
+use miden_protocol::transaction::TransactionId;
+use tracing::Value;
+
+const BOOLEAN_FIELD_NAMES: &[&str] = &[
+    "account.updated",
+    "note.erased",
+    "note.id_resolved",
+    "panic",
+    "request.include_mmr_proof",
+    "request.include_proof",
+    "rpc.authentication.configured",
+];
+
+const NUMBER_FIELD_NAMES: &[&str] = &[
+    "account.assets.count",
+    "account.crashes.count",
+    "account.id.length",
+    "account.ids.count",
+    "account.index",
+    "account.storage.map.entries.count",
+    "asset.amount",
+    "batch.account_updates.count",
+    "batch.expiration_height",
+    "batch.expires_at",
+    "batch.input_notes.count",
+    "batch.output_notes.count",
+    "batch.reference_block.number",
+    "batch.size",
+    "block.batches.count",
+    "block.batches.output_notes.count",
+    "block.erased_note_proofs.count",
+    "block.erased_notes.count",
+    "block.from",
+    "block.nullifiers.count",
+    "block.number",
+    "block.output_notes.count",
+    "block.protocol.version",
+    "block.size",
+    "block.timestamp",
+    "block.transactions.count",
+    "block.updated_accounts.count",
+    "block_range.from",
+    "block_range.to",
+    "counter.failures.consecutive",
+    "counter.latency.timeout_ms",
+    "counter.value.expected",
+    "counter.value.observed",
+    "counter.value.target",
+    "current_client_block_height",
+    "cutoff_block",
+    "db.account_state_forest.size",
+    "db.account_tree.size",
+    "db.block_store.size",
+    "db.nullifier_tree.size",
+    "db.sqlite.connection_pool_size",
+    "db.sqlite.size",
+    "db.sqlite.wal.size",
+    "dice_roll",
+    "failure_rate",
+    "inputs_size",
+    "mempool.accounts",
+    "mempool.batches.proposed",
+    "mempool.batches.proven",
+    "mempool.nullifiers",
+    "mempool.output_notes",
+    "mempool.transactions.unbatched",
+    "mempool.transactions.uncommitted",
+    "migration.count",
+    "note.tags.count",
+    "notes.count",
+    "notes.deferred.count",
+    "notes.failed.count",
+    "notes.oversized.count",
+    "notes.rejected.count",
+    "nullifiers.count",
+    "ntx_builder.max_cycles",
+    "ntx_builder.tx_expiration_delta",
+    "port",
+    "pow.hash",
+    "pow.nonce",
+    "pow.target",
+    "pow.target.leading_zero_bits",
+    "prefix_len",
+    "prefixes.count",
+    "proof_size",
+    "prover.capacity",
+    "prover.port",
+    "prover.proof_type.raw",
+    "reference_block.number",
+    "retry.attempt",
+    "retry.delay_ms",
+    "shutdown.grace_period_ms",
+    "snapshot.block_num",
+    "snapshot.lifetime_ms",
+    "snapshot.superseded_for_ms",
+    "snapshots.live",
+    "subscription.idle_ms",
+    "subscription.stall_timeout_ms",
+    "sync.block_gap",
+    "sync.ready_threshold",
+    "sync.upstream_block",
+    "timeout.ms",
+    "tip.number",
+    "tip.stale_duration_secs",
+    "transaction.expiration_delta",
+    "transaction.expires_at",
+    "transaction.input_notes.count",
+    "transaction.output_notes.count",
+    "transaction.reference_block.number",
+    "transaction.submitted_at",
+    "transactions.count",
+    "transactions.input_notes.count",
+    "transactions.output_notes.count",
+    "transactions.unauthenticated_notes.count",
+    "validators.count",
+    "worker.status.raw",
+    "workers.active",
+    "workers.capacity",
+    "workers.count",
+];
+
+const STRING_FIELD_NAMES: &[&str] = &[
+    "account.id",
+    "account.storage.kind",
+    "account.storage.map.entry.operation",
+    "account.storage.operation",
+    "asset.symbol",
+    "batch.interval",
+    "block.interval",
+    "dependency.endpoint",
+    "dependency.name",
+    "genesis.source",
+    "genesis.source.kind",
+    "internal.listen",
+    "mempool.removal.reason",
+    "network_monitor.listen",
+    "node.role",
+    "note.execution_cycles",
+    "ntx_builder.endpoint",
+    "ntx_builder.idle_timeout",
+    "ntx_builder.listen",
+    "operation.name",
+    "path",
+    "pow.challenge.prefix",
+    "prover",
+    "prover.kind",
+    "prover.timeout",
+    "request.kind",
+    "rpc.endpoint",
+    "rpc.listen",
+    "sequencer.endpoint",
+    "service.name",
+    "service.version",
+    "shutdown.signal",
+    "sync.block_source.endpoint",
+    "task.name",
+    "transaction.id",
+    "transaction.input_notes",
+    "transaction.output_notes",
+    "tx_prover.endpoint",
+    "validator.admin_listen",
+    "validator.endpoints",
+    "validator.listen",
+    "validator.signer",
+    "worker.name",
+];
+
+/// Converts a value into its canonical tracing attribute representation.
+///
+/// Implementations decide the allowed field names, the attribute's primitive type, and its
+/// formatting, allowing tracing macros to use one name and representation consistently at every
+/// recording site.
+pub trait RecordAttribute {
+    /// Field names which may record this value as a scalar attribute.
+    const FIELD_NAMES: &'static [&'static str];
+
+    /// Field names which may record a collection of this value.
+    const LIST_FIELD_NAMES: &'static [&'static str] = &[];
+
+    /// Returns the value that is passed to `tracing`.
+    fn record_attribute(&self) -> impl Value + '_;
+}
+
+/// Returns whether `field_name` occurs in `field_names`.
+///
+/// This is public because it is referenced by the tracing proc macros. Callers should use the
+/// macros rather than invoking it directly.
+#[doc(hidden)]
+pub const fn field_name_allowed(field_names: &[&str], field_name: &str) -> bool {
+    let mut index = 0;
+    while index < field_names.len() {
+        if str_eq(field_names[index], field_name) {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+const fn str_eq(left: &str, right: &str) -> bool {
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    if left.len() != right.len() {
+        return false;
+    }
+
+    let mut index = 0;
+    while index < left.len() {
+        if left[index] != right[index] {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
+
+/// Converts an approved attribute into a `tracing` value.
+///
+/// This is public because it is referenced by the tracing proc macros. Callers should use the
+/// macros rather than invoking it directly.
+#[doc(hidden)]
+pub fn record_attribute<T: RecordAttribute + ?Sized>(value: &T) -> impl Value + '_ {
+    value.record_attribute()
+}
+
+macro_rules! impl_scalar_attribute {
+    ($field_names:expr, $list_field_names:expr; $($ty:ty),* $(,)?) => {
+        $(
+            impl RecordAttribute for $ty {
+                const FIELD_NAMES: &'static [&'static str] = $field_names;
+                const LIST_FIELD_NAMES: &'static [&'static str] = $list_field_names;
+
+                fn record_attribute(&self) -> impl Value + '_ {
+                    *self
+                }
+            }
+        )*
+    };
+}
+
+impl_scalar_attribute!(BOOLEAN_FIELD_NAMES, &[]; bool);
+impl_scalar_attribute!(
+    NUMBER_FIELD_NAMES,
+    &[];
+    f32,
+    f64,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    u8,
+    u16,
+    u64,
+    u128,
+    usize,
+);
+impl_scalar_attribute!(NUMBER_FIELD_NAMES, &["note.tags", "prefixes"]; u32);
+
+impl RecordAttribute for str {
+    const FIELD_NAMES: &'static [&'static str] = STRING_FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self
+    }
+}
+
+impl RecordAttribute for String {
+    const FIELD_NAMES: &'static [&'static str] = <str as RecordAttribute>::FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_str()
+    }
+}
+
+impl<T: RecordAttribute + ?Sized> RecordAttribute for &T {
+    const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
+    const LIST_FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        (*self).record_attribute()
+    }
+}
+
+impl<T: RecordAttribute> RecordAttribute for Option<T> {
+    const FIELD_NAMES: &'static [&'static str] = T::FIELD_NAMES;
+    const LIST_FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_ref().map(RecordAttribute::record_attribute)
+    }
+}
+
+impl RecordAttribute for Path {
+    const FIELD_NAMES: &'static [&'static str] = &["data.directory", "genesis.file", "path"];
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        tracing::field::display(self.display())
+    }
+}
+
+impl RecordAttribute for PathBuf {
+    const FIELD_NAMES: &'static [&'static str] = <Path as RecordAttribute>::FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_path().record_attribute()
+    }
+}
+
+impl RecordAttribute for BlockNumber {
+    const FIELD_NAMES: &'static [&'static str] = &[
+        "batch.expiration_height",
+        "batch.expires_at",
+        "batch.reference_block.number",
+        "block.from",
+        "block.number",
+        "block_range.from",
+        "block_range.to",
+        "cutoff_block",
+        "current_client_block_height",
+        "reference_block.number",
+        "snapshot.block_num",
+        "sync.upstream_block",
+        "tip.number",
+        "transaction.expires_at",
+        "transaction.reference_block.number",
+        "transaction.submitted_at",
+    ];
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_u64()
+    }
+}
+
+macro_rules! impl_display_attribute {
+    ($ty:ty, $field_names:expr, $list_field_names:expr $(,)?) => {
+        impl RecordAttribute for $ty {
+            const FIELD_NAMES: &'static [&'static str] = $field_names;
+            const LIST_FIELD_NAMES: &'static [&'static str] = $list_field_names;
+
+            fn record_attribute(&self) -> impl Value + '_ {
+                tracing::field::display(self)
+            }
+        }
+    };
+}
+
+impl_display_attribute!(
+    AccountId,
+    &[
+        "account.id",
+        "counter.account.id.new",
+        "counter.account.id.old",
+        "note.sender",
+        "wallet.account.id.new",
+        "wallet.account.id.old",
+    ],
+    &["account.ids"],
+);
+impl_display_attribute!(AccountIdPrefix, &["account.id.network_prefix"], &[]);
+impl_display_attribute!(StorageMapKey, &["account.storage.map.key"], &[]);
+impl_display_attribute!(StorageSlotName, &["account.storage.slot"], &[]);
+impl_display_attribute!(BatchId, &["batch.id"], &["block.batch.ids"]);
+impl_display_attribute!(NoteId, &["note.id"], &["notes.ids"]);
+impl_display_attribute!(Nullifier, &["note.nullifier"], &["nullifiers"]);
+impl_display_attribute!(
+    TransactionId,
+    &["transaction.id"],
+    &["block.transactions.ids", "transactions.ids"],
+);
+impl_display_attribute!(
+    Word,
+    &[
+        "account.final_state.commitment",
+        "account.initial_state.commitment",
+        "account.storage.value",
+        "batch.reference_block.commitment",
+        "block.commitment",
+        "block.commitments.account",
+        "block.commitments.chain",
+        "block.commitments.kernel",
+        "block.commitments.note",
+        "block.commitments.nullifier",
+        "block.commitments.transaction",
+        "block.prev_block_commitment",
+        "block.sub_commitment",
+        "genesis.commitment",
+        "script.root",
+        "transaction.reference_block.commitment",
+    ],
+    &[],
+);
+
+/// Formats a slice as one string-valued tracing attribute.
+///
+/// This is not an OpenTelemetry array: `tracing::Value` has no array representation, so the `OTel`
+/// tracing layer receives the formatted list as a string.
+struct AttributeList<'a, T>(&'a [T]);
+
+impl<T: Display> Display for AttributeList<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut values = self.0.iter();
+        let Some(first) = values.next() else {
+            return f.write_str("None");
+        };
+
+        write!(f, "[{first}")?;
+        for value in values {
+            write!(f, ", {value}")?;
+        }
+        f.write_str("]")
+    }
+}
+
+impl<T: Display + RecordAttribute> RecordAttribute for [T] {
+    const FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        tracing::field::display(AttributeList(self))
+    }
+}
+
+impl<T: Display + RecordAttribute, const N: usize> RecordAttribute for [T; N] {
+    const FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_slice().record_attribute()
+    }
+}
+
+impl<T: Display + RecordAttribute> RecordAttribute for Vec<T> {
+    const FIELD_NAMES: &'static [&'static str] = T::LIST_FIELD_NAMES;
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_slice().record_attribute()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::account::AccountId;
+
+    use super::{AttributeList, RecordAttribute, field_name_allowed};
+
+    #[test]
+    fn lists_use_the_canonical_format() {
+        assert_eq!(AttributeList::<u32>(&[]).to_string(), "None");
+        assert_eq!(AttributeList(&[1, 2, 3]).to_string(), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn references_are_approved_when_the_referenced_type_is_approved() {
+        fn assert_record_attribute(_: &impl RecordAttribute) {}
+
+        let value = "attribute";
+        assert_record_attribute(&value);
+        assert_record_attribute(&&value);
+        assert_record_attribute(&Some(value));
+        assert_record_attribute(&None::<&str>);
+    }
+
+    #[test]
+    fn field_names_are_specific_to_the_attribute_type() {
+        assert!(field_name_allowed(AccountId::FIELD_NAMES, "account.id"));
+        assert!(!field_name_allowed(AccountId::FIELD_NAMES, "block.number"));
+        assert!(field_name_allowed(<[AccountId]>::FIELD_NAMES, "account.ids"));
+        assert!(!field_name_allowed(<[AccountId]>::FIELD_NAMES, "account.id"));
+    }
+}

--- a/crates/utils/src/tracing/mod.rs
+++ b/crates/utils/src/tracing/mod.rs
@@ -1,5 +1,9 @@
+mod attribute;
 pub mod grpc;
 mod span_ext;
 
+#[doc(hidden)]
+pub use attribute::field_name_allowed;
+pub use attribute::{RecordAttribute, record_attribute};
 pub use miden_node_tracing_macro::{miden_instrument, miden_span_record};
 pub use span_ext::ErrorSpanExt;

--- a/crates/utils/tests/tracing_macros.rs
+++ b/crates/utils/tests/tracing_macros.rs
@@ -110,6 +110,18 @@ fn records_fields_from_multiple_calls() {
     );
 }
 
+#[miden_instrument(
+    target = "miden-node-utils-test",
+    name = "records_nonstandard_explicit_field",
+    fields(custom.explicit = %value #[nonstandard]),
+)]
+fn records_nonstandard_explicit_field(value: &str) {}
+
+#[miden_instrument(target = "miden-node-utils-test", name = "records_nonstandard_delayed_field")]
+fn records_nonstandard_delayed_field() {
+    miden_span_record!(custom.delayed = %"delayed" #[nonstandard]);
+}
+
 #[test]
 fn inferred_fields_can_be_recorded_after_span_creation() {
     let recorded = RecordedFields::default();
@@ -168,10 +180,25 @@ fn multiple_span_record_macros_can_record_fields_after_span_creation() {
 }
 
 #[test]
+fn nonstandard_fields_bypass_the_name_registry() {
+    let recorded = RecordedFields::default();
+    let subscriber = tracing_subscriber::registry().with(recorded.clone());
+
+    tracing::subscriber::with_default(subscriber, || {
+        records_nonstandard_explicit_field("explicit");
+        records_nonstandard_delayed_field();
+    });
+
+    assert_eq!(recorded.get("custom.explicit").as_deref(), Some("explicit"));
+    assert_eq!(recorded.get("custom.delayed").as_deref(), Some("delayed"));
+}
+
+#[test]
 fn ui_tests() {
     let tests = trybuild::TestCases::new();
     tests.pass("tests/ui/tracing_macros/pass.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_field_name.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_field_annotation.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_instrument_field_name.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip_all.rs");

--- a/crates/utils/tests/ui/tracing_macros/invalid_field_annotation.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_field_annotation.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+
+#[miden_instrument]
+fn records_invalid_annotation() {
+    miden_span_record!(custom.attribute = 1 #[unchecked]);
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_field_annotation.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_field_annotation.stderr
@@ -1,0 +1,5 @@
+error: only `#[nonstandard]` is supported after a tracing field value
+ --> tests/ui/tracing_macros/invalid_field_annotation.rs:5:45
+  |
+5 |     miden_span_record!(custom.attribute = 1 #[unchecked]);
+  |                                             ^^^^^^^^^^^^

--- a/crates/utils/tests/ui/tracing_macros/pass.rs
+++ b/crates/utils/tests/ui/tracing_macros/pass.rs
@@ -38,6 +38,13 @@ fn records_allowed_instrument_fields() {}
 
 #[miden_instrument(
     fields(
+        custom.attribute = %"explicit" #[nonstandard],
+    ),
+)]
+fn records_nonstandard_instrument_field() {}
+
+#[miden_instrument(
+    fields(
         %dice_roll,
     ),
 )]
@@ -54,6 +61,11 @@ fn records_same_field_more_than_once() {
     miden_span_record!(
         block.number = updated,
     );
+}
+
+#[miden_instrument]
+fn records_nonstandard_delayed_field() {
+    miden_span_record!(custom.attribute = %"delayed" #[nonstandard]);
 }
 
 #[miden_instrument]
@@ -144,7 +156,9 @@ fn main() {
     records_fields();
     records_with_default_instrument_args(NotDebug);
     records_allowed_instrument_fields();
+    records_nonstandard_instrument_field();
     records_allowed_shorthand_instrument_field(0.5);
     records_same_field_more_than_once();
+    records_nonstandard_delayed_field();
     records_allowed_canonical_fields();
 }


### PR DESCRIPTION
Closes #2325

## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Adds a new tracing trait `RecordAttribute`. Recorded fields _must_ implement this trait in order to be recorded (opt-out is possible).

The trait allows a type to define its trace value encoding, as well as the attribute names it allows. This tightens the contract on what key-value fields may assume, I'm hoping this allows us to standardize better.

This PR doesn't migrate to this trait yet; that will come in follow-up stack PRs.

One additional (debateable) detail is that this automatically allows for pluralisation for list-type containers. This is pretty basic; but we can extend the grammar e.g. if `T` allows `transaction.id` then `&[T]` allows `transaction.ids`.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```