### PR TITLE
docs(proto): correct stale block-range comment on SyncAccountVault/SyncAccountStorageMaps

### DIFF
--- a/proto/proto/rpc.proto
+++ b/proto/proto/rpc.proto
@@ -453,8 +453,8 @@ message SyncNullifiersResponse {
 message SyncAccountVaultRequest {
     // Block range from which to start synchronizing.
     //
-    // If the `block_to` is specified, this block must be close to the chain tip (i.e., within 30 blocks),
-    // otherwise an error will be returned.
+    // If the `block_to` is specified, it must not be beyond the current chain tip, otherwise an
+    // error will be returned.
     BlockRange block_range = 1;
 
     // Account for which we want to sync asset vault.
@@ -580,8 +580,8 @@ message SyncChainMmrResponse {
 message SyncAccountStorageMapsRequest {
     // Block range from which to start synchronizing.
     //
-    // If the `block_to` is specified, this block must be close to the chain tip (i.e., within 30 blocks),
-    // otherwise an error will be returned.
+    // If the `block_to` is specified, it must not be beyond the current chain tip, otherwise an
+    // error will be returned.
     BlockRange block_range = 1;
 
     // Account for which we want to sync storage maps.


### PR DESCRIPTION
## Summary
The doc comments on `SyncAccountVaultRequest` and `SyncAccountStorageMapsRequest`
(proto/proto/rpc.proto, added in #1176 / #1140) state that `block_to`
must be within 30 blocks of the chain tip, but no such check exists
in the implementation — `StateView::scope_range` only rejects
ranges that extend beyond the tip (crates/store/src/state/view/mod.rs).

I traced this back to the original commit (99c9848a, feat: asset
vault sync #1176) that introduced both endpoints — the 30-block
constraint was never implemented, so this isn't a regression, just
a stale/aspirational comment that could mislead client implementers
into adding unnecessary defensive checks.

## Changes
Updated both doc comments to describe actual current behavior:
only rejects ranges where `block_to` exceeds the chain tip.

No behavioral change — comment-only fix.

