### PR TITLE
0.16.0-rc.4 release bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "miden-benchmark"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-large-account-benchmark"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "miden-network-monitor"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-block-producer"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-db"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-grpc-error-macro"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "build-rs",
  "codegen",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-rpc"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-store"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-stress-test"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "clap",
  "fs-err",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-tracing"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-tracing-macro"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "miden-node-utils"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "backon",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "miden-ntx-builder"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "backon",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "miden-validator"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -8534,7 +8534,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ license      = "MIT"
 readme       = "README.md"
 repository   = "https://github.com/0xMiden/node"
 rust-version = "1.96.1"
-version      = "0.16.0-rc.3"
+version      = "0.16.0-rc.4"
 
 # Optimize the cryptography for faster tests involving account creation.
 [profile.test.package.miden-crypto]
@@ -44,17 +44,17 @@ debug = true
 
 [workspace.dependencies]
 # Workspace crates.
-miden-node-block-producer   = { path = "crates/block-producer", version = "0.16.0-rc.3" }
-miden-node-db               = { path = "crates/db", version = "0.16.0-rc.3" }
-miden-node-grpc-error-macro = { path = "crates/grpc-error-macro", version = "0.16.0-rc.3" }
-miden-node-proto            = { path = "crates/proto", version = "0.16.0-rc.3" }
-miden-node-proto-build      = { path = "proto", version = "0.16.0-rc.3" }
-miden-node-rpc              = { path = "crates/rpc", version = "0.16.0-rc.3" }
-miden-node-store            = { path = "crates/store", version = "0.16.0-rc.3" }
+miden-node-block-producer   = { path = "crates/block-producer", version = "0.16.0-rc.4" }
+miden-node-db               = { path = "crates/db", version = "0.16.0-rc.4" }
+miden-node-grpc-error-macro = { path = "crates/grpc-error-macro", version = "0.16.0-rc.4" }
+miden-node-proto            = { path = "crates/proto", version = "0.16.0-rc.4" }
+miden-node-proto-build      = { path = "proto", version = "0.16.0-rc.4" }
+miden-node-rpc              = { path = "crates/rpc", version = "0.16.0-rc.4" }
+miden-node-store            = { path = "crates/store", version = "0.16.0-rc.4" }
 miden-node-test-macro       = { path = "crates/test-macro" }
-miden-node-tracing          = { path = "crates/tracing", version = "0.16.0-rc.3" }
-miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.16.0-rc.3" }
-miden-node-utils            = { path = "crates/utils", version = "0.16.0-rc.3" }
+miden-node-tracing          = { path = "crates/tracing", version = "0.16.0-rc.4" }
+miden-node-tracing-macro    = { path = "crates/tracing-macro", version = "0.16.0-rc.4" }
+miden-node-utils            = { path = "crates/utils", version = "0.16.0-rc.4" }
 
 # miden-protocol dependencies. These should be updated in sync.
 miden-block-prover = { version = "=0.16.0-rc.4" }


### PR DESCRIPTION
title.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->


```toml
changelog = "none"
reason    = "Internal change only."
```
