### PR TITLE
chore(network-monitor): add new NTL stats to monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,7 +4185,6 @@ dependencies = [
  "time",
  "tokio",
  "tonic",
- "tonic-health",
  "tracing",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,7 @@ dependencies = [
  "maud",
  "miden-node-proto",
  "miden-node-utils",
+ "miden-note-transport-proto",
  "miden-protocol",
  "miden-standards",
  "miden-testing",
@@ -4450,6 +4451,34 @@ dependencies = [
  "tracing-subscriber",
  "trybuild",
  "url",
+]
+
+[[package]]
+name = "miden-note-transport-proto"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a9c3ee4ae464eb2c8acfd5a44cf37f47abe906eeb78ed97d722f3660e17ca1"
+dependencies = [
+ "fs-err",
+ "miden-note-transport-proto-build",
+ "miette",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "miden-note-transport-proto-build"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9d736051a42941788c6534caf8cf779b388c0ae72c9d5f0d729d2a9872d833"
+dependencies = [
+ "fs-err",
+ "miette",
+ "protox",
+ "tonic-prost-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ miden-tx           = { default-features = false, version = "=0.16.0-rc.4" }
 miden-tx-batch     = { version = "=0.16.0-rc.4" }
 
 # Other miden dependencies. These should align with those expected by miden-protocol.
-miden-crypto = { version = "0.29.1" }
+miden-crypto               = { version = "0.29.1" }
+miden-note-transport-proto = { version = "0.5.0-rc.2" }
 
 # External dependencies
 anyhow             = { version = "1.0" }

--- a/bin/network-monitor/Cargo.toml
+++ b/bin/network-monitor/Cargo.toml
@@ -39,7 +39,6 @@ sha2                       = { workspace = true }
 time                       = { features = ["formatting", "macros"], version = "0.3" }
 tokio                      = { features = ["full"], workspace = true }
 tonic                      = { features = ["codegen", "tls-native-roots", "transport"], workspace = true }
-tonic-health               = { workspace = true }
 tracing                    = { workspace = true }
 url                        = { features = ["serde"], workspace = true }
 

--- a/bin/network-monitor/Cargo.toml
+++ b/bin/network-monitor/Cargo.toml
@@ -15,32 +15,33 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
-anyhow              = { workspace = true }
-axum                = { workspace = true }
-backon              = { workspace = true }
-clap                = { features = ["env"], workspace = true }
-futures             = { workspace = true }
-hex                 = { workspace = true }
-humantime           = { workspace = true }
-maud                = { features = ["axum"], version = "0.27" }
-miden-node-proto    = { workspace = true }
-miden-node-utils    = { workspace = true }
-miden-protocol      = { features = ["std"], workspace = true }
-miden-standards     = { workspace = true }
-miden-tx            = { features = ["concurrent", "std"], workspace = true }
-rand                = { workspace = true }
-rand_chacha         = { workspace = true }
-reqwest             = { features = ["json", "query"], workspace = true }
-serde               = { workspace = true }
-serde_json          = { version = "1.0" }
-serde_path_to_error = { version = "0.1" }
-sha2                = { workspace = true }
-time                = { features = ["formatting", "macros"], version = "0.3" }
-tokio               = { features = ["full"], workspace = true }
-tonic               = { features = ["codegen", "tls-native-roots", "transport"], workspace = true }
-tonic-health        = { workspace = true }
-tracing             = { workspace = true }
-url                 = { features = ["serde"], workspace = true }
+anyhow                     = { workspace = true }
+axum                       = { workspace = true }
+backon                     = { workspace = true }
+clap                       = { features = ["env"], workspace = true }
+futures                    = { workspace = true }
+hex                        = { workspace = true }
+humantime                  = { workspace = true }
+maud                       = { features = ["axum"], version = "0.27" }
+miden-node-proto           = { workspace = true }
+miden-node-utils           = { workspace = true }
+miden-note-transport-proto = { workspace = true }
+miden-protocol             = { features = ["std"], workspace = true }
+miden-standards            = { workspace = true }
+miden-tx                   = { features = ["concurrent", "std"], workspace = true }
+rand                       = { workspace = true }
+rand_chacha                = { workspace = true }
+reqwest                    = { features = ["json", "query"], workspace = true }
+serde                      = { workspace = true }
+serde_json                 = { version = "1.0" }
+serde_path_to_error        = { version = "0.1" }
+sha2                       = { workspace = true }
+time                       = { features = ["formatting", "macros"], version = "0.3" }
+tokio                      = { features = ["full"], workspace = true }
+tonic                      = { features = ["codegen", "tls-native-roots", "transport"], workspace = true }
+tonic-health               = { workspace = true }
+tracing                    = { workspace = true }
+url                        = { features = ["serde"], workspace = true }
 
 [dev-dependencies]
 miden-protocol = { features = ["std", "testing"], workspace = true }

--- a/bin/network-monitor/src/note_transport.rs
+++ b/bin/network-monitor/src/note_transport.rs
@@ -4,9 +4,12 @@
 use std::time::Duration;
 
 use miden_node_utils::tracing::miden_instrument;
+use miden_note_transport_proto::miden_note_transport::StatsResponse;
+use miden_note_transport_proto::miden_note_transport::miden_note_transport_client::MidenNoteTransportClient;
 use tonic::transport::{Channel, ClientTlsConfig};
 use tonic_health::pb::health_client::HealthClient;
 use tonic_health::pb::{HealthCheckRequest, health_check_response};
+use tracing::warn;
 use url::Url;
 
 use crate::COMPONENT;
@@ -16,14 +19,16 @@ use crate::status::{NoteTransportStatusDetails, ServiceDetails, ServiceStatus};
 pub struct NoteTransportService {
     url: Url,
     client: HealthClient<Channel>,
+    stats_client: MidenNoteTransportClient<Channel>,
     interval: Duration,
 }
 
 impl NoteTransportService {
     pub fn new(url: Url, interval: Duration, timeout: Duration) -> Self {
         let channel = create_channel(&url, timeout).expect("failed to create channel");
-        let client = HealthClient::new(channel);
-        Self { url, client, interval }
+        let client = HealthClient::new(channel.clone());
+        let stats_client = MidenNoteTransportClient::new(channel);
+        Self { url, client, stats_client, interval }
     }
 }
 
@@ -57,10 +62,24 @@ impl Service for NoteTransportService {
                 let serving_status = response.into_inner().status();
                 let is_serving = serving_status == health_check_response::ServingStatus::Serving;
                 let serving_status_str = format!("{serving_status:?}");
-                let details = ServiceDetails::NoteTransportStatus(NoteTransportStatusDetails {
+
+                let mut details = NoteTransportStatusDetails {
                     url,
                     serving_status: serving_status_str.clone(),
-                });
+                    ..NoteTransportStatusDetails::default()
+                };
+
+                // Stats enrich the card but do not decide health: a deployment that predates the
+                // Stats RPC (or a transient stats failure) must not flip a serving service to
+                // unhealthy.
+                match self.stats_client.stats(()).await {
+                    Ok(stats) => apply_stats(&mut details, &stats.into_inner()),
+                    Err(e) => {
+                        warn!(target: COMPONENT, error = %e, "Note transport stats call failed");
+                    },
+                }
+
+                let details = ServiceDetails::NoteTransportStatus(details);
 
                 if is_serving {
                     ServiceStatus::healthy(self.name(), details)
@@ -75,6 +94,24 @@ impl Service for NoteTransportService {
             Err(e) => ServiceStatus::error(self.name(), e),
         }
     }
+}
+
+/// Copies the stats response into the card details.
+///
+/// The version is a plain string on the wire, so a server that predates the field reports an
+/// empty string; that degrades to `None` rather than rendering an empty value.
+fn apply_stats(details: &mut NoteTransportStatusDetails, stats: &StatsResponse) {
+    details.version = (!stats.version.is_empty()).then(|| stats.version.clone());
+    details.total_notes = Some(stats.total_notes);
+    details.total_tags = Some(stats.total_tags);
+    // Empty until the server implements per-tag stats; kept so the card lights up the moment it
+    // does.
+    details.last_activity = stats
+        .notes_per_tag
+        .iter()
+        .filter_map(|tag| tag.last_activity.as_ref())
+        .filter_map(|ts| u64::try_from(ts.seconds).ok())
+        .max();
 }
 
 /// Creates a `tonic` channel for the given URL, enabling TLS for `https` schemes.

--- a/bin/network-monitor/src/note_transport.rs
+++ b/bin/network-monitor/src/note_transport.rs
@@ -7,9 +7,6 @@ use miden_node_utils::tracing::miden_instrument;
 use miden_note_transport_proto::miden_note_transport::StatsResponse;
 use miden_note_transport_proto::miden_note_transport::miden_note_transport_client::MidenNoteTransportClient;
 use tonic::transport::{Channel, ClientTlsConfig};
-use tonic_health::pb::health_client::HealthClient;
-use tonic_health::pb::{HealthCheckRequest, health_check_response};
-use tracing::warn;
 use url::Url;
 
 use crate::COMPONENT;
@@ -18,17 +15,15 @@ use crate::status::{NoteTransportStatusDetails, ServiceDetails, ServiceStatus};
 
 pub struct NoteTransportService {
     url: Url,
-    client: HealthClient<Channel>,
-    stats_client: MidenNoteTransportClient<Channel>,
+    client: MidenNoteTransportClient<Channel>,
     interval: Duration,
 }
 
 impl NoteTransportService {
     pub fn new(url: Url, interval: Duration, timeout: Duration) -> Self {
         let channel = create_channel(&url, timeout).expect("failed to create channel");
-        let client = HealthClient::new(channel.clone());
-        let stats_client = MidenNoteTransportClient::new(channel);
-        Self { url, client, stats_client, interval }
+        let client = MidenNoteTransportClient::new(channel);
+        Self { url, client, interval }
     }
 }
 
@@ -54,45 +49,32 @@ impl Service for NoteTransportService {
         ret(level = "info"),
     )]
     async fn check(&mut self) -> ServiceStatus {
-        let request = HealthCheckRequest { service: String::new() };
-        let url = self.url.to_string();
+        let details = NoteTransportStatusDetails {
+            url: self.url.to_string(),
+            ..NoteTransportStatusDetails::default()
+        };
 
-        match self.client.check(request).await {
-            Ok(response) => {
-                let serving_status = response.into_inner().status();
-                let is_serving = serving_status == health_check_response::ServingStatus::Serving;
-                let serving_status_str = format!("{serving_status:?}");
+        let stats = self.client.stats(()).await.map(tonic::Response::into_inner);
+        status_from_stats(self.name(), details, stats)
+    }
+}
 
-                let mut details = NoteTransportStatusDetails {
-                    url,
-                    serving_status: serving_status_str.clone(),
-                    ..NoteTransportStatusDetails::default()
-                };
-
-                // Stats enrich the card but do not decide health: a deployment that predates the
-                // Stats RPC (or a transient stats failure) must not flip a serving service to
-                // unhealthy.
-                match self.stats_client.stats(()).await {
-                    Ok(stats) => apply_stats(&mut details, &stats.into_inner()),
-                    Err(e) => {
-                        warn!(target: COMPONENT, error = %e, "Note transport stats call failed");
-                    },
-                }
-
-                let details = ServiceDetails::NoteTransportStatus(details);
-
-                if is_serving {
-                    ServiceStatus::healthy(self.name(), details)
-                } else {
-                    ServiceStatus::unhealthy(
-                        self.name(),
-                        format!("serving status: {serving_status_str}"),
-                        details,
-                    )
-                }
-            },
-            Err(e) => ServiceStatus::error(self.name(), e),
-        }
+/// Builds the service status from the note transport's stats response.
+fn status_from_stats(
+    service_name: &str,
+    mut details: NoteTransportStatusDetails,
+    stats: Result<StatsResponse, tonic::Status>,
+) -> ServiceStatus {
+    match stats {
+        Ok(stats) => {
+            apply_stats(&mut details, &stats);
+            ServiceStatus::healthy(service_name, ServiceDetails::NoteTransportStatus(details))
+        },
+        Err(e) => ServiceStatus::unhealthy(
+            service_name,
+            format!("stats call failed: {e}"),
+            ServiceDetails::NoteTransportStatus(details),
+        ),
     }
 }
 
@@ -123,4 +105,61 @@ fn create_channel(url: &Url, timeout: Duration) -> Result<Channel, tonic::transp
     }
 
     Ok(endpoint.connect_lazy())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::status::Status;
+
+    #[test]
+    fn successful_stats_response_is_healthy() {
+        let details = NoteTransportStatusDetails {
+            url: "https://nt.example".to_string(),
+            ..NoteTransportStatusDetails::default()
+        };
+        let response = StatsResponse {
+            version: "0.5.0".to_string(),
+            total_notes: 42,
+            total_tags: 7,
+            notes_per_tag: Vec::new(),
+        };
+
+        let service_status = status_from_stats("Note Transport", details, Ok(response));
+
+        assert_eq!(service_status.status, Status::Healthy);
+        assert_eq!(service_status.error, None);
+        let ServiceDetails::NoteTransportStatus(details) = service_status.details else {
+            panic!("expected note transport details");
+        };
+        assert_eq!(details.version.as_deref(), Some("0.5.0"));
+        assert_eq!(details.total_notes, Some(42));
+        assert_eq!(details.total_tags, Some(7));
+    }
+
+    #[test]
+    fn failed_stats_response_is_unhealthy_and_preserves_url() {
+        let details = NoteTransportStatusDetails {
+            url: "https://nt.example".to_string(),
+            ..NoteTransportStatusDetails::default()
+        };
+
+        let status = status_from_stats(
+            "Note Transport",
+            details,
+            Err(tonic::Status::unavailable("stats unavailable")),
+        );
+
+        assert_eq!(status.status, Status::Unhealthy);
+        assert!(status.error.as_deref().is_some_and(|error| {
+            error.contains("stats call failed") && error.contains("stats unavailable")
+        }));
+        let ServiceDetails::NoteTransportStatus(details) = status.details else {
+            panic!("expected note transport details");
+        };
+        assert_eq!(details.url, "https://nt.example");
+        assert_eq!(details.version, None);
+        assert_eq!(details.total_notes, None);
+        assert_eq!(details.total_tags, None);
+    }
 }

--- a/bin/network-monitor/src/service_status.rs
+++ b/bin/network-monitor/src/service_status.rs
@@ -211,10 +211,24 @@ pub struct ExplorerStatusDetails {
 }
 
 /// Details of the note transport service.
+///
+/// The stats fields are sourced from the note transport's `Stats` RPC and are `None` when the
+/// stats call failed (e.g. an older deployment); the health check alone decides the status.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NoteTransportStatusDetails {
     pub url: String,
     pub serving_status: String,
+    /// Version reported by the note transport service; `None` when unavailable.
+    pub version: Option<String>,
+    /// Total number of notes stored by the service.
+    pub total_notes: Option<u64>,
+    /// Total number of distinct note tags seen by the service.
+    pub total_tags: Option<u64>,
+    /// Unix timestamp of the most recent note activity across all tags.
+    ///
+    /// Sourced from the per-tag stats, which the current server does not populate yet
+    /// (`notes_per_tag` is a TODO server-side); stays `None` and renders as `-` until it does.
+    pub last_activity: Option<u64>,
 }
 
 /// Details of the validator service.

--- a/bin/network-monitor/src/service_status.rs
+++ b/bin/network-monitor/src/service_status.rs
@@ -212,12 +212,11 @@ pub struct ExplorerStatusDetails {
 
 /// Details of the note transport service.
 ///
-/// The stats fields are sourced from the note transport's `Stats` RPC and are `None` when the
-/// stats call failed (e.g. an older deployment); the health check alone decides the status.
+/// The stats fields are sourced from the note transport's `Stats` RPC. A successful response marks
+/// the service as healthy; a failed call marks it as unhealthy and leaves the fields as `None`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NoteTransportStatusDetails {
     pub url: String,
-    pub serving_status: String,
     /// Version reported by the note transport service; `None` when unavailable.
     pub version: Option<String>,
     /// Total number of notes stored by the service.

--- a/bin/network-monitor/src/view/cards/note_transport.rs
+++ b/bin/network-monitor/src/view/cards/note_transport.rs
@@ -1,8 +1,8 @@
-//! Renders the note-transport card (URL + gRPC serving status).
+//! Renders the note-transport card (URL, gRPC serving status and server stats).
 
 use maud::{Markup, html};
 
-use super::super::helpers::{copy_button, metric_row};
+use super::super::helpers::{copy_button, format_timestamp, metric_row};
 use crate::status::NoteTransportStatusDetails;
 
 pub(in crate::view) fn render_note_transport(
@@ -26,8 +26,30 @@ pub(in crate::view) fn render_note_transport(
                         }
                     }
                     (metric_row("Serving Status:", &details.serving_status))
+                    (metric_row("Version:", &stat_or_dash(details.version.clone(), healthy)))
+                    (metric_row(
+                        "Total Notes:",
+                        &stat_or_dash(details.total_notes.map(|v| v.to_string()), healthy),
+                    ))
+                    (metric_row(
+                        "Total Tags:",
+                        &stat_or_dash(details.total_tags.map(|v| v.to_string()), healthy),
+                    ))
+                    (metric_row(
+                        "Last Note Activity:",
+                        &stat_or_dash(details.last_activity.map(format_timestamp), healthy),
+                    ))
                 }
             }
         }
+    }
+}
+
+/// Renders the stat when present and the service is healthy, `-` otherwise. Mirrors the convention
+/// used across cards: stale numbers from an unhealthy probe are not shown.
+fn stat_or_dash(value: Option<String>, healthy: bool) -> String {
+    match value {
+        Some(v) if healthy => v,
+        _ => "-".to_string(),
     }
 }

--- a/bin/network-monitor/src/view/cards/note_transport.rs
+++ b/bin/network-monitor/src/view/cards/note_transport.rs
@@ -1,4 +1,4 @@
-//! Renders the note-transport card (URL, gRPC serving status and server stats).
+//! Renders the note-transport card (URL and server stats).
 
 use maud::{Markup, html};
 
@@ -25,7 +25,6 @@ pub(in crate::view) fn render_note_transport(
                             (details.url) (copy_button(&details.url, "URL"))
                         }
                     }
-                    (metric_row("Serving Status:", &details.serving_status))
                     (metric_row("Version:", &stat_or_dash(details.version.clone(), healthy)))
                     (metric_row(
                         "Total Notes:",

--- a/bin/network-monitor/src/view/mod.rs
+++ b/bin/network-monitor/src/view/mod.rs
@@ -474,11 +474,20 @@ mod tests {
         let details = NoteTransportStatusDetails {
             url: "https://nt.example".to_string(),
             serving_status: "SERVING".to_string(),
+            version: Some("0.5.0".to_string()),
+            total_notes: Some(42),
+            total_tags: Some(7),
+            last_activity: None,
         };
         let html =
             render(vec![healthy("note-transport", ServiceDetails::NoteTransportStatus(details))]);
         assert!(html.contains("Note Transport"));
         assert!(html.contains("SERVING"));
+        assert!(html.contains("0.5.0"));
+        assert!(html.contains("42"));
+        assert!(html.contains("Total Notes"));
+        // Server-side per-tag stats are not implemented yet, so the row renders as a dash.
+        assert!(html.contains("Last Note Activity"));
     }
 
     #[test]

--- a/bin/network-monitor/src/view/mod.rs
+++ b/bin/network-monitor/src/view/mod.rs
@@ -473,7 +473,6 @@ mod tests {
     fn renders_note_transport_card() {
         let details = NoteTransportStatusDetails {
             url: "https://nt.example".to_string(),
-            serving_status: "SERVING".to_string(),
             version: Some("0.5.0".to_string()),
             total_notes: Some(42),
             total_tags: Some(7),
@@ -482,7 +481,6 @@ mod tests {
         let html =
             render(vec![healthy("note-transport", ServiceDetails::NoteTransportStatus(details))]);
         assert!(html.contains("Note Transport"));
-        assert!(html.contains("SERVING"));
         assert!(html.contains("0.5.0"));
         assert!(html.contains("42"));
         assert!(html.contains("Total Notes"));


### PR DESCRIPTION
## Summary

Updated the NTL status card with data from the NTL Stats RPC (`v0.5.0-rc.2`): version, total notes, total tags, and last note activity.


## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "network-monitor"
impact      = "added"
description = "Show note transport version, total notes and total tags on the status dashboard."
```
