### PR TITLE
Respect user batch reference blocks

### DIFF
--- a/bin/stress-test/src/seeding/mod.rs
+++ b/bin/stress-test/src/seeding/mod.rs
@@ -1080,6 +1080,7 @@ async fn get_batch_inputs(
     let batch_inputs = state
         .view()
         .get_batch_inputs(
+            block_ref.block_num(),
             [block_ref.block_num()].into_iter().collect(),
             notes.iter().map(|note| note.id().as_word()).collect(),
         )

--- a/crates/block-producer/src/batch_builder/mod.rs
+++ b/crates/block-producer/src/batch_builder/mod.rs
@@ -300,6 +300,7 @@ impl BatchJob {
         &self,
         batch: SelectedBatch,
     ) -> Result<(SelectedBatch, BatchInputs), BuildBatchError> {
+        let batch_reference_block_num = batch.parameters().reference_block;
         let block_references = batch
             .transactions()
             .iter()
@@ -314,6 +315,7 @@ impl BatchJob {
         self.state
             .view()
             .get_batch_inputs(
+                batch_reference_block_num,
                 block_references.map(|(block_num, _)| block_num).collect(),
                 unauthenticated_notes.collect(),
             )

--- a/crates/block-producer/src/domain/batch.rs
+++ b/crates/block-producer/src/domain/batch.rs
@@ -11,6 +11,19 @@ use crate::domain::transaction::AuthenticatedTransaction;
 // SELECTED BATCH
 // ================================================================================================
 
+/// Parameters that define how the node builds a batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct BatchParameters {
+    pub reference_block: BlockNumber,
+}
+
+#[cfg(test)]
+impl BatchParameters {
+    pub(crate) fn for_tests() -> Self {
+        Self { reference_block: BlockNumber::GENESIS }
+    }
+}
+
 /// A sequence of transactions selected by the [`Mempool`] to be processed by the
 /// [`BatchBuilder`] into a [`ProposedBatch`], and then finally into a [`ProvenBatch`].
 ///
@@ -22,13 +35,18 @@ use crate::domain::transaction::AuthenticatedTransaction;
 pub(crate) struct SelectedBatch {
     txs: Vec<Arc<AuthenticatedTransaction>>,
     id: BatchId,
+    parameters: BatchParameters,
     account_updates: HashMap<AccountId, (Word, Word, Option<Word>)>,
     unauthenticated_notes: HashSet<Word>,
 }
 
 impl SelectedBatch {
-    pub(crate) fn builder() -> SelectedBatchBuilder {
-        SelectedBatchBuilder::default()
+    pub(crate) fn builder(parameters: BatchParameters) -> SelectedBatchBuilder {
+        SelectedBatchBuilder {
+            parameters,
+            txs: Vec::new(),
+            account_updates: HashMap::new(),
+        }
     }
 
     pub(crate) fn id(&self) -> BatchId {
@@ -41,6 +59,10 @@ impl SelectedBatch {
 
     pub(crate) fn transactions(&self) -> &[Arc<AuthenticatedTransaction>] {
         &self.txs
+    }
+
+    pub(crate) fn parameters(&self) -> BatchParameters {
+        self.parameters
     }
 
     /// The aggregated list of account transitions this batch causes given as tuples of `(AccountId,
@@ -71,8 +93,9 @@ impl SelectedBatch {
 }
 
 /// A builder to construct a [`SelectedBatch`].
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct SelectedBatchBuilder {
+    parameters: BatchParameters,
     pub(crate) txs: Vec<Arc<AuthenticatedTransaction>>,
     pub(crate) account_updates: HashMap<AccountId, (Word, Word, Option<Word>)>,
 }
@@ -118,7 +141,7 @@ not match the current commitment {}",
 
     /// Finalizes the batch selection.
     pub(crate) fn build(self) -> SelectedBatch {
-        let Self { txs, account_updates } = self;
+        let Self { parameters, txs, account_updates } = self;
         let id = BatchId::from_ids(txs.iter().map(|tx| (tx.id(), tx.account_id())));
 
         let mut unauthenticated_notes: HashSet<_> =
@@ -131,6 +154,7 @@ not match the current commitment {}",
         SelectedBatch {
             txs,
             id,
+            parameters,
             account_updates,
             unauthenticated_notes,
         }

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -8,7 +8,7 @@ use miden_protocol::block::BlockNumber;
 use miden_protocol::note::Nullifier;
 use miden_protocol::transaction::TransactionId;
 
-use crate::domain::batch::SelectedBatch;
+use crate::domain::batch::{BatchParameters, SelectedBatch};
 use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::StateConflict;
 use crate::mempool::BatchBudget;
@@ -140,6 +140,7 @@ impl TransactionGraph {
     pub fn append_user_batch(
         &mut self,
         batch: &[Arc<AuthenticatedTransaction>],
+        parameters: BatchParameters,
     ) -> Result<(), StateConflict> {
         let batch_id =
             BatchId::from_transactions(batch.iter().map(|tx| tx.raw_proven_transaction()));
@@ -159,22 +160,30 @@ impl TransactionGraph {
         }
 
         let txs = batch.iter().map(GraphNode::id).collect::<Vec<_>>();
-        self.user_batches.insert(batch_id, txs);
+        self.user_batches.insert(batch_id, txs, parameters);
 
         Ok(())
     }
 
-    pub fn select_any_batch(&mut self, budget: BatchBudget) -> Option<SelectedBatch> {
+    pub fn select_any_batch(
+        &mut self,
+        budget: BatchBudget,
+        internal_parameters: BatchParameters,
+    ) -> Option<SelectedBatch> {
         self.select_user_batch()
-            .or_else(|| self.select_internal_batch(budget).into_batch())
+            .or_else(|| self.select_internal_batch(budget, internal_parameters).into_batch())
     }
 
-    pub fn select_full_batch(&mut self, budget: BatchBudget) -> Option<SelectedBatch> {
+    pub fn select_full_batch(
+        &mut self,
+        budget: BatchBudget,
+        internal_parameters: BatchParameters,
+    ) -> Option<SelectedBatch> {
         if let Some(user_batch) = self.select_user_batch() {
             return Some(user_batch);
         }
 
-        match self.select_internal_batch(budget) {
+        match self.select_internal_batch(budget, internal_parameters) {
             BatchSelection::Full(batch) => Some(batch),
             BatchSelection::Partial(batch) => {
                 // Full-batch selection is speculative; partial selections must not reserve txs.
@@ -211,9 +220,8 @@ impl TransactionGraph {
     /// Transactions can fail selection if they depend on any external transactions that have
     /// not yet been selected.
     fn try_select_user_batch_candidate(&mut self, candidate: BatchId) -> Option<SelectedBatch> {
-        let mut selected = SelectedBatch::builder();
-
-        let txs = self.user_batches.get_txs_contained_in_batch(&candidate)?;
+        let (txs, parameters) = self.user_batches.get(&candidate)?;
+        let mut selected = SelectedBatch::builder(parameters);
 
         for tx in txs {
             let Some(tx) = self.inner.selection_candidates().get(&tx).copied() else {
@@ -234,8 +242,12 @@ impl TransactionGraph {
         Some(selected.build())
     }
 
-    fn select_internal_batch(&mut self, mut budget: BatchBudget) -> BatchSelection {
-        let mut selected = SelectedBatch::builder();
+    fn select_internal_batch(
+        &mut self,
+        mut budget: BatchBudget,
+        parameters: BatchParameters,
+    ) -> BatchSelection {
+        let mut selected = SelectedBatch::builder(parameters);
 
         'outer: loop {
             // Select arbitrary candidate which is _not_ part of a user batch.
@@ -460,24 +472,32 @@ impl TransactionGraph {
 /// A bijective mapping of batches and their transactions.
 #[derive(Clone, Debug, PartialEq, Default)]
 struct BatchTxMap {
-    by_batch: HashMap<BatchId, Vec<TransactionId>>,
+    by_batch: HashMap<BatchId, UserBatch>,
     by_tx: HashMap<TransactionId, BatchId>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct UserBatch {
+    txs: Vec<TransactionId>,
+    parameters: BatchParameters,
+}
+
 impl BatchTxMap {
-    fn insert(&mut self, batch: BatchId, txs: Vec<TransactionId>) {
+    fn insert(&mut self, batch: BatchId, txs: Vec<TransactionId>, parameters: BatchParameters) {
         for tx in &txs {
             assert!(self.by_tx.insert(*tx, batch).is_none());
         }
-        assert!(self.by_batch.insert(batch, txs).is_none());
+        assert!(self.by_batch.insert(batch, UserBatch { txs, parameters }).is_none());
     }
 
     fn remove(&mut self, batch: &BatchId) -> Vec<TransactionId> {
-        let txs = self.by_batch.remove(batch).unwrap_or_default();
-        for tx in &txs {
+        let Some(batch) = self.by_batch.remove(batch) else {
+            return Vec::new();
+        };
+        for tx in &batch.txs {
             self.by_tx.remove(tx);
         }
-        txs
+        batch.txs
     }
 
     fn batches(&self) -> impl Iterator<Item = &BatchId> {
@@ -489,8 +509,8 @@ impl BatchTxMap {
         self.by_tx.get(tx)
     }
 
-    fn get_txs_contained_in_batch(&self, batch: &BatchId) -> Option<&[TransactionId]> {
-        self.by_batch.get(batch).map(Vec::as_slice)
+    fn get(&self, batch: &BatchId) -> Option<(&[TransactionId], BatchParameters)> {
+        self.by_batch.get(batch).map(|batch| (batch.txs.as_slice(), batch.parameters))
     }
 
     fn contains_tx(&self, tx: &TransactionId) -> bool {

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -61,7 +61,7 @@ use miden_protocol::transaction::TransactionHeader;
 use thiserror::Error;
 
 use crate::block_builder::SelectedBlock;
-use crate::domain::batch::SelectedBatch;
+use crate::domain::batch::{BatchParameters, SelectedBatch};
 use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::{MempoolSubmissionError, StateConflict};
 use crate::mempool::budget::BudgetStatus;
@@ -279,6 +279,7 @@ impl Mempool {
     pub fn add_user_batch(
         &mut self,
         txs: &[Arc<AuthenticatedTransaction>],
+        parameters: BatchParameters,
     ) -> Result<BlockNumber, MempoolSubmissionError> {
         assert!(!txs.is_empty(), "Cannot have a batch with no transactions");
 
@@ -303,7 +304,7 @@ impl Mempool {
         }
 
         self.transactions
-            .append_user_batch(txs)
+            .append_user_batch(txs, parameters)
             .map_err(MempoolSubmissionError::StateConflict)?;
 
         let telemetry = self.telemetry();
@@ -333,7 +334,10 @@ impl Mempool {
         name = "mempool.select_any_batch",
     )]
     pub fn select_any_batch(&mut self) -> Option<SelectedBatch> {
-        let batch = self.transactions.select_any_batch(self.config.batch_budget)?;
+        let parameters = BatchParameters {
+            reference_block: self.committed_chain_tip,
+        };
+        let batch = self.transactions.select_any_batch(self.config.batch_budget, parameters)?;
         let batch = self.append_selected_batch(batch);
         let telemetry = self.telemetry();
         miden_span_record!(
@@ -358,7 +362,10 @@ impl Mempool {
         name = "mempool.select_full_batch",
     )]
     pub fn select_full_batch(&mut self) -> Option<SelectedBatch> {
-        let batch = self.transactions.select_full_batch(self.config.batch_budget)?;
+        let parameters = BatchParameters {
+            reference_block: self.committed_chain_tip,
+        };
+        let batch = self.transactions.select_full_batch(self.config.batch_budget, parameters)?;
         let batch = self.append_selected_batch(batch);
         let telemetry = self.telemetry();
         miden_span_record!(

--- a/crates/block-producer/src/mempool/tests/add_user_batch.rs
+++ b/crates/block-producer/src/mempool/tests/add_user_batch.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use miden_protocol::batch::BatchId;
+use miden_protocol::block::BlockNumber;
 use pretty_assertions::assert_eq;
 
+use crate::domain::batch::BatchParameters;
 use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::{MempoolSubmissionError, StateConflict};
 use crate::mempool::Mempool;
@@ -28,7 +30,8 @@ fn user_batch_is_isolated_from_other_transactions() {
     let user_batch_txs = MockProvenTxBuilder::sequential();
     let user_batch_id =
         BatchId::from_transactions(user_batch_txs.iter().map(|tx| tx.raw_proven_transaction()));
-    uut.add_user_batch(&user_batch_txs).unwrap();
+    let user_parameters = BatchParameters { reference_block: 42.into() };
+    uut.add_user_batch(&user_batch_txs, user_parameters).unwrap();
 
     let batch_a = uut.select_any_batch().unwrap();
     let batch_b = uut.select_any_batch().unwrap();
@@ -41,10 +44,15 @@ fn user_batch_is_isolated_from_other_transactions() {
 
     assert_eq!(user.id(), user_batch_id);
     assert_eq!(user.transactions(), user_batch_txs.as_slice());
+    assert_eq!(user.parameters(), user_parameters);
 
     assert_eq!(conventional.transactions().len(), 2);
     assert!(conventional.transactions().contains(&conventional_a));
     assert!(conventional.transactions().contains(&conventional_b));
+    assert_eq!(
+        conventional.parameters(),
+        BatchParameters { reference_block: BlockNumber::GENESIS }
+    );
 }
 
 #[test]
@@ -53,7 +61,7 @@ fn user_batch_respects_batch_budget() {
     uut.config.batch_budget.transactions = 1;
 
     let user_batch_txs = MockProvenTxBuilder::sequential();
-    let result = uut.add_user_batch(&user_batch_txs[..2]);
+    let result = uut.add_user_batch(&user_batch_txs[..2], BatchParameters::for_tests());
 
     assert_matches!(result, Err(MempoolSubmissionError::CapacityExceeded));
 }
@@ -68,7 +76,10 @@ fn user_batch_capacity_counts_batched_uncommitted_transactions() {
     uut.add_transaction(conventional).unwrap();
     uut.select_any_batch().unwrap();
 
-    assert_matches!(uut.add_user_batch(&user_batch), Err(MempoolSubmissionError::CapacityExceeded));
+    assert_matches!(
+        uut.add_user_batch(&user_batch, BatchParameters::for_tests()),
+        Err(MempoolSubmissionError::CapacityExceeded)
+    );
 }
 
 #[test]
@@ -77,7 +88,7 @@ fn user_batch_counts_as_full_batch() {
     uut.config.batch_budget.transactions = 3;
 
     let user_batch_txs = MockProvenTxBuilder::sequential();
-    uut.add_user_batch(&user_batch_txs[..1]).unwrap();
+    uut.add_user_batch(&user_batch_txs[..1], BatchParameters::for_tests()).unwrap();
 
     let batch = uut.select_full_batch().unwrap();
     assert_eq!(batch.transactions(), &user_batch_txs[..1]);
@@ -90,7 +101,10 @@ fn user_batch_with_internal_state_conflicts_are_rejected() {
     let conflicting_a = tx_with_nullifiers(10, 0..1);
     let conflicting_b = tx_with_nullifiers(11, 0..1);
 
-    let result = uut.add_user_batch(&[conflicting_a.clone(), conflicting_b.clone()]);
+    let result = uut.add_user_batch(
+        &[conflicting_a.clone(), conflicting_b.clone()],
+        BatchParameters::for_tests(),
+    );
 
     assert_matches!(
         result,
@@ -111,7 +125,8 @@ fn user_batch_conflicts_with_existing_state_are_rejected() {
     let conflicting = tx_with_nullifiers(21, 5..6);
     let companion = tx_with_nullifiers(22, 6..7);
 
-    let result = uut.add_user_batch(&[conflicting.clone(), companion.clone()]);
+    let result =
+        uut.add_user_batch(&[conflicting.clone(), companion.clone()], BatchParameters::for_tests());
 
     assert_matches!(
         result,

--- a/crates/block-producer/src/server/mod.rs
+++ b/crates/block-producer/src/server/mod.rs
@@ -18,6 +18,7 @@ use url::Url;
 use crate::batch_builder::{BatchBuilder, BatchIntervals};
 use crate::block_builder::BlockBuilder;
 use crate::block_prover::BlockProver;
+use crate::domain::batch::BatchParameters;
 use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::MempoolSubmissionError;
 use crate::mempool::{BatchBudget, BlockBudget, Mempool, MempoolConfig, SharedMempool};
@@ -417,6 +418,9 @@ impl BlockProducerApi {
             "transaction inputs must match the batch's transactions"
         );
 
+        let parameters = BatchParameters {
+            reference_block: batch.reference_block_header().block_num(),
+        };
         let mut txs = Vec::with_capacity(batch.transactions().len());
         for (tx, inputs) in batch.transactions().iter().zip(inputs) {
             // SAFETY: We assume that the rpc component has verified the transaction proofs, as well
@@ -432,7 +436,7 @@ impl BlockProducerApi {
         let result = shared_mempool
             .lock()
             .map_err(MempoolSubmissionError::MempoolPoisoned)?
-            .add_user_batch(&txs);
+            .add_user_batch(&txs, parameters);
         result
     }
 

--- a/crates/store/src/errors.rs
+++ b/crates/store/src/errors.rs
@@ -335,10 +335,10 @@ pub enum GetBatchInputsError {
     #[error("set of blocks referenced by transactions is empty")]
     TransactionBlockReferencesEmpty,
     #[error(
-        "highest block number {highest_block_num} referenced by a transaction is newer than the latest block {latest_block_num}"
+        "batch reference block {reference_block_num} is newer than the latest block {latest_block_num}"
     )]
-    UnknownTransactionBlockReference {
-        highest_block_num: BlockNumber,
+    UnknownBatchReferenceBlock {
+        reference_block_num: BlockNumber,
         latest_block_num: BlockNumber,
     },
 }

--- a/crates/store/src/state/view/batch_inputs.rs
+++ b/crates/store/src/state/view/batch_inputs.rs
@@ -19,6 +19,7 @@ impl StateView {
     /// ## Inputs
     ///
     /// The function takes as input:
+    /// - The batch reference block is the block against which the batch is built.
     /// - The tx reference blocks are the set of blocks referenced by transactions in the batch.
     /// - The unauthenticated note commitments are the set of commitments of unauthenticated notes
     ///   consumed by all transactions in the batch. For these notes, we attempt to find inclusion
@@ -31,9 +32,10 @@ impl StateView {
     /// - A block inclusion proof for all tx reference blocks and for all blocks which are
     ///   referenced by a note inclusion proof.
     /// - Note inclusion proofs for all notes that were found in the DB.
-    /// - The block header that the batch should reference, i.e. the latest known block.
+    /// - The block header that the batch references.
     pub async fn get_batch_inputs(
         &self,
+        batch_reference_block_num: BlockNumber,
         tx_reference_blocks: BTreeSet<BlockNumber>,
         unauthenticated_note_commitments: BTreeSet<Word>,
     ) -> Result<BatchInputs, GetBatchInputsError> {
@@ -42,6 +44,12 @@ impl StateView {
         }
 
         let latest_block_num = self.tip();
+        let batch_reference_block_num = self.scope_block(batch_reference_block_num).ok_or(
+            GetBatchInputsError::UnknownBatchReferenceBlock {
+                reference_block_num: batch_reference_block_num,
+                latest_block_num: *latest_block_num,
+            },
+        )?;
 
         // First we grab note inclusion proofs for the known notes. These proofs only prove that the
         // note was included in a given block. We then also need to prove that each of those blocks
@@ -49,7 +57,10 @@ impl StateView {
         // report a note from a block the pinned snapshot cannot prove yet.
         let note_proofs = self
             .db
-            .select_note_inclusion_proofs(unauthenticated_note_commitments, latest_block_num)
+            .select_note_inclusion_proofs(
+                unauthenticated_note_commitments,
+                batch_reference_block_num,
+            )
             .await
             .map_err(GetBatchInputsError::SelectNoteInclusionProofError)?;
 
@@ -62,44 +73,35 @@ impl StateView {
         let mut blocks: BTreeSet<BlockNumber> = tx_reference_blocks;
         blocks.extend(note_blocks);
 
-        // Remove the latest block from the to-be-tracked blocks as it will be the reference block
-        // for the batch itself and thus added to the MMR within the batch kernel, so there is no
-        // need to prove its inclusion.
-        blocks.remove(&*latest_block_num);
+        // Remove the batch reference block from the tracked blocks. The batch kernel adds this
+        // block to the MMR, so the partial blockchain does not contain it.
+        blocks.remove(&*batch_reference_block_num);
 
-        // Scoping the blocks doubles as the validation that none lies beyond the view's tip. Scoped
-        // in descending order, so the first failure carries the highest block number.
+        // Batch validation ensures that all transaction reference blocks are at or below the batch
+        // reference block. The note query applies the same limit to note blocks.
         let scoped_blocks = blocks
             .iter()
-            .rev()
             .map(|&block| {
-                self.scope_block(block).ok_or(
-                    GetBatchInputsError::UnknownTransactionBlockReference {
-                        highest_block_num: block,
-                        latest_block_num: *latest_block_num,
-                    },
-                )
+                self.scope_block(block)
+                    .expect("batch input blocks must not exceed the batch reference block")
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
 
         // SAFETY:
-        // - The latest block num was retrieved from the view's blockchain from which we will
-        //   also retrieve the proofs, so it is guaranteed to exist in that chain.
-        // - Scoping above proved that no block in the set is greater than the latest block number
-        //   *and* the latest block num was removed from the set. Therefore only block numbers
-        //   smaller than latest block num remain in the set. Therefore all the block numbers are
-        //   guaranteed to exist in the chain state at latest block num.
-        let partial_mmr =
-            self.blockchain().partial_mmr_from_blocks(&blocks, *latest_block_num).expect(
-                "latest block num should exist and all blocks in set should be < than latest block",
-            );
+        // - The batch reference block was scoped against the view's blockchain.
+        // - The batch reference block was removed from the set.
+        // - All remaining block numbers are less than the batch reference block.
+        let partial_mmr = self
+            .blockchain()
+            .partial_mmr_from_blocks(&blocks, *batch_reference_block_num)
+            .expect("all tracked blocks must exist before the batch reference block");
 
         // Fetch the reference block of the batch as part of this query, so we can avoid looking it
         // up in a separate DB access.
         let mut headers = self
             .db
             .select_block_headers(
-                scoped_blocks.into_iter().chain(std::iter::once(latest_block_num)),
+                scoped_blocks.into_iter().chain(std::iter::once(batch_reference_block_num)),
             )
             .await
             .map_err(GetBatchInputsError::SelectBlockHeaderError)?;
@@ -108,7 +110,9 @@ impl StateView {
         let header_index = headers
             .iter()
             .enumerate()
-            .find_map(|(index, header)| (header.block_num() == *latest_block_num).then_some(index))
+            .find_map(|(index, header)| {
+                (header.block_num() == *batch_reference_block_num).then_some(index)
+            })
             .expect("DB should have returned the header of the batch reference block");
 
         // The order doesn't matter for PartialBlockchain::new, so swap remove is fine.
@@ -130,5 +134,67 @@ impl StateView {
             note_proofs,
             partial_block_chain,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_node_utils::fee::test_fee_params;
+    use miden_protocol::block::ValidatorKeys;
+    use miden_protocol::testing::random_secret_key::random_secret_key;
+
+    use super::*;
+    use crate::GenesisState;
+    use crate::state::State;
+
+    #[tokio::test]
+    async fn batch_inputs_use_an_explicit_reference_block() {
+        let data_directory = tempfile::tempdir().expect("tempdir should be created");
+        bootstrap_store(data_directory.path());
+        let (state, _block_writer, _proof_writer) = State::for_tests(data_directory.path()).await;
+
+        let inputs = state
+            .view()
+            .get_batch_inputs(
+                BlockNumber::GENESIS,
+                BTreeSet::from([BlockNumber::GENESIS]),
+                BTreeSet::new(),
+            )
+            .await
+            .expect("batch inputs should be returned");
+        assert_eq!(inputs.batch_reference_block_header.block_num(), BlockNumber::GENESIS);
+        assert_eq!(inputs.partial_block_chain.chain_length(), BlockNumber::GENESIS);
+
+        let error = state
+            .view()
+            .get_batch_inputs(
+                BlockNumber::GENESIS.child(),
+                BTreeSet::from([BlockNumber::GENESIS]),
+                BTreeSet::new(),
+            )
+            .await
+            .expect_err("a batch reference after the tip should fail");
+        assert!(matches!(
+            error,
+            GetBatchInputsError::UnknownBatchReferenceBlock {
+                reference_block_num,
+                latest_block_num,
+            } if reference_block_num == BlockNumber::GENESIS.child()
+                && latest_block_num == BlockNumber::GENESIS
+        ));
+    }
+
+    fn bootstrap_store(path: &std::path::Path) {
+        let signer = random_secret_key();
+        let genesis_state = GenesisState::new(
+            vec![],
+            test_fee_params(),
+            1,
+            1,
+            ValidatorKeys::new(vec![signer.public_key()]).expect("validator keys should be valid"),
+        );
+        let genesis_block = genesis_state.into_block().expect("genesis block should be created");
+
+        State::bootstrap(genesis_block, path).expect("store should bootstrap");
     }
 }


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Closes #2039.

The node currently ignores the specified reference block, and instead processes it the same as an internally selected batch i.e. uses the chain tip to build against.

This PR fixes this by wiring the original reference block through, and utilising that instead when the batch is built as part of a block. This metadata is also added to internal blocks so that the flows remain consistent.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "node"
impact      = "fixed"
description = "Respect user batch's reference block instead of always using the chain tip"
```
