### PR TITLE
Enforce canonical tracing span attributes

### DIFF
--- a/bin/network-monitor/src/commands/start.rs
+++ b/bin/network-monitor/src/commands/start.rs
@@ -22,7 +22,7 @@ use crate::{COMPONENT, LOG_TARGET};
     name = "network_monitor.start_monitor",
     level = "info",
     fields(
-        port = %config.port,
+        port = config.port,
     ),
     ret(level = "debug"),
     err,

--- a/bin/network-monitor/src/counter.rs
+++ b/bin/network-monitor/src/counter.rs
@@ -261,7 +261,7 @@ impl IncrementService {
         target = COMPONENT,
         name = "network_monitor.counter.try_resync_wallet_account",
         fields(
-            account.id = %self.tx.wallet_account.id(),
+            account.id = self.tx.wallet_account.id(),
         ),
         level = "warn",
         err,

--- a/bin/network-monitor/src/remote_prover.rs
+++ b/bin/network-monitor/src/remote_prover.rs
@@ -277,7 +277,7 @@ impl Service for ProverStatusService {
         level = "info",
         ret(level = "debug"),
         fields(
-            prover = %self.name,
+            prover = self.name,
         ),
     )]
     async fn check(&mut self) -> ServiceStatus {
@@ -357,7 +357,7 @@ const PAYLOAD_RETRY_DELAY: Duration = Duration::from_secs(30);
     name = "network_monitor.prover.run_test",
     level = "info",
     fields(
-        prover = %name,
+        prover = name,
     ),
 )]
 async fn run_prover_test(

--- a/bin/ntx-builder/src/actor/execute.rs
+++ b/bin/ntx-builder/src/actor/execute.rs
@@ -269,10 +269,10 @@ impl NtxContext {
             chain_mmr,
         } = tx;
         miden_span_record!(
-            account.id = %account.id(),
-            account.id.network_prefix = %account.id().prefix(),
-            notes.count = num_notes,
-            reference_block.number = %chain_tip_header.block_num(),
+            account.id = account.id(),
+            account.id.network_prefix = account.id().prefix(),
+            note.count = num_notes,
+            reference_block.number = chain_tip_header.block_num()
         );
 
         async move {

--- a/bin/ntx-builder/src/actor/mod.rs
+++ b/bin/ntx-builder/src/actor/mod.rs
@@ -638,7 +638,7 @@ impl AccountActor {
     /// re-declaring the stale commitment.
     #[miden_instrument(
         name = "ntx.actor.execute_transactions",
-        fields(account.id = %account_id),
+        fields(account.id = account_id),
     )]
     async fn execute_transactions(
         &self,

--- a/bin/ntx-builder/src/builder.rs
+++ b/bin/ntx-builder/src/builder.rs
@@ -242,8 +242,8 @@ impl NetworkTransactionBuilder {
     #[miden_instrument(
         name = "ntx.builder.apply_committed_block",
         fields(
-            block.number = %block.header().block_num(),
-            tip.number = %committed_tip,
+            block.number = block.header().block_num(),
+            tip.number = committed_tip,
         ),
     )]
     async fn apply_committed_block_with_effects(

--- a/bin/ntx-builder/src/clients/rpc.rs
+++ b/bin/ntx-builder/src/clients/rpc.rs
@@ -186,7 +186,7 @@ impl RpcClient {
         target = COMPONENT,
         name = "rpc.client.block_subscription_with_retry",
         fields(
-            block.from = %block_from,
+            block.from = block_from,
         ),
         err,
     )]

--- a/bin/ntx-builder/src/coordinator.rs
+++ b/bin/ntx-builder/src/coordinator.rs
@@ -143,7 +143,7 @@ impl Coordinator {
     /// processing transactions and managing state for the network account.
     #[miden_instrument(
         name = "ntx.builder.spawn_actor",
-        fields(account.id = %account_id),
+        fields(account.id = account_id),
     )]
     pub fn spawn_actor(&mut self, account_id: AccountId) {
         if let Some(&count) = self.crash_counts.get(&account_id)

--- a/bin/ntx-builder/src/db/mod.rs
+++ b/bin/ntx-builder/src/db/mod.rs
@@ -275,7 +275,7 @@ impl NtxDbWriter {
 #[miden_instrument(
     target = COMPONENT,
     name = "ntx_builder.database.load",
-    fields(path=%database_filepath.display()),
+    fields(path = database_filepath),
     err,
 )]
 pub async fn load(database_filepath: PathBuf) -> anyhow::Result<NtxDbWriter> {
@@ -287,7 +287,7 @@ pub async fn load(database_filepath: PathBuf) -> anyhow::Result<NtxDbWriter> {
 #[miden_instrument(
     target = COMPONENT,
     name = "ntx_builder.database.load",
-    fields(path=%database_filepath.display()),
+    fields(path = database_filepath),
     err,
 )]
 pub async fn load_with_pool_size(
@@ -335,7 +335,7 @@ fn open_with_pool_size(
 #[miden_instrument(
     target = COMPONENT,
     name = "ntx_builder.database.bootstrap",
-    fields(path=%database_filepath.display()),
+    fields(path = database_filepath),
     err,
 )]
 pub async fn bootstrap(database_filepath: PathBuf, genesis: &SignedBlock) -> anyhow::Result<()> {

--- a/bin/ntx-builder/src/server/get_network_note_status.rs
+++ b/bin/ntx-builder/src/server/get_network_note_status.rs
@@ -24,7 +24,7 @@ impl grpc::server::ntx_builder_api::GetNetworkNoteStatus for NtxBuilderRpcServer
         target = COMPONENT,
         name = "get_network_note_status",
         fields (
-            note.id = %note_id,
+            note.id = note_id,
         ),
         err,
     )]

--- a/bin/remote-prover/src/server/proof_kind.rs
+++ b/bin/remote-prover/src/server/proof_kind.rs
@@ -1,4 +1,5 @@
 use miden_node_proto::generated::remote_prover as proto;
+use miden_node_utils::tracing::RecordAttribute;
 
 /// Specifies the type of proof supported by the remote prover.
 #[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
@@ -31,5 +32,13 @@ impl From<proto::ProofType> for ProofKind {
 impl std::fmt::Display for ProofKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+impl RecordAttribute for ProofKind {
+    const FIELD_NAMES: &'static [&'static str] = &["prover.kind", "request.kind"];
+
+    fn record_attribute(&self) -> impl tracing::Value + '_ {
+        self.as_str()
     }
 }

--- a/bin/remote-prover/src/server/prove.rs
+++ b/bin/remote-prover/src/server/prove.rs
@@ -23,9 +23,7 @@ impl grpc::server::remote_prover_api::Prove for ProverService {
         _metadata: &tonic::metadata::MetadataMap,
         _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
-        miden_span_record!(
-            request.kind = %proof_kind,
-        );
+        miden_span_record!(request.kind = proof_kind);
 
         // Reject unsupported proof types early so they don't clog the queue.
         if !self.is_supported(proof_kind) {

--- a/bin/validator/src/db/mod.rs
+++ b/bin/validator/src/db/mod.rs
@@ -252,7 +252,7 @@ async fn setup_with_pool_size(
 /// Returns an error if the database has already been bootstrapped.
 #[miden_instrument(
     target = COMPONENT,
-    fields(path = %database_filepath.display()),
+    fields(path = database_filepath),
     err,
 )]
 pub async fn bootstrap(

--- a/bin/validator/src/server/validator_service/block_subscription.rs
+++ b/bin/validator/src/server/validator_service/block_subscription.rs
@@ -56,7 +56,7 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
         _metadata: &tonic::metadata::MetadataMap,
         _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::ItemStream> {
-        miden_span_record!(block.from = request.block_from,);
+        miden_span_record!(block.from = request.block_from);
 
         let committed_tip = *self.committed_tip.borrow();
         if request.block_from > committed_tip.as_u32() {
@@ -74,7 +74,7 @@ impl grpc::server::validator_api::BlockSubscription for ValidatorService {
         let from = BlockNumber::from(request.block_from);
         // The tip should never move since we are in recovery mode and therefore there is no active
         // sequencer.
-        miden_span_record!(tip.number = %committed_tip);
+        miden_span_record!(tip.number = committed_tip);
 
         let (tx, rx) = tokio::sync::mpsc::channel(32);
 

--- a/bin/validator/src/server/validator_service/mod.rs
+++ b/bin/validator/src/server/validator_service/mod.rs
@@ -205,7 +205,7 @@ impl ValidatorService {
         proposed_block: ProposedBlock,
         chain_tip: BlockHeader,
     ) -> Result<(Signature, BlockHeader), ValidatorError> {
-        miden_span_record!(tip.number = chain_tip.block_num().as_u32(),);
+        miden_span_record!(tip.number = chain_tip.block_num());
 
         // Search for any proposed transactions that have not previously been validated.
         let proposed_tx_ids =
@@ -230,8 +230,8 @@ impl ValidatorService {
                 .map_err(ValidatorError::BlockBuildingFailed)?;
 
         miden_span_record!(
-            block.number = proposed_header.block_num().as_u32(),
-            block.commitment = %proposed_header.commitment(),
+            block.number = proposed_header.block_num(),
+            block.commitment = proposed_header.commitment()
         );
 
         // If the proposed block has the same block number as the current chain tip, this is a
@@ -308,7 +308,7 @@ impl ValidatorService {
         name = "sign_block",
         err,
         fields(
-            block.number = header.block_num().as_u32(),
+            block.number = header.block_num(),
         ),
     )]
     async fn sign_header(&self, header: &BlockHeader) -> Result<Signature, ValidatorError> {

--- a/bin/validator/src/server/validator_service/submit_proven_transaction.rs
+++ b/bin/validator/src/server/validator_service/submit_proven_transaction.rs
@@ -33,9 +33,7 @@ impl grpc::server::validator_api::SubmitProvenTransaction for ValidatorService {
     ) -> tonic::Result<Self::Output> {
         let Input { tx, sealed } = input;
         let tx_id = tx.id();
-        miden_span_record!(
-            transaction.id = %tx_id,
-        );
+        miden_span_record!(transaction.id = tx_id);
 
         let inputs = self.unseal_transaction_inputs(&sealed, tx_id).await?;
 

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use futures::TryFutureExt;
 use miden_node_proto::domain::batch::BatchInputs;
 use miden_node_store::state::State;
-use miden_node_utils::formatting::format_array;
 use miden_node_utils::shutdown::CancellationToken;
 use miden_node_utils::spawn::spawn_blocking_in_current_span;
 use miden_node_utils::tracing::{ErrorSpanExt, miden_instrument, miden_span_record};
@@ -147,17 +146,17 @@ impl BatchBuilder {
     fn build_batch(&mut self, mempool: SharedMempool, batch: SelectedBatch) {
         miden_span_record!(
             workers.active = self.active_jobs.len(),
-            workers.capacity = self.num_workers.get(),
+            workers.capacity = self.num_workers.get()
         );
 
         let telemetry = batch.telemetry();
         miden_span_record!(
-            batch.id = %telemetry.batch_id,
-            transactions.count = telemetry.transactions_count,
-            transactions.ids = %format_array(&telemetry.transaction_ids),
-            transactions.input_notes.count = telemetry.input_notes_count,
-            transactions.output_notes.count = telemetry.output_notes_count,
-            transactions.unauthenticated_notes.count = telemetry.unauthenticated_notes_count,
+            batch.id = telemetry.batch_id,
+            transaction.count = telemetry.transactions_count,
+            transaction.ids = telemetry.transaction_ids,
+            transaction.input_note.count = telemetry.input_notes_count,
+            transaction.output_note.count = telemetry.output_notes_count,
+            transaction.unauthenticated_note.count = telemetry.unauthenticated_notes_count
         );
         let job = BatchJob {
             state: self.state.clone(),
@@ -258,10 +257,10 @@ impl BatchJob {
             .inspect_ok(|proposed| {
                 let telemetry = proposed_batch_telemetry(proposed);
                 miden_span_record!(
-                    batch.expiration_height = %telemetry.expiration_height,
-                    batch.account_updates.count = telemetry.account_updates_count,
-                    batch.input_notes.count = telemetry.input_notes_count,
-                    batch.output_notes.count = telemetry.output_notes_count,
+                    batch.expiration_height = telemetry.expiration_height,
+                    batch.account_update.count = telemetry.account_updates_count,
+                    batch.input_note.count = telemetry.input_notes_count,
+                    batch.output_note.count = telemetry.output_notes_count
                 );
             })
             .and_then(|proposed| self.prove_batch(proposed))
@@ -347,7 +346,7 @@ impl BatchJob {
         &self,
         proposed_batch: ProposedBatch,
     ) -> Result<Arc<ProvenBatch>, BuildBatchError> {
-        miden_span_record!(prover.kind = self.batch_prover.kind(),);
+        miden_span_record!(prover.kind = self.batch_prover.kind());
 
         let proven_batch = match &self.batch_prover {
             BatchProver::Remote(prover) => prover

--- a/crates/block-producer/src/block_builder/mod.rs
+++ b/crates/block-producer/src/block_builder/mod.rs
@@ -125,11 +125,11 @@ impl BlockBuilder {
         let selected = Self::select_block(mempool)?;
         let telemetry = selected.telemetry();
         miden_span_record!(
-            block.number = %telemetry.block_number,
-            block.batches.count = telemetry.batches_count,
-            block.batch.ids = %format_array(telemetry.batch_ids),
-            block.transactions.ids = %format_array(&telemetry.transaction_ids),
-            block.transactions.count = telemetry.transactions_count,
+            block.number = telemetry.block_number,
+            block.batch.count = telemetry.batches_count,
+            block.batch.ids = telemetry.batch_ids,
+            block.transaction.ids = telemetry.transaction_ids,
+            block.transaction.count = telemetry.transactions_count
         );
         let block_num = selected.block_number;
 
@@ -143,18 +143,18 @@ impl BlockBuilder {
                 .inspect_ok(|inputs| {
                     let telemetry = inputs.telemetry();
                     miden_span_record!(
-                        block.updated_accounts.count = telemetry.updated_accounts_count,
-                        block.erased_note_proofs.count = telemetry.erased_note_proofs_count,
+                        block.updated_account.count = telemetry.updated_accounts_count,
+                        block.erased_note_proof.count = telemetry.erased_note_proofs_count
                     );
                 })
                 .and_then(|inputs| self.propose_block(inputs))
                 .inspect_ok(|proposed_block| {
                     let telemetry = proposed_block_telemetry(&proposed_block.proposed_block);
                     miden_span_record!(
-                        block.nullifiers.count = telemetry.nullifiers_count,
-                        block.output_notes.count = telemetry.output_notes_count,
-                        block.batches.output_notes.count = telemetry.batch_output_notes_count,
-                        block.erased_notes.count = telemetry.erased_notes_count,
+                        block.nullifier.count = telemetry.nullifiers_count,
+                        block.output_note.count = telemetry.output_notes_count,
+                        block.batch.output_note.count = telemetry.batch_output_notes_count,
+                        block.erased_note.count = telemetry.erased_notes_count
                     );
                 })
                 .and_then(|proposed_block| self.build_and_validate_block(proposed_block))
@@ -374,9 +374,9 @@ impl BlockBuilder {
         let num_transactions = signed_block.body().transactions().as_slice().len();
 
         miden_span_record!(
-            block.number = %header.block_num(),
-            block.commitment = %header.commitment(),
-            block.transactions.count = num_transactions,
+            block.number = header.block_num(),
+            block.commitment = header.commitment(),
+            block.transaction.count = num_transactions
         );
 
         if num_transactions > 0 {

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -259,14 +259,14 @@ impl Mempool {
             .map_err(MempoolSubmissionError::StateConflict)?;
         let telemetry = self.telemetry();
         miden_span_record!(
-            transaction.id = %tx.id(),
+            transaction.id = tx.id(),
             mempool.transactions.uncommitted = telemetry.uncommitted_transactions,
             mempool.transactions.unbatched = telemetry.unbatched_transactions,
             mempool.batches.proposed = telemetry.proposed_batches,
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         emit_transaction_added(&tx);
 
@@ -315,7 +315,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         for tx in txs {
             emit_transaction_added(tx);
@@ -344,7 +344,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         Some(batch)
     }
@@ -369,7 +369,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         Some(batch)
     }
@@ -430,7 +430,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         emit_transaction_evictions(&evicted, "failure_limit", "dependency_evicted");
     }
@@ -450,7 +450,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
     }
 
@@ -486,7 +486,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         block
     }
@@ -527,7 +527,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         emit_transaction_expirations(&expired, self.committed_chain_tip);
     }
@@ -577,7 +577,7 @@ impl Mempool {
             mempool.batches.proven = telemetry.proven_batches,
             mempool.accounts = telemetry.accounts,
             mempool.nullifiers = telemetry.nullifiers,
-            mempool.output_notes = telemetry.output_notes,
+            mempool.output_notes = telemetry.output_notes
         );
         emit_transaction_evictions(&evicted, "failure_limit", "dependency_evicted");
     }

--- a/crates/block-producer/src/proof_scheduler.rs
+++ b/crates/block-producer/src/proof_scheduler.rs
@@ -171,7 +171,7 @@ pub(crate) async fn run(
     target = COMPONENT,
     name = "prove_block",
     fields(
-        block.number=block_num.as_u32(),
+        block.number = block_num
     ),
     err,
 )]
@@ -241,7 +241,7 @@ async fn prove_block(
     target = COMPONENT,
     name = "prove_block.generate",
     fields(
-        block.number=block_num.as_u32(),
+        block.number = block_num
     ),
     err,
 )]

--- a/crates/block-producer/src/store/mod.rs
+++ b/crates/block-producer/src/store/mod.rs
@@ -173,7 +173,7 @@ impl Display for TransactionInputs {
     name = "store.state.get_tx_inputs",
     err,
     fields(
-        transaction.id = %proven_tx.id().to_hex(),
+        transaction.id = proven_tx.id()
     ),
 )]
 pub async fn get_tx_inputs(

--- a/crates/proto/src/domain/mod.rs
+++ b/crates/proto/src/domain/mod.rs
@@ -9,6 +9,17 @@ pub mod nullifier;
 pub mod proof_request;
 pub mod transaction;
 
+use miden_node_utils::tracing::RecordAttribute;
+use tracing::Value;
+
+impl RecordAttribute for crate::generated::rpc::FinalityLevel {
+    const FIELD_NAMES: &'static [&'static str] = &["finality_level"];
+
+    fn record_attribute(&self) -> impl Value + '_ {
+        self.as_str_name()
+    }
+}
+
 // UTILITIES
 // ================================================================================================
 

--- a/crates/rpc/src/server/api.rs
+++ b/crates/rpc/src/server/api.rs
@@ -193,7 +193,7 @@ impl RpcService {
         target = COMPONENT,
         name = "get_block_commitment",
         fields(
-            block.number = %block,
+            block.number = block,
         ),
     )]
     async fn get_block_commitment(&self, block: BlockNumber) -> Result<Word, Status> {

--- a/crates/rpc/src/server/api/get_account.rs
+++ b/crates/rpc/src/server/api/get_account.rs
@@ -40,14 +40,7 @@ impl proto::server::rpc_api::GetAccount for RpcService {
         _metadata: &tonic::metadata::MetadataMap,
         _extensions: &tonic::codegen::http::Extensions,
     ) -> tonic::Result<Self::Output> {
-        miden_span_record!(
-            account.id = %request.account_id,
-        );
-        if let Some(block) = request.block_num {
-            miden_span_record!(
-                block.number = %block,
-            );
-        }
+        miden_span_record!(account.id = request.account_id, block.number = request.block_num);
         tracing::trace!(target: LOG_TARGET, ?request);
         debug!(target: LOG_TARGET, "Getting account");
 

--- a/crates/rpc/src/server/api/get_block_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_by_number.rs
@@ -23,7 +23,7 @@ impl proto::server::rpc_api::GetBlockByNumber for RpcService {
         target = COMPONENT,
         name = "get_block_by_number",
         fields(
-            block.number = %request.block_num,
+            block.number = request.block_num,
         ),
         err,
     )]

--- a/crates/rpc/src/server/api/get_block_header_by_number.rs
+++ b/crates/rpc/src/server/api/get_block_header_by_number.rs
@@ -23,7 +23,7 @@ impl proto::server::rpc_api::GetBlockHeaderByNumber for RpcService {
         target = COMPONENT,
         name = "get_block_header_by_number",
         fields(
-            block.number = %request.block_num(),
+            block.number = request.block_num(),
         ),
         err,
     )]

--- a/crates/rpc/src/server/api/get_network_note_status.rs
+++ b/crates/rpc/src/server/api/get_network_note_status.rs
@@ -42,9 +42,7 @@ impl proto::server::rpc_api::GetNetworkNoteStatus for RpcService {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let note_id = request;
-        miden_span_record!(
-            note.id = %note_id,
-        );
+        miden_span_record!(note.id = note_id);
 
         debug!(target: LOG_TARGET, "Getting network note status");
 

--- a/crates/rpc/src/server/api/get_note_script_by_root.rs
+++ b/crates/rpc/src/server/api/get_note_script_by_root.rs
@@ -35,9 +35,7 @@ impl proto::server::rpc_api::GetNoteScriptByRoot for RpcService {
         tracing::trace!(target: LOG_TARGET, ?request);
 
         let root = read_root::<Status>(request.root, "NoteScriptRoot")?;
-        miden_span_record!(
-            script.root = %root,
-        );
+        miden_span_record!(script.root = root);
 
         debug!(target: LOG_TARGET, "Getting note script by root");
 

--- a/crates/rpc/src/server/api/submit_proven_tx.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx.rs
@@ -55,11 +55,11 @@ impl proto::server::rpc_api::SubmitProvenTx for RpcService {
         })?;
 
         miden_span_record!(
-            transaction.id = %tx.id(),
-            account.id = %tx.account_id(),
-            transaction.expires_at = %tx.expiration_block_num(),
-            transaction.reference_block.number = %tx.ref_block_num(),
-            transaction.reference_block.commitment = %tx.ref_block_commitment(),
+            transaction.id = tx.id(),
+            account.id = tx.account_id(),
+            transaction.expires_at = tx.expiration_block_num(),
+            transaction.reference_block.number = tx.ref_block_num(),
+            transaction.reference_block.commitment = tx.ref_block_commitment()
         );
 
         debug!(target: LOG_TARGET, "Submitting transaction");

--- a/crates/rpc/src/server/api/submit_proven_tx_batch.rs
+++ b/crates/rpc/src/server/api/submit_proven_tx_batch.rs
@@ -52,10 +52,10 @@ impl proto::server::rpc_api::SubmitProvenTxBatch for RpcService {
         })?;
 
         miden_span_record!(
-            batch.id = %proven_batch.id(),
-            batch.expires_at = %proven_batch.batch_expiration_block_num(),
-            batch.reference_block.number = %proven_batch.reference_block_num(),
-            batch.reference_block.commitment = %proven_batch.reference_block_commitment(),
+            batch.id = proven_batch.id(),
+            batch.expires_at = proven_batch.batch_expiration_block_num(),
+            batch.reference_block.number = proven_batch.reference_block_num(),
+            batch.reference_block.commitment = proven_batch.reference_block_commitment()
         );
 
         let proposed_batch = request

--- a/crates/rpc/src/server/api/subscription/block.rs
+++ b/crates/rpc/src/server/api/subscription/block.rs
@@ -29,7 +29,7 @@ impl proto::server::rpc_api::BlockSubscription for RpcService {
         target = COMPONENT,
         name = "block_subscription",
         fields(
-            block.from = %input,
+            block.from = input,
         ),
         err,
     )]

--- a/crates/rpc/src/server/api/subscription/proof.rs
+++ b/crates/rpc/src/server/api/subscription/proof.rs
@@ -30,7 +30,7 @@ impl proto::server::rpc_api::ProofSubscription for RpcService {
         target = COMPONENT,
         name = "proof_subscription",
         fields(
-            block.from = %input,
+            block.from = input,
         ),
         err,
     )]

--- a/crates/rpc/src/server/api/sync_account_storage_maps.rs
+++ b/crates/rpc/src/server/api/sync_account_storage_maps.rs
@@ -44,9 +44,9 @@ impl proto::server::rpc_api::SyncAccountStorageMaps for RpcService {
             read_block_range::<Status>(request.block_range, "SyncAccountStorageMapsRequest")?;
 
         miden_span_record!(
-            account.id = %account_id,
+            account.id = account_id,
             block_range.from = range.block_from,
-            block_range.to = range.block_to,
+            block_range.to = range.block_to
         );
 
         tracing::debug!(target: LOG_TARGET, "Syncing account storage maps");

--- a/crates/rpc/src/server/api/sync_account_vault.rs
+++ b/crates/rpc/src/server/api/sync_account_vault.rs
@@ -44,9 +44,9 @@ impl proto::server::rpc_api::SyncAccountVault for RpcService {
         let range = read_block_range::<Status>(request.block_range, "SyncAccountVaultRequest")?;
 
         miden_span_record!(
-            account.id = %account_id,
+            account.id = account_id,
             block_range.from = range.block_from,
-            block_range.to = range.block_to,
+            block_range.to = range.block_to
         );
 
         tracing::debug!(target: LOG_TARGET, "Syncing account vault");

--- a/crates/rpc/src/server/api/sync_chain_mmr.rs
+++ b/crates/rpc/src/server/api/sync_chain_mmr.rs
@@ -25,8 +25,8 @@ impl proto::server::rpc_api::SyncChainMmr for RpcService {
         target = COMPONENT,
         name = "sync_chain_mmr",
         fields(
-            current_client_block_height = %request.current_client_block_height,
-            finality_level = %request.finality_level().as_str_name(),
+            current_client_block_height = request.current_client_block_height,
+            finality_level = request.finality_level()
         ),
         err,
     )]

--- a/crates/rpc/src/server/api/sync_notes.rs
+++ b/crates/rpc/src/server/api/sync_notes.rs
@@ -37,7 +37,7 @@ impl proto::server::rpc_api::SyncNotes for RpcService {
 
         let range = read_block_range::<Status>(request.block_range, "SyncNotesRequest")?;
 
-        miden_span_record!(block_range.from = range.block_from, block_range.to = range.block_to,);
+        miden_span_record!(block_range.from = range.block_from, block_range.to = range.block_to);
 
         debug!(target: LOG_TARGET, "Syncing notes");
 

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -42,7 +42,7 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
 
         let range = read_block_range::<Status>(request.block_range, "SyncNullifiersRequest")?;
 
-        miden_span_record!(block_range.from = range.block_from, block_range.to = range.block_to,);
+        miden_span_record!(block_range.from = range.block_from, block_range.to = range.block_to);
 
         debug!(target: LOG_TARGET, "Syncing nullifiers");
 

--- a/crates/rpc/src/server/api/sync_transactions.rs
+++ b/crates/rpc/src/server/api/sync_transactions.rs
@@ -1,7 +1,6 @@
 use miden_node_proto::decode::{read_account_ids, read_block_range};
 use miden_node_proto::generated as proto;
 use miden_node_store::{NoteSyncRecord, TransactionRecord};
-use miden_node_utils::formatting::format_array;
 use miden_node_utils::limiter::QueryParamAccountIdLimit;
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
 use tonic::Status;
@@ -50,8 +49,8 @@ impl proto::server::rpc_api::SyncTransactions for RpcService {
         miden_span_record!(
             block_range.from = range.block_from,
             block_range.to = range.block_to,
-            account.ids = %format_array(&account_ids),
-            account.ids.count = n_accounts,
+            account.ids = account_ids,
+            account.count = n_accounts
         );
 
         debug!(target: LOG_TARGET, "Syncing transactions");

--- a/crates/store/src/blocks.rs
+++ b/crates/store/src/blocks.rs
@@ -38,7 +38,7 @@ impl BlockStore {
         name = "store.block_store.bootstrap",
         err,
         fields(
-            path = %store_dir.display(),
+            path = store_dir,
         ),
     )]
     pub fn bootstrap(store_dir: PathBuf, genesis_block: &GenesisBlock) -> std::io::Result<Self> {
@@ -90,7 +90,7 @@ impl BlockStore {
         name = "store.block_store.save_block",
         err,
         fields(
-            block.number = %block_num,
+            block.number = block_num,
             block.size = data.len(),
         ),
     )]
@@ -120,8 +120,8 @@ impl BlockStore {
         name = "store.block_store.save_proof",
         err,
         fields(
-            block.number = block_num.as_u32(),
-            proof_size = data.len(),
+            block.number = block_num,
+            proof_size = data.len()
         ),
     )]
     async fn save_proof(&self, block_num: BlockNumber, data: &[u8]) -> std::io::Result<()> {
@@ -149,8 +149,8 @@ impl BlockStore {
         name = "store.block_store.save_proving_inputs",
         err,
         fields(
-            block.number = block_num.as_u32(),
-            inputs_size = data.len(),
+            block.number = block_num,
+            inputs_size = data.len()
         ),
     )]
     pub async fn save_proving_inputs(

--- a/crates/store/src/db/mod.rs
+++ b/crates/store/src/db/mod.rs
@@ -209,7 +209,7 @@ impl Db {
     #[miden_instrument(
         target = COMPONENT,
         name = "store.database.bootstrap",
-        fields(path=%database_filepath.display())
+        fields(path = database_filepath),
         err,
     )]
     pub fn bootstrap(database_filepath: PathBuf, genesis: GenesisBlock) -> anyhow::Result<()> {
@@ -300,7 +300,7 @@ impl Db {
         target = COMPONENT,
         fields(
             prefix_len,
-            prefixes = nullifier_prefixes.len(),
+            prefix.count = nullifier_prefixes.len(),
         ),
         err,
     )]

--- a/crates/store/src/state/disk_monitor.rs
+++ b/crates/store/src/state/disk_monitor.rs
@@ -37,14 +37,14 @@ async fn measure_disk_space_usage(data_dir: PathBuf) -> Result<(), tokio::task::
     miden_span_record!(
         db.sqlite.size = usage.sqlite_db,
         db.sqlite.wal.size = usage.sqlite_wal,
-        db.block_store.size = usage.block_store,
+        db.block_store.size = usage.block_store
     );
     #[cfg(feature = "rocksdb")]
     {
         miden_span_record!(
             db.account_tree.size = usage.account_tree,
             db.nullifier_tree.size = usage.nullifier_tree,
-            db.account_state_forest.size = usage.account_state_forest,
+            db.account_state_forest.size = usage.account_state_forest
         );
     }
 

--- a/crates/store/src/state/loader.rs
+++ b/crates/store/src/state/loader.rs
@@ -412,7 +412,7 @@ impl AccountForestLoader for ForestInMemoryBackend {
     #[miden_instrument(
         target = COMPONENT,
         fields(
-            block.number = %block_num,
+            block.number = block_num,
         ),
     )]
     async fn load_account_state_forest(
@@ -465,7 +465,7 @@ impl AccountForestLoader for ForestPersistentBackend {
     #[miden_instrument(
         target = COMPONENT,
         fields(
-            block.number = %block_num,
+            block.number = block_num,
         ),
     )]
     async fn load_account_state_forest(
@@ -549,7 +549,7 @@ fn verify_chain_mmr_consistency(
 #[miden_instrument(
     target = COMPONENT,
     fields(
-        block.number = %block_num,
+        block.number = block_num,
     ),
 )]
 pub async fn rebuild_account_state_forest(

--- a/crates/store/src/state/view/transaction_inputs.rs
+++ b/crates/store/src/state/view/transaction_inputs.rs
@@ -3,7 +3,6 @@
 use std::collections::HashSet;
 use std::ops::ControlFlow;
 
-use miden_node_utils::formatting::format_array;
 use miden_node_utils::tracing::miden_instrument;
 use miden_protocol::Word;
 use miden_protocol::account::AccountId;
@@ -28,8 +27,8 @@ impl StateView {
     #[miden_instrument(
         target = COMPONENT,
         fields(
-            account.id=%account_id,
-            nullifiers = %format_array(nullifiers),
+            account.id = account_id,
+            note.nullifiers = nullifiers,
         ),
     )]
     pub async fn get_transaction_inputs(

--- a/crates/store/src/state/writer/apply_proof.rs
+++ b/crates/store/src/state/writer/apply_proof.rs
@@ -17,7 +17,7 @@ impl ProofWriter {
         target = COMPONENT,
         err,
         fields(
-            block.number = block_num.as_u32(),
+            block.number = block_num
         ),
     )]
     pub async fn apply_proof(

--- a/crates/store/src/state/writer/worker.rs
+++ b/crates/store/src/state/writer/worker.rs
@@ -190,9 +190,9 @@ impl WriteWorker {
         let num_transactions = body.transactions().as_slice().len();
 
         miden_span_record!(
-            block.number = %block_num,
-            block.commitment = %block_commitment,
-            block.transactions.count = num_transactions,
+            block.number = block_num,
+            block.commitment = block_commitment,
+            block.transaction.count = num_transactions
         );
 
         self.validate_block_header(header).await?;

--- a/crates/tracing-macro/src/lib.rs
+++ b/crates/tracing-macro/src/lib.rs
@@ -21,101 +21,12 @@ use syn::{
     parse_quote,
 };
 
-const ALLOWED_FIELD_NAMES: &[&str] = &[
-    "account.id",
-    "account.id.network_prefix",
-    "account.ids",
-    "account.ids.count",
-    "account.updated",
-    "batch.id",
-    "batch.account_updates.count",
-    "batch.expires_at",
-    "batch.expiration_height",
-    "batch.input_notes.count",
-    "batch.output_notes.count",
-    "batch.reference_block.commitment",
-    "batch.reference_block.number",
-    "block.batch.ids",
-    "block.batches.count",
-    "block.batches.output_notes.count",
-    "block.commitment",
-    "block.commitments.account",
-    "block.commitments.chain",
-    "block.commitments.kernel",
-    "block.commitments.note",
-    "block.commitments.nullifier",
-    "block.commitments.transaction",
-    "block.erased_note_proofs.count",
-    "block.erased_notes.count",
-    "block.from",
-    "block.nullifiers.count",
-    "block.number",
-    "block.output_notes.count",
-    "block.prev_block_commitment",
-    "block.protocol.version",
-    "block.size",
-    "block.sub_commitment",
-    "block.timestamp",
-    "block.transactions.ids",
-    "block.transactions.count",
-    "block.updated_accounts.count",
-    "block_range.from",
-    "block_range.to",
-    "current_client_block_height",
-    "cutoff_block",
-    "db.account_state_forest.size",
-    "db.account_tree.size",
-    "db.block_store.size",
-    "db.nullifier_tree.size",
-    "db.sqlite.size",
-    "db.sqlite.wal.size",
-    "dice_roll",
-    "failure_rate",
-    "finality_level",
-    "inputs_size",
-    "mempool.accounts",
-    "mempool.batches.proposed",
-    "mempool.batches.proven",
-    "mempool.nullifiers",
-    "mempool.output_notes",
-    "mempool.transactions.unbatched",
-    "mempool.transactions.uncommitted",
-    "note.id",
-    "notes.count",
-    "nullifiers",
-    "path",
-    "port",
-    "prefix_len",
-    "prefixes",
-    "proof_size",
-    "prover",
-    "prover.kind",
-    "reference_block.number",
-    "request.kind",
-    "script.root",
-    "snapshot.block_num",
-    "snapshot.lifetime_ms",
-    "snapshots.live",
-    "transaction.id",
-    "transaction.expires_at",
-    "transaction.input_notes.count",
-    "transaction.output_notes.count",
-    "transaction.reference_block.commitment",
-    "transaction.reference_block.number",
-    "tip.number",
-    "transactions.count",
-    "transactions.ids",
-    "transactions.input_notes.count",
-    "transactions.output_notes.count",
-    "transactions.unauthenticated_notes.count",
-    "workers.active",
-    "workers.capacity",
-    "workers.count",
-];
-
-/// Instruments a function using registered tracing fields.
+/// Instruments a function using canonical tracing attributes.
 ///
-/// Append `#[nonstandard]` to a field value to permit a name outside the field registry.
+/// Field values must implement `RecordAttribute`, and their names must be registered for the value
+/// type. A field whose name ends in `.count` accepts any `usize` without registration. Append
+/// `#[nonstandard]` to any other field value to permit an unregistered name while retaining its
+/// canonical encoding.
 #[proc_macro_attribute]
 pub fn miden_instrument(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = match rewrite_explicit_fields(TokenStream2::from(attr)) {
@@ -228,6 +139,38 @@ fn rewrite_explicit_fields(attr: TokenStream2) -> Result<TokenStream2> {
     Ok(quote! { #(#args),* })
 }
 
+fn reject_formatter(input: ParseStream<'_>) -> Result<()> {
+    let formatter = if input.peek(Token![%]) {
+        Some(input.parse::<Token![%]>()?.span)
+    } else if input.peek(Token![?]) {
+        Some(input.parse::<Token![?]>()?.span)
+    } else {
+        None
+    };
+
+    if let Some(span) = formatter {
+        Err(syn::Error::new(
+            span,
+            "tracing format specifiers are not supported; implement `RecordAttribute` to define \
+             the type's canonical encoding",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+impl RecordField {
+    fn instrument_tokens(&self) -> TokenStream2 {
+        let path = &self.path;
+        if let Some(value) = &self.value {
+            let value = value.value_tokens(&self.path.name(), self.path.is_count());
+            quote! { #path = #value }
+        } else {
+            quote! { #path }
+        }
+    }
+}
+
 fn split_top_level_args(tokens: TokenStream2) -> Vec<TokenStream2> {
     let mut args = Vec::new();
     let mut current = TokenStream2::new();
@@ -275,9 +218,12 @@ fn ends_with_comma(tokens: &TokenStream2) -> bool {
     )
 }
 
-/// Records fields on the current `miden_instrument` span.
+/// Records canonical attributes on the current `miden_instrument` span.
 ///
-/// Append `#[nonstandard]` to a field value to permit a name outside the field registry.
+/// Field values must implement `RecordAttribute`, and their names must be registered for the value
+/// type. A field whose name ends in `.count` accepts any `usize` without registration. Append
+/// `#[nonstandard]` to any other field value to permit an unregistered name while retaining its
+/// canonical encoding.
 #[proc_macro]
 pub fn miden_span_record(input: TokenStream) -> TokenStream {
     let records = parse_macro_input!(input as RecordFields);
@@ -286,7 +232,7 @@ pub fn miden_span_record(input: TokenStream) -> TokenStream {
         let value = field
             .value
             .expect("record fields are parsed with required values")
-            .value_tokens();
+            .value_tokens(&name, field.path.is_count());
 
         quote! {
             ::tracing::Span::current().record(#name, #value);
@@ -298,22 +244,6 @@ pub fn miden_span_record(input: TokenStream) -> TokenStream {
         #(#records)*
     }
     .into()
-}
-
-fn validate_field_name(path: &FieldPath) -> Result<()> {
-    let name = path.name();
-
-    if ALLOWED_FIELD_NAMES.contains(&name.as_str()) {
-        Ok(())
-    } else {
-        Err(syn::Error::new_spanned(
-            path,
-            format!(
-                "unsupported tracing field `{name}`; use one of: {}",
-                ALLOWED_FIELD_NAMES.join(", "),
-            ),
-        ))
-    }
 }
 
 fn collect_recorded_fields(function: &ItemFn) -> Vec<FieldPath> {
@@ -364,44 +294,23 @@ impl<const VALUE_REQUIRED: bool> Parse for Fields<VALUE_REQUIRED> {
 }
 
 struct RecordField {
-    shorthand_formatter: Option<Formatter>,
     path: FieldPath,
     value: Option<RecordValue>,
 }
 
 impl RecordField {
     fn parse(input: ParseStream<'_>, value_required: bool) -> Result<Self> {
-        let shorthand_formatter = if value_required {
-            None
-        } else {
-            Formatter::parse_optional(input)?
-        };
+        reject_formatter(input)?;
         let path = input.parse()?;
-        let value: Option<RecordValue> =
-            if value_required || shorthand_formatter.is_none() && input.peek(Token![=]) {
-                input.parse::<Token![=]>()?;
-                Some(input.parse()?)
-            } else {
-                None
-            };
-        if value.as_ref().is_none_or(|value| !value.nonstandard) {
-            validate_field_name(&path)?;
-        }
-
-        Ok(Self { shorthand_formatter, path, value })
-    }
-
-    fn instrument_tokens(&self) -> TokenStream2 {
-        let path = &self.path;
-        if let Some(value) = &self.value {
-            let value = value.instrument_tokens();
-            quote! { #path = #value }
-        } else if let Some(formatter) = self.shorthand_formatter {
-            let formatter = formatter.tokens();
-            quote! { #formatter #path }
+        let value = if value_required || input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            reject_formatter(input)?;
+            Some(input.parse()?)
         } else {
-            quote! { #path }
-        }
+            None
+        };
+
+        Ok(Self { path, value })
     }
 }
 
@@ -417,6 +326,10 @@ impl FieldPath {
             .map(ToString::to_string)
             .collect::<Vec<_>>()
             .join(".")
+    }
+
+    fn is_count(&self) -> bool {
+        self.rest.last().is_some_and(|(_, ident)| ident == "count")
     }
 }
 
@@ -444,32 +357,60 @@ impl ToTokens for FieldPath {
 }
 
 struct RecordValue {
-    formatter: Formatter,
     expr: Expr,
     nonstandard: bool,
 }
 
 impl RecordValue {
-    fn value_tokens(&self) -> TokenStream2 {
+    fn value_tokens(&self, field_name: &str, is_count: bool) -> TokenStream2 {
         let expr = &self.expr;
+        let assert_field_name = (!self.nonstandard && !is_count).then(|| {
+            quote! {
+                fn __miden_assert_field_name<T>(_: &T)
+                where
+                    T: ::miden_node_utils::tracing::RecordAttribute + ?Sized,
+                {
+                    const {
+                        assert!(
+                            ::miden_node_utils::tracing::field_name_allowed(
+                                T::FIELD_NAMES,
+                                #field_name,
+                                T::PLURALIZE_FIELD_NAMES,
+                            ),
+                            concat!(
+                                "tracing field `",
+                                #field_name,
+                                "` is not allowed for this attribute type",
+                            ),
+                        );
+                    }
+                }
 
-        match self.formatter {
-            Formatter::Display => quote! { &::tracing::field::display(#expr) },
-            Formatter::Debug => quote! { &::tracing::field::debug(#expr) },
-            Formatter::Plain => quote! { &#expr },
+                __miden_assert_field_name(value);
+            }
+        });
+        let assert_count = is_count.then(|| {
+            quote! {
+                fn __miden_assert_count(_: &usize) {}
+
+                __miden_assert_count(value);
+            }
+        });
+
+        quote! {
+            match &(#expr) {
+                value => {
+                    #assert_field_name
+                    #assert_count
+                    ::miden_node_utils::tracing::record_attribute(value)
+                }
+            }
         }
-    }
-
-    fn instrument_tokens(&self) -> TokenStream2 {
-        let formatter = self.formatter.tokens();
-        let expr = &self.expr;
-        quote! { #formatter #expr }
     }
 }
 
 impl Parse for RecordValue {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let formatter = Formatter::parse_optional(input)?.unwrap_or(Formatter::Plain);
         let expr = input.parse()?;
         let attributes = input.call(Attribute::parse_outer)?;
         let nonstandard = match attributes.as_slice() {
@@ -485,35 +426,6 @@ impl Parse for RecordValue {
             },
         };
 
-        Ok(Self { formatter, expr, nonstandard })
-    }
-}
-
-#[derive(Clone, Copy)]
-enum Formatter {
-    Display,
-    Debug,
-    Plain,
-}
-
-impl Formatter {
-    fn tokens(self) -> TokenStream2 {
-        match self {
-            Self::Display => quote! { % },
-            Self::Debug => quote! { ? },
-            Self::Plain => TokenStream2::new(),
-        }
-    }
-
-    fn parse_optional(input: ParseStream<'_>) -> Result<Option<Self>> {
-        if input.peek(Token![%]) {
-            input.parse::<Token![%]>()?;
-            Ok(Some(Self::Display))
-        } else if input.peek(Token![?]) {
-            input.parse::<Token![?]>()?;
-            Ok(Some(Self::Debug))
-        } else {
-            Ok(None)
-        }
+        Ok(Self { expr, nonstandard })
     }
 }

--- a/crates/utils/tests/tracing_macros.rs
+++ b/crates/utils/tests/tracing_macros.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+use miden_protocol::block::BlockNumber;
 use tracing::Subscriber;
 use tracing::field::{Field, Visit};
 use tracing_subscriber::Layer;
@@ -45,7 +46,41 @@ struct FieldVisitor(Arc<Mutex<BTreeMap<String, String>>>);
 
 impl Visit for FieldVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        self.0.lock().unwrap().insert(field.name().to_owned(), format!("{value:?}"));
+        self.record(field, format!("{value:?}"));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, value.to_owned());
+    }
+}
+
+impl FieldVisitor {
+    fn record(&self, field: &Field, value: String) {
+        self.0.lock().unwrap().insert(field.name().to_owned(), value);
     }
 }
 
@@ -53,10 +88,13 @@ impl Visit for FieldVisitor {
 fn records_inferred_fields() {
     let parsed_value = 42;
     let parsed_text = "parsed";
+    let omitted = None::<u32>;
 
     miden_span_record!(
         block.number = parsed_value,
-        transaction.id = %parsed_text,
+        service.name = parsed_text,
+        batch.expires_at = Some(3_u32),
+        batch.expiration_height = omitted
     );
 }
 
@@ -64,8 +102,8 @@ fn records_inferred_fields() {
     target = "miden-node-utils-test",
     name = "records_explicit_fields",
     fields(
-        account.id = tracing::field::Empty,
-        account.updated = tracing::field::Empty,
+        account.id,
+        account.updated,
     ),
 )]
 fn records_explicit_fields() {
@@ -77,49 +115,54 @@ fn records_explicit_fields() {
     target = "miden-node-utils-test",
     name = "records_explicit_argument_field",
     fields(
-        account.id = %account_id,
+        service.name = service_name,
     ),
 )]
-fn records_explicit_argument_field(account_id: &str) {}
+fn records_explicit_argument_field(service_name: &str) {}
 
 #[miden_instrument(
     target = "miden-node-utils-test",
     name = "records_explicit_and_inferred_fields",
     fields(
-        account.id = tracing::field::Empty,
+        account.id,
     ),
 )]
 fn records_explicit_and_inferred_fields() {
     let block_number = 9;
 
     tracing::Span::current().record("account.id", tracing::field::display("mixed-account"));
-    miden_span_record!(
-        block.number = block_number,
-        transaction.id = %"mixed-tx",
-    );
+    miden_span_record!(block.number = block_number, service.name = "mixed-service");
 }
 
 #[miden_instrument(target = "miden-node-utils-test", name = "records_fields_from_multiple_calls")]
 fn records_fields_from_multiple_calls() {
     let block_number = 14;
-    let tx_id = "multi-call-tx";
+    let service_name = "multi-call-service";
 
-    miden_span_record!(block.number = block_number,);
-    miden_span_record!(
-        transaction.id = %tx_id,
-    );
+    miden_span_record!(block.number = block_number);
+    miden_span_record!(service.name = service_name);
+}
+
+#[miden_instrument(target = "miden-node-utils-test", name = "records_canonical_types")]
+fn records_canonical_types() {
+    miden_span_record!(block.number = BlockNumber::from(42));
+}
+
+#[miden_instrument(target = "miden-node-utils-test", name = "records_count_field")]
+fn records_count_field() {
+    miden_span_record!(unregistered.item.count = 3_usize);
 }
 
 #[miden_instrument(
     target = "miden-node-utils-test",
     name = "records_nonstandard_explicit_field",
-    fields(custom.explicit = %value #[nonstandard]),
+    fields(custom.explicit = value #[nonstandard]),
 )]
 fn records_nonstandard_explicit_field(value: &str) {}
 
 #[miden_instrument(target = "miden-node-utils-test", name = "records_nonstandard_delayed_field")]
 fn records_nonstandard_delayed_field() {
-    miden_span_record!(custom.delayed = %"delayed" #[nonstandard]);
+    miden_span_record!(custom.delayed = "delayed" #[nonstandard]);
 }
 
 #[test]
@@ -130,7 +173,9 @@ fn inferred_fields_can_be_recorded_after_span_creation() {
     tracing::subscriber::with_default(subscriber, records_inferred_fields);
 
     assert_eq!(recorded.get("block.number").as_deref(), Some("42"));
-    assert_eq!(recorded.get("transaction.id").as_deref(), Some("parsed"));
+    assert_eq!(recorded.get("service.name").as_deref(), Some("parsed"));
+    assert_eq!(recorded.get("batch.expires_at").as_deref(), Some("3"));
+    assert_eq!(recorded.get("batch.expiration_height"), None);
 }
 
 #[test]
@@ -150,10 +195,10 @@ fn explicit_argument_fields_are_recorded_at_span_creation() {
     let subscriber = tracing_subscriber::registry().with(recorded.clone());
 
     tracing::subscriber::with_default(subscriber, || {
-        records_explicit_argument_field("argument-account");
+        records_explicit_argument_field("argument-service");
     });
 
-    assert_eq!(recorded.get("account.id").as_deref(), Some("argument-account"));
+    assert_eq!(recorded.get("service.name").as_deref(), Some("argument-service"));
 }
 
 #[test]
@@ -165,7 +210,7 @@ fn explicit_and_inferred_fields_can_be_recorded_after_span_creation() {
 
     assert_eq!(recorded.get("account.id").as_deref(), Some("mixed-account"));
     assert_eq!(recorded.get("block.number").as_deref(), Some("9"));
-    assert_eq!(recorded.get("transaction.id").as_deref(), Some("mixed-tx"));
+    assert_eq!(recorded.get("service.name").as_deref(), Some("mixed-service"));
 }
 
 #[test]
@@ -176,11 +221,31 @@ fn multiple_span_record_macros_can_record_fields_after_span_creation() {
     tracing::subscriber::with_default(subscriber, records_fields_from_multiple_calls);
 
     assert_eq!(recorded.get("block.number").as_deref(), Some("14"));
-    assert_eq!(recorded.get("transaction.id").as_deref(), Some("multi-call-tx"));
+    assert_eq!(recorded.get("service.name").as_deref(), Some("multi-call-service"));
 }
 
 #[test]
-fn nonstandard_fields_bypass_the_name_registry() {
+fn domain_types_use_their_canonical_attribute_type() {
+    let recorded = RecordedFields::default();
+    let subscriber = tracing_subscriber::registry().with(recorded.clone());
+
+    tracing::subscriber::with_default(subscriber, records_canonical_types);
+
+    assert_eq!(recorded.get("block.number").as_deref(), Some("42"));
+}
+
+#[test]
+fn count_fields_do_not_require_registration() {
+    let recorded = RecordedFields::default();
+    let subscriber = tracing_subscriber::registry().with(recorded.clone());
+
+    tracing::subscriber::with_default(subscriber, records_count_field);
+
+    assert_eq!(recorded.get("unregistered.item.count").as_deref(), Some("3"));
+}
+
+#[test]
+fn nonstandard_fields_retain_canonical_attribute_encoding() {
     let recorded = RecordedFields::default();
     let subscriber = tracing_subscriber::registry().with(recorded.clone());
 
@@ -199,8 +264,17 @@ fn ui_tests() {
     tests.pass("tests/ui/tracing_macros/pass.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_field_name.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_field_annotation.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_field_type.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_count_type.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_scalar_plural.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_collection_singular.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_instrument_field_name.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip.rs");
     tests.compile_fail("tests/ui/tracing_macros/invalid_skip_all.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_record_attribute.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_nonstandard_attribute.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_instrument_attribute.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_record_formatter.rs");
+    tests.compile_fail("tests/ui/tracing_macros/invalid_instrument_formatter.rs");
     tests.compile_fail("tests/ui/tracing_macros/outside_miden_instrument.rs");
 }

--- a/crates/utils/tests/ui/tracing_macros/invalid_collection_singular.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_collection_singular.rs
@@ -1,0 +1,28 @@
+use std::fmt::{self, Display};
+
+use miden_node_utils::tracing::{RecordAttribute, miden_instrument, miden_span_record};
+
+struct AccountId;
+
+impl RecordAttribute for AccountId {
+    const FIELD_NAMES: &'static [&'static str] = &["account.id"];
+
+    fn record_attribute(&self) -> impl tracing::Value + '_ {
+        "account-id"
+    }
+}
+
+impl Display for AccountId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("account-id")
+    }
+}
+
+#[miden_instrument]
+fn records_collection_with_singular_field() {
+    miden_span_record!(account.id = vec![AccountId]);
+}
+
+fn main() {
+    records_collection_with_singular_field();
+}

--- a/crates/utils/tests/ui/tracing_macros/invalid_collection_singular.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_collection_singular.stderr
@@ -1,0 +1,21 @@
+error[E0080]: evaluation panicked: tracing field `account.id` is not allowed for this attribute type
+  --> tests/ui/tracing_macros/invalid_collection_singular.rs:23:5
+   |
+23 |     miden_span_record!(account.id = vec![AccountId]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `records_collection_with_singular_field::__miden_assert_field_name::<std::vec::Vec<AccountId>>::{constant#0}` failed here
+
+note: erroneous constant encountered
+  --> tests/ui/tracing_macros/invalid_collection_singular.rs:23:5
+   |
+23 |     miden_span_record!(account.id = vec![AccountId]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn __miden_assert_field_name::<Vec<AccountId>>`
+  --> tests/ui/tracing_macros/invalid_collection_singular.rs:23:5
+   |
+23 |     miden_span_record!(account.id = vec![AccountId]);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_count_type.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_count_type.rs
@@ -1,0 +1,10 @@
+use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+
+#[miden_instrument]
+fn records_count_with_wrong_type() {
+    miden_span_record!(note.count = 1_u32);
+}
+
+fn main() {
+    records_count_with_wrong_type();
+}

--- a/crates/utils/tests/ui/tracing_macros/invalid_count_type.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_count_type.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+ --> tests/ui/tracing_macros/invalid_count_type.rs:5:5
+  |
+5 |     miden_span_record!(note.count = 1_u32);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |     |
+  |     expected `&usize`, found `&u32`
+  |     arguments to this function are incorrect
+  |
+  = note: expected reference `&usize`
+             found reference `&u32`
+note: function defined here
+ --> tests/ui/tracing_macros/invalid_count_type.rs:5:5
+  |
+5 |     miden_span_record!(note.count = 1_u32);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_field_name.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_field_name.rs
@@ -5,7 +5,7 @@ fn records_invalid_field_name() {
     let tx_id = "0x1234";
 
     miden_span_record!(
-        tx_id = %tx_id,
+        tx_id = tx_id
     );
 }
 

--- a/crates/utils/tests/ui/tracing_macros/invalid_field_name.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_field_name.stderr
@@ -1,5 +1,27 @@
-error: unsupported tracing field `tx_id`; use one of: account.id, account.id.network_prefix, account.ids, account.ids.count, account.updated, batch.id, batch.account_updates.count, batch.expires_at, batch.expiration_height, batch.input_notes.count, batch.output_notes.count, batch.reference_block.commitment, batch.reference_block.number, block.batch.ids, block.batches.count, block.batches.output_notes.count, block.commitment, block.commitments.account, block.commitments.chain, block.commitments.kernel, block.commitments.note, block.commitments.nullifier, block.commitments.transaction, block.erased_note_proofs.count, block.erased_notes.count, block.from, block.nullifiers.count, block.number, block.output_notes.count, block.prev_block_commitment, block.protocol.version, block.size, block.sub_commitment, block.timestamp, block.transactions.ids, block.transactions.count, block.updated_accounts.count, block_range.from, block_range.to, current_client_block_height, cutoff_block, db.account_state_forest.size, db.account_tree.size, db.block_store.size, db.nullifier_tree.size, db.sqlite.size, db.sqlite.wal.size, dice_roll, failure_rate, finality_level, inputs_size, mempool.accounts, mempool.batches.proposed, mempool.batches.proven, mempool.nullifiers, mempool.output_notes, mempool.transactions.unbatched, mempool.transactions.uncommitted, note.id, notes.count, nullifiers, path, port, prefix_len, prefixes, proof_size, prover, prover.kind, reference_block.number, request.kind, script.root, snapshot.block_num, snapshot.lifetime_ms, snapshots.live, transaction.id, transaction.expires_at, transaction.input_notes.count, transaction.output_notes.count, transaction.reference_block.commitment, transaction.reference_block.number, tip.number, transactions.count, transactions.ids, transactions.input_notes.count, transactions.output_notes.count, transactions.unauthenticated_notes.count, workers.active, workers.capacity, workers.count
- --> tests/ui/tracing_macros/invalid_field_name.rs:8:9
+error[E0080]: evaluation panicked: tracing field `tx_id` is not allowed for this attribute type
+ --> tests/ui/tracing_macros/invalid_field_name.rs:7:5
   |
-8 |         tx_id = %tx_id,
-  |         ^^^^^
+7 | /     miden_span_record!(
+8 | |         tx_id = tx_id
+9 | |     );
+  | |_____^ evaluation of `records_invalid_field_name::__miden_assert_field_name::<&str>::{constant#0}` failed here
+
+note: erroneous constant encountered
+ --> tests/ui/tracing_macros/invalid_field_name.rs:7:5
+  |
+7 | /     miden_span_record!(
+8 | |         tx_id = tx_id
+9 | |     );
+  | |_____^
+  |
+  = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn __miden_assert_field_name::<&str>`
+ --> tests/ui/tracing_macros/invalid_field_name.rs:7:5
+  |
+7 | /     miden_span_record!(
+8 | |         tx_id = tx_id
+9 | |     );
+  | |_____^
+  |
+  = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_field_type.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_field_type.rs
@@ -1,0 +1,10 @@
+use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+
+#[miden_instrument]
+fn records_field_with_wrong_type() {
+    miden_span_record!(account.id = 42_u32);
+}
+
+fn main() {
+    records_field_with_wrong_type();
+}

--- a/crates/utils/tests/ui/tracing_macros/invalid_field_type.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_field_type.stderr
@@ -1,0 +1,21 @@
+error[E0080]: evaluation panicked: tracing field `account.id` is not allowed for this attribute type
+ --> tests/ui/tracing_macros/invalid_field_type.rs:5:5
+  |
+5 |     miden_span_record!(account.id = 42_u32);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `records_field_with_wrong_type::__miden_assert_field_name::<u32>::{constant#0}` failed here
+
+note: erroneous constant encountered
+ --> tests/ui/tracing_macros/invalid_field_type.rs:5:5
+  |
+5 |     miden_span_record!(account.id = 42_u32);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn __miden_assert_field_name::<u32>`
+ --> tests/ui/tracing_macros/invalid_field_type.rs:5:5
+  |
+5 |     miden_span_record!(account.id = 42_u32);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_instrument_attribute.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_instrument_attribute.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::miden_instrument;
+
+struct UnapprovedAttribute;
+
+#[miden_instrument(fields(transaction.id = UnapprovedAttribute))]
+fn records_unapproved_attribute() {}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_instrument_attribute.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_instrument_attribute.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `UnapprovedAttribute: RecordAttribute` is not satisfied
+ --> tests/ui/tracing_macros/invalid_instrument_attribute.rs:5:1
+  |
+5 | #[miden_instrument(fields(transaction.id = UnapprovedAttribute))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+  |
+help: the trait `RecordAttribute` is not implemented for `UnapprovedAttribute`
+ --> tests/ui/tracing_macros/invalid_instrument_attribute.rs:3:1
+  |
+3 | struct UnapprovedAttribute;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: the following other types implement trait `RecordAttribute`:
+            &T
+            Option<T>
+            Path
+            PathBuf
+            String
+            Vec<T>
+            [T; N]
+            [T]
+          and $N others
+note: required by a bound in `records_unapproved_attribute::__miden_assert_field_name`
+ --> tests/ui/tracing_macros/invalid_instrument_attribute.rs:5:1
+  |
+5 | #[miden_instrument(fields(transaction.id = UnapprovedAttribute))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__miden_assert_field_name`
+  = note: this error originates in the attribute macro `miden_instrument` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_instrument_field_name.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_instrument_field_name.rs
@@ -2,7 +2,7 @@ use miden_node_utils::tracing::miden_instrument;
 
 #[miden_instrument(
     fields(
-        tx_id = %"0x1234",
+        tx_id = "0x1234",
     ),
 )]
 fn records_invalid_field_name() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_instrument_field_name.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_instrument_field_name.stderr
@@ -1,5 +1,33 @@
-error: unsupported tracing field `tx_id`; use one of: account.id, account.id.network_prefix, account.ids, account.ids.count, account.updated, batch.id, batch.account_updates.count, batch.expires_at, batch.expiration_height, batch.input_notes.count, batch.output_notes.count, batch.reference_block.commitment, batch.reference_block.number, block.batch.ids, block.batches.count, block.batches.output_notes.count, block.commitment, block.commitments.account, block.commitments.chain, block.commitments.kernel, block.commitments.note, block.commitments.nullifier, block.commitments.transaction, block.erased_note_proofs.count, block.erased_notes.count, block.from, block.nullifiers.count, block.number, block.output_notes.count, block.prev_block_commitment, block.protocol.version, block.size, block.sub_commitment, block.timestamp, block.transactions.ids, block.transactions.count, block.updated_accounts.count, block_range.from, block_range.to, current_client_block_height, cutoff_block, db.account_state_forest.size, db.account_tree.size, db.block_store.size, db.nullifier_tree.size, db.sqlite.size, db.sqlite.wal.size, dice_roll, failure_rate, finality_level, inputs_size, mempool.accounts, mempool.batches.proposed, mempool.batches.proven, mempool.nullifiers, mempool.output_notes, mempool.transactions.unbatched, mempool.transactions.uncommitted, note.id, notes.count, nullifiers, path, port, prefix_len, prefixes, proof_size, prover, prover.kind, reference_block.number, request.kind, script.root, snapshot.block_num, snapshot.lifetime_ms, snapshots.live, transaction.id, transaction.expires_at, transaction.input_notes.count, transaction.output_notes.count, transaction.reference_block.commitment, transaction.reference_block.number, tip.number, transactions.count, transactions.ids, transactions.input_notes.count, transactions.output_notes.count, transactions.unauthenticated_notes.count, workers.active, workers.capacity, workers.count
- --> tests/ui/tracing_macros/invalid_instrument_field_name.rs:5:9
+error[E0080]: evaluation panicked: tracing field `tx_id` is not allowed for this attribute type
+ --> tests/ui/tracing_macros/invalid_instrument_field_name.rs:3:1
   |
-5 |         tx_id = %"0x1234",
-  |         ^^^^^
+3 | / #[miden_instrument(
+4 | |     fields(
+5 | |         tx_id = "0x1234",
+6 | |     ),
+7 | | )]
+  | |__^ evaluation of `records_invalid_field_name::__miden_assert_field_name::<&str>::{constant#0}` failed here
+
+note: erroneous constant encountered
+ --> tests/ui/tracing_macros/invalid_instrument_field_name.rs:3:1
+  |
+3 | / #[miden_instrument(
+4 | |     fields(
+5 | |         tx_id = "0x1234",
+6 | |     ),
+7 | | )]
+  | |__^
+  |
+  = note: this note originates in the attribute macro `miden_instrument` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn records_invalid_field_name::__miden_assert_field_name::<&str>`
+ --> tests/ui/tracing_macros/invalid_instrument_field_name.rs:3:1
+  |
+3 | / #[miden_instrument(
+4 | |     fields(
+5 | |         tx_id = "0x1234",
+6 | |     ),
+7 | | )]
+  | |__^
+  |
+  = note: this note originates in the attribute macro `miden_instrument` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_instrument_formatter.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_instrument_formatter.rs
@@ -1,0 +1,6 @@
+use miden_node_utils::tracing::miden_instrument;
+
+#[miden_instrument(fields(transaction.id = ?"0x1234"))]
+fn selects_instrument_formatter() {}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_instrument_formatter.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_instrument_formatter.stderr
@@ -1,0 +1,5 @@
+error: tracing format specifiers are not supported; implement `RecordAttribute` to define the type's canonical encoding
+ --> tests/ui/tracing_macros/invalid_instrument_formatter.rs:3:44
+  |
+3 | #[miden_instrument(fields(transaction.id = ?"0x1234"))]
+  |                                            ^

--- a/crates/utils/tests/ui/tracing_macros/invalid_nonstandard_attribute.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_nonstandard_attribute.rs
@@ -1,0 +1,10 @@
+use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+
+struct UnapprovedAttribute;
+
+#[miden_instrument]
+fn records_unapproved_attribute() {
+    miden_span_record!(custom.attribute = UnapprovedAttribute #[nonstandard]);
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_nonstandard_attribute.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_nonstandard_attribute.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `UnapprovedAttribute: RecordAttribute` is not satisfied
+ --> tests/ui/tracing_macros/invalid_nonstandard_attribute.rs:7:5
+  |
+7 |     miden_span_record!(custom.attribute = UnapprovedAttribute #[nonstandard]);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+  |
+help: the trait `RecordAttribute` is not implemented for `UnapprovedAttribute`
+ --> tests/ui/tracing_macros/invalid_nonstandard_attribute.rs:3:1
+  |
+3 | struct UnapprovedAttribute;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: the following other types implement trait `RecordAttribute`:
+            &T
+            Option<T>
+            Path
+            PathBuf
+            String
+            Vec<T>
+            [T; N]
+            [T]
+          and $N others
+note: required by a bound in `miden_node_utils::tracing::record_attribute`
+ --> src/tracing/attribute.rs
+  |
+  | pub fn record_attribute<T: RecordAttribute + ?Sized>(value: &T) -> impl Value + '_ {
+  |                            ^^^^^^^^^^^^^^^ required by this bound in `record_attribute`
+  = note: this error originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_record_attribute.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_record_attribute.rs
@@ -1,0 +1,10 @@
+use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+
+struct UnapprovedAttribute;
+
+#[miden_instrument]
+fn records_unapproved_attribute() {
+    miden_span_record!(transaction.id = UnapprovedAttribute);
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_record_attribute.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_record_attribute.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `UnapprovedAttribute: RecordAttribute` is not satisfied
+ --> tests/ui/tracing_macros/invalid_record_attribute.rs:7:5
+  |
+7 |     miden_span_record!(transaction.id = UnapprovedAttribute);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+  |
+help: the trait `RecordAttribute` is not implemented for `UnapprovedAttribute`
+ --> tests/ui/tracing_macros/invalid_record_attribute.rs:3:1
+  |
+3 | struct UnapprovedAttribute;
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: the following other types implement trait `RecordAttribute`:
+            &T
+            Option<T>
+            Path
+            PathBuf
+            String
+            Vec<T>
+            [T; N]
+            [T]
+          and $N others
+note: required by a bound in `__miden_assert_field_name`
+ --> tests/ui/tracing_macros/invalid_record_attribute.rs:7:5
+  |
+7 |     miden_span_record!(transaction.id = UnapprovedAttribute);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__miden_assert_field_name`
+  = note: this error originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/invalid_record_formatter.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_record_formatter.rs
@@ -1,0 +1,8 @@
+use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+
+#[miden_instrument]
+fn selects_record_formatter() {
+    miden_span_record!(transaction.id = %"0x1234");
+}
+
+fn main() {}

--- a/crates/utils/tests/ui/tracing_macros/invalid_record_formatter.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_record_formatter.stderr
@@ -1,0 +1,5 @@
+error: tracing format specifiers are not supported; implement `RecordAttribute` to define the type's canonical encoding
+ --> tests/ui/tracing_macros/invalid_record_formatter.rs:5:41
+  |
+5 |     miden_span_record!(transaction.id = %"0x1234");
+  |                                         ^

--- a/crates/utils/tests/ui/tracing_macros/invalid_scalar_plural.rs
+++ b/crates/utils/tests/ui/tracing_macros/invalid_scalar_plural.rs
@@ -1,0 +1,20 @@
+use miden_node_utils::tracing::{RecordAttribute, miden_instrument, miden_span_record};
+
+struct AccountId;
+
+impl RecordAttribute for AccountId {
+    const FIELD_NAMES: &'static [&'static str] = &["account.id"];
+
+    fn record_attribute(&self) -> impl tracing::Value + '_ {
+        "account-id"
+    }
+}
+
+#[miden_instrument]
+fn records_scalar_with_plural_field() {
+    miden_span_record!(account.ids = AccountId);
+}
+
+fn main() {
+    records_scalar_with_plural_field();
+}

--- a/crates/utils/tests/ui/tracing_macros/invalid_scalar_plural.stderr
+++ b/crates/utils/tests/ui/tracing_macros/invalid_scalar_plural.stderr
@@ -1,0 +1,21 @@
+error[E0080]: evaluation panicked: tracing field `account.ids` is not allowed for this attribute type
+  --> tests/ui/tracing_macros/invalid_scalar_plural.rs:15:5
+   |
+15 |     miden_span_record!(account.ids = AccountId);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `records_scalar_with_plural_field::__miden_assert_field_name::<AccountId>::{constant#0}` failed here
+
+note: erroneous constant encountered
+  --> tests/ui/tracing_macros/invalid_scalar_plural.rs:15:5
+   |
+15 |     miden_span_record!(account.ids = AccountId);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn __miden_assert_field_name::<AccountId>`
+  --> tests/ui/tracing_macros/invalid_scalar_plural.rs:15:5
+   |
+15 |     miden_span_record!(account.ids = AccountId);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `miden_span_record` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/utils/tests/ui/tracing_macros/outside_miden_instrument.rs
+++ b/crates/utils/tests/ui/tracing_macros/outside_miden_instrument.rs
@@ -4,7 +4,7 @@ fn records_outside_miden_instrument() {
     let tx_id = "0x1234";
 
     miden_span_record!(
-        transaction.id = %tx_id,
+        transaction.id = tx_id
     );
 }
 

--- a/crates/utils/tests/ui/tracing_macros/outside_miden_instrument.stderr
+++ b/crates/utils/tests/ui/tracing_macros/outside_miden_instrument.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `__miden_span_record_must_be_used_within_miden_instrume
  --> tests/ui/tracing_macros/outside_miden_instrument.rs:6:5
   |
 6 | /     miden_span_record!(
-7 | |         transaction.id = %tx_id,
+7 | |         transaction.id = tx_id
 8 | |     );
   | |_____^
   |

--- a/crates/utils/tests/ui/tracing_macros/pass.rs
+++ b/crates/utils/tests/ui/tracing_macros/pass.rs
@@ -1,21 +1,42 @@
-use miden_node_utils::tracing::{miden_instrument, miden_span_record};
+use miden_node_utils::tracing::{RecordAttribute, miden_instrument, miden_span_record};
 
 struct NotDebug;
+
+struct ApprovedAttribute(&'static str);
+
+impl RecordAttribute for ApprovedAttribute {
+    const FIELD_NAMES: &'static [&'static str] = &["account.id", "transaction.id"];
+
+    fn record_attribute(&self) -> impl tracing::Value + '_ {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ApprovedAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
 
 #[miden_instrument(
     target = "miden-node-utils-test",
     name = "records_fields",
 )]
 fn records_fields() {
-    let display_value = "display";
-    let debug_value = vec![1, 2, 3];
+    let display_value = ApprovedAttribute("display");
+    let list_value = vec![ApprovedAttribute("first"), ApprovedAttribute("second")];
     let plain_value = 7;
 
     miden_span_record!(
-        transaction.id = %display_value,
-        transactions.ids = ?debug_value,
-        block.number = plain_value,
+        transaction.id = display_value,
+        transaction.ids = list_value,
+        block.number = plain_value
     );
+}
+
+#[miden_instrument]
+fn records_user_defined_attribute() {
+    miden_span_record!(transaction.id = ApprovedAttribute("approved"));
 }
 
 #[miden_instrument]
@@ -24,13 +45,13 @@ fn records_with_default_instrument_args(not_debug: NotDebug) {
     let value = 1;
 
     miden_span_record!(
-        block.number = value,
+        block.number = value
     );
 }
 
 #[miden_instrument(
     fields(
-        transaction.id = %"0x1234",
+        transaction.id = ApprovedAttribute("0x1234"),
         account.updated,
     ),
 )]
@@ -38,14 +59,14 @@ fn records_allowed_instrument_fields() {}
 
 #[miden_instrument(
     fields(
-        custom.attribute = %"explicit" #[nonstandard],
+        custom.attribute = ApprovedAttribute("explicit") #[nonstandard],
     ),
 )]
 fn records_nonstandard_instrument_field() {}
 
 #[miden_instrument(
     fields(
-        %dice_roll,
+        dice_roll = dice_roll,
     ),
 )]
 fn records_allowed_shorthand_instrument_field(dice_roll: f64) {}
@@ -56,104 +77,43 @@ fn records_same_field_more_than_once() {
     let updated = 2;
 
     miden_span_record!(
-        block.number = value,
+        block.number = value
     );
     miden_span_record!(
-        block.number = updated,
+        block.number = updated
     );
 }
 
 #[miden_instrument]
 fn records_nonstandard_delayed_field() {
-    miden_span_record!(custom.attribute = %"delayed" #[nonstandard]);
+    miden_span_record!(custom.attribute = ApprovedAttribute("delayed") #[nonstandard]);
 }
 
 #[miden_instrument]
 fn records_allowed_canonical_fields() {
-    let tx_id = "0x1234";
-    let account_id = "0xabcd";
+    let tx_id = ApprovedAttribute("0x1234");
+    let account_id = ApprovedAttribute("0xabcd");
     let block_number = 12u32;
-    let transaction_ids = ["0x1", "0x2"];
+    let transaction_ids = [ApprovedAttribute("0x1"), ApprovedAttribute("0x2")];
     let transaction_count = transaction_ids.len();
-    let size = 1024u64;
 
     miden_span_record!(
-        transaction.id = %tx_id,
-        transaction.expires_at = block_number,
-        transaction.reference_block.number = block_number,
-        transaction.reference_block.commitment = %tx_id,
-        tip.number = block_number,
-        transaction.input_notes.count = transaction_count,
-        transaction.output_notes.count = transaction_count,
-        account.id = %account_id,
-        account.id.network_prefix = %account_id,
+        transaction.id = tx_id,
+        account.id = account_id,
         account.updated = true,
         block.number = block_number,
-        block.from = block_number,
-        block.commitment = %tx_id,
-        block.sub_commitment = %tx_id,
-        block.prev_block_commitment = %tx_id,
-        block.timestamp = block_number,
-        block.protocol.version = block_number,
-        block.batch.ids = ?transaction_ids,
-        block.batches.count = transaction_count,
-        block.batches.output_notes.count = transaction_count,
-        block.transactions.ids = ?transaction_ids,
-        block.updated_accounts.count = transaction_count,
-        block.erased_note_proofs.count = transaction_count,
-        block.nullifiers.count = transaction_count,
-        block.output_notes.count = transaction_count,
-        block.erased_notes.count = transaction_count,
-        block.commitments.kernel = %tx_id,
-        block.commitments.nullifier = %tx_id,
-        block.commitments.account = %tx_id,
-        block.commitments.chain = %tx_id,
-        block.commitments.note = %tx_id,
-        block.commitments.transaction = %tx_id,
-        block_range.from = block_number,
-        block_range.to = block_number,
-        transactions.ids = ?transaction_ids,
-        transactions.count = transaction_count,
-        transactions.input_notes.count = transaction_count,
-        transactions.output_notes.count = transaction_count,
-        transactions.unauthenticated_notes.count = transaction_count,
-        block.transactions.count = transaction_count,
-        batch.expires_at = block_number,
-        batch.expiration_height = block_number,
-        batch.reference_block.number = block_number,
-        batch.reference_block.commitment = %tx_id,
-        batch.account_updates.count = transaction_count,
-        batch.input_notes.count = transaction_count,
-        batch.output_notes.count = transaction_count,
-        script.root = %tx_id,
-        note.id = %tx_id,
-        notes.count = transaction_count,
-        reference_block.number = block_number,
-        request.kind = "block",
-        workers.count = transaction_count,
-        workers.active = transaction_count,
-        workers.capacity = transaction_count,
-        prover.kind = "local",
-        failure_rate = 0.0,
-        dice_roll = 0.5,
-        mempool.transactions.uncommitted = transaction_count,
-        mempool.transactions.unbatched = transaction_count,
-        mempool.batches.proposed = transaction_count,
-        mempool.batches.proven = transaction_count,
-        mempool.accounts = transaction_count,
-        mempool.nullifiers = transaction_count,
-        mempool.output_notes = transaction_count,
-        db.sqlite.size = size,
-        db.sqlite.wal.size = size,
-        db.block_store.size = size,
-        db.account_tree.size = size,
-        db.nullifier_tree.size = size,
-        db.account_state_forest.size = size,
+        transaction.ids = transaction_ids,
+        transaction.count = transaction_count,
+        service.name = "node"
     );
 }
 
+#[miden_instrument(fields(unregistered.item.count = item_count))]
+fn records_count_without_registration(item_count: usize) {}
+
 fn main() {
     records_fields();
+    records_user_defined_attribute();
     records_with_default_instrument_args(NotDebug);
     records_allowed_instrument_fields();
     records_nonstandard_instrument_field();
@@ -161,4 +121,5 @@ fn main() {
     records_same_field_more_than_once();
     records_nonstandard_delayed_field();
     records_allowed_canonical_fields();
+    records_count_without_registration(2);
 }


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Tracing fields are now required to standardize on the `RecordAttribute` trait. This PR applies this migration to the instrument and record fields macros. The macros no longer allow for `?`, `%` etc display style selections.

In addition, this enables support for arbitrary `.count` suffixes which must be a usize field. This is intended to easily cover various `x.len()` recording without being overly pedantic about the base name.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```