### PR TITLE
Prefund faucet operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "miden-benchmark"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-large-account-benchmark"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "build-rs",
  "codegen",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "clap",
  "fs-err",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-tracing-macro"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "backon",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "backon",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -8490,7 +8490,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.96.1"
-version      = "0.16.0-rc.2"
+version      = "0.16.0-rc.3"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]
@@ -43,16 +43,16 @@ debug = true
 
 [workspace.dependencies]
 # Workspace crates.
-miden-node-block-producer   = { path = "crates/block-producer", version = "0.16.0-rc.2" }
-miden-node-db               = { path = "crates/db", version = "0.16.0-rc.2" }
-miden-node-grpc-error-macro = { path = "crates/grpc-error-macro", version = "0.16.0-rc.2" }
-miden-node-proto            = { path = "crates/proto", version = "0.16.0-rc.2" }
-miden-node-proto-build      = { path = "proto", version = "0.16.0-rc.2" }
-miden-node-rpc              = { path = "crates/rpc", version = "0.16.0-rc.2" }
-miden-node-store            = { path = "crates/store", version = "0.16.0-rc.2" }
+miden-node-block-producer   = { path = "crates/block-producer", version = "0.16.0-rc.3" }
+miden-node-db               = { path = "crates/db", version = "0.16.0-rc.3" }
+miden-node-grpc-error-macro = { path = "crates/grpc-error-macro", version = "0.16.0-rc.3" }
+miden-node-proto            = { path = "crates/proto", version = "0.16.0-rc.3" }
+miden-node-proto-build      = { path = "proto", version = "0.16.0-rc.3" }
+miden-node-rpc              = { path = "crates/rpc", version = "0.16.0-rc.3" }
+miden-node-store            = { path = "crates/store", version = "0.16.0-rc.3" }
 miden-node-test-macro       = { path = "crates/test-macro" }
-miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.16.0-rc.2" }
-miden-node-utils            = { path = "crates/utils", version = "0.16.0-rc.2" }
+miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.16.0-rc.3" }
+miden-node-utils            = { path = "crates/utils", version = "0.16.0-rc.3" }
 
 # miden-protocol dependencies. These should be updated in sync.
 miden-block-prover = { version = "=0.16.0-rc.4" }

--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -45,6 +45,8 @@ mod tests;
 const DEFAULT_NATIVE_FAUCET_SYMBOL: &str = "MIDEN";
 const DEFAULT_NATIVE_FAUCET_DECIMALS: u8 = 6;
 const DEFAULT_NATIVE_FAUCET_MAX_SUPPLY: u64 = 100_000_000_000_000_000;
+/// One thousand native tokens, used to bootstrap the operator's fee payments.
+const DEFAULT_FAUCET_OPERATOR_BALANCE: u64 = 1_000_000_000;
 
 /// Name of the account file written for the generated native faucet.
 pub const NATIVE_FAUCET_FILE_NAME: &str = "native_faucet.mac";
@@ -83,6 +85,9 @@ pub struct GenesisConfig {
     /// decimals   = 6
     /// max_supply = 100_000_000_000_000_000
     /// ```
+    ///
+    /// The generated operator is pre-funded with 1,000 MIDEN tokens so it can pay the fees required
+    /// to submit the first mint requests.
     #[serde(default)]
     native_faucet: Option<PathBuf>,
     fee_parameters: FeeParameterConfig,
@@ -190,6 +195,15 @@ impl GenesisConfig {
             symbol,
             operator,
         } = NativeFaucetConfig(native_faucet).build_account(&config_dir)?;
+        let native_faucet_account_id = native_faucet_account.id();
+
+        // Track all genesis issuance, one entry per faucet account id. A generated faucet operator
+        // is pre-funded in `NativeFaucetConfig::build_account`, so account for that allocation
+        // before adding configured wallet balances below.
+        let mut faucet_issuance = IndexMap::<AccountId, u64>::new();
+        if operator.is_some() {
+            faucet_issuance.insert(native_faucet_account_id, DEFAULT_FAUCET_OPERATOR_BALANCE);
+        }
 
         let operator_account = match operator {
             Some((operator, operator_secret)) => {
@@ -211,7 +225,6 @@ impl GenesisConfig {
             None => None,
         };
 
-        let native_faucet_account_id = native_faucet_account.id();
         faucet_accounts.insert(symbol.clone(), native_faucet_account);
 
         // Setup additional fungible faucets from parameters
@@ -234,9 +247,6 @@ impl GenesisConfig {
 
         let fee_parameters =
             FeeParameters::new(native_faucet_account_id, fee_parameters.verification_base_fee);
-
-        // Track all adjustments, one per faucet account id
-        let mut faucet_issuance = IndexMap::<AccountId, u64>::new();
 
         let zero_padding_width = usize::ilog10(std::cmp::max(10, wallet_configs.len())) as usize;
 
@@ -341,7 +351,7 @@ impl GenesisConfig {
 
             all_accounts.push(faucet_account);
         }
-        // The operator holds no assets, so its position among the accounts does not matter.
+        // Keep the operator after the faucets because its vault references the native faucet.
         all_accounts.extend(operator_account);
 
         // Ensure the faucets always precede the wallets referencing them
@@ -405,8 +415,13 @@ impl NativeFaucetConfig {
         match self.0 {
             None => {
                 // The operator is built first, since the faucet it owns commits to its id.
-                let (operator, operator_secret) = build_faucet_operator()?;
+                let (mut operator, operator_secret) = build_faucet_operator()?;
                 let (account, symbol) = build_native_faucet(operator.id())?;
+                // Now that the faucet id is known, pre-fund the operator so it can pay fees for the
+                // first mint requests. Genesis issuance is updated in `into_state`.
+                let operator_asset =
+                    FungibleAsset::new(account.id(), DEFAULT_FAUCET_OPERATOR_BALANCE)?;
+                operator.vault_mut().add_asset(operator_asset.into())?;
                 Ok(NativeFaucet {
                     account,
                     symbol,
@@ -432,8 +447,10 @@ impl NativeFaucetConfig {
 // FAUCET OPERATOR
 // ================================================================================================
 
-/// Builds the faucet operator account and returns it along with its signing key. Its nonce is set
-/// to `1`, marking it as deployed at genesis.
+/// Builds the initially assetless faucet operator account and returns it with its signing key.
+///
+/// Its nonce is set to `1`, marking it as deployed at genesis. The operator is funded after the
+/// native faucet is built, because its asset id is not known before then.
 fn build_faucet_operator() -> Result<(Account, RpoSecretKey), GenesisConfigError> {
     let mut rng = ChaCha20Rng::from_seed(rand::random());
 

--- a/crates/store/src/genesis/config/mod.rs
+++ b/crates/store/src/genesis/config/mod.rs
@@ -499,6 +499,9 @@ fn build_native_faucet(
             (BurnNote::script_root(), AssetAmount::ZERO),
         ])
         .into();
+    // TODO: Replace this workaround with `create_native_fungible_faucet_for_genesis` once a
+    // `miden-standards` release containing 0xMiden/protocol#3588 is available.
+    //
     // The faucet should charge fees in its own asset, but setting its own id as the fee faucet id
     // would require knowing that id before creating the account, which is not possible: the fee
     // faucet id is part of the storage the account id is derived from. We use the operator id

--- a/crates/store/src/genesis/config/samples/01-simple.toml
+++ b/crates/store/src/genesis/config/samples/01-simple.toml
@@ -3,8 +3,9 @@ version   = 1
 
 # No `native_faucet` is set below, so the native MIDEN faucet is generated as a network account
 # owned by a generated operator account that holds the only key permitted to mint. Both are written
-# to the accounts directory as `native_faucet.mac` and `faucet_operator.mac`. Wallet balances below
-# are funded directly in the genesis state and do not require minting.
+# to the accounts directory as `native_faucet.mac` and `faucet_operator.mac`. The operator is
+# pre-funded with 1,000 MIDEN tokens to bootstrap fee payments. Wallet balances below are funded
+# directly in the genesis state and do not require minting.
 
 # The genesis validator set is not part of this configuration: the hex-encoded public keys (see
 # `miden-validator pubkey`) are passed to `miden-validator genesis` via `--validator.key` flags.

--- a/crates/store/src/genesis/config/tests.rs
+++ b/crates/store/src/genesis/config/tests.rs
@@ -37,7 +37,7 @@ fn parsing_yields_expected_default_values() -> TestResult {
     let gcfg = GenesisConfig::read_toml_file(&config_path)?;
     let (state, _secrets) = gcfg.into_state(dev_validator_keys())?;
     let _ = state;
-    // faucets, then the generated faucet operator, then the wallet accounts
+    // Faucets, then the generated faucet operator, then the wallet accounts.
     let native_faucet = state.accounts[0].clone();
     let _excess = state.accounts[1].clone();
     let _faucet_operator = state.accounts[2].clone();
@@ -71,7 +71,11 @@ fn parsing_yields_expected_default_values() -> TestResult {
 
     // check total issuance of the faucet
     let faucet = FungibleFaucet::try_from(native_faucet.storage()).unwrap();
-    assert_eq!(faucet.token_supply().as_u64(), 999_777, "Issuance mismatch");
+    assert_eq!(
+        faucet.token_supply().as_u64(),
+        DEFAULT_FAUCET_OPERATOR_BALANCE + 999_777,
+        "Issuance mismatch"
+    );
 
     Ok(())
 }
@@ -204,6 +208,15 @@ fn generated_native_faucet_is_a_network_account_owned_by_an_operator() -> TestRe
         .expect("the operator account is part of the genesis state");
     assert_eq!(operator.nonce(), ONE);
     assert!(FungibleFaucet::try_from(operator).is_err());
+    let native_asset_id = miden_protocol::asset::AssetId::new_fungible(native_faucet.id());
+    assert_eq!(
+        operator.vault().get_balance(native_asset_id)?.as_u64(),
+        DEFAULT_FAUCET_OPERATOR_BALANCE,
+    );
+
+    // The pre-funded balance is part of the faucet's genesis issuance.
+    let faucet = FungibleFaucet::try_from(native_faucet.storage())?;
+    assert_eq!(faucet.token_supply().as_u64(), DEFAULT_FAUCET_OPERATOR_BALANCE);
 
     // The faucet is network authenticated: `AuthNetworkAccount` checks an allowlist of note scripts
     // instead of a signature. Only mint and burn notes are accepted.

--- a/docs/external/src/network-operator/bootstrap-and-genesis.md
+++ b/docs/external/src/network-operator/bootstrap-and-genesis.md
@@ -55,8 +55,9 @@ miden-validator genesis \
 
 Unless the configuration sets `native_faucet` to a pre-built account file, the native faucet is generated as a network
 account and holds no key of its own; minting from it is restricted to the faucet operator account generated alongside
-it. Both are written to the accounts directory as `native_faucet.mac` and `faucet_operator.mac`, and the faucet account
-id is printed. The operator file carries the only signing key permitted to mint, so treat it as a secret.
+it. The operator starts with 1,000 MIDEN tokens so it can pay fees for the first mint requests. Both accounts are
+written to the accounts directory as `native_faucet.mac` and `faucet_operator.mac`, and the faucet account id is
+printed. The operator file carries the only signing key permitted to mint, so treat it as a secret.
 
 To run a faucet against the network, pass `faucet_operator.mac` to the faucet's `init --import`, and the faucet account
 id to `--faucet-account-id`.


### PR DESCRIPTION
## Summary

Adds some token to the faucet operator, and bumps the crate versions.
## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "node"
impact      = "fixed"
description = "Pre-fund the generated native faucet operator with 1,000 MIDEN at genesis so it can pay transaction fees."
```
