### PR TITLE
Simplify docker with Kache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 **/.env
 **/.git
 **/.gitignore
+/.github
 **/.project
 **/.settings
 **/.toolstarget
@@ -26,10 +27,13 @@
 **/npm-debug.log
 **/secrets.dev.yaml
 **/values.dev.yaml
+/docs
+/AGENTS.md
+/CLAUDE.md
 ./target
 /target
 LICENSE
-README.md
+**/README.md
 accounts
 genesis.dat
 miden-store.*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,12 +99,12 @@ jobs:
           images="$(
             jq -cn '
               [
-                {"component":"node","bin":"miden-node","port":57291},
-                {"component":"validator","bin":"miden-validator","port":50101},
-                {"component":"ntx-builder","bin":"miden-ntx-builder","port":50301},
-                {"component":"remote-prover","bin":"miden-remote-prover","port":50051},
-                {"component":"network-monitor","bin":"miden-network-monitor","port":3000},
-                {"component":"node-tps-benchmark","bin":"miden-benchmark","target":"runtime-tool"}
+                {"component":"node",               "bin":"miden-node",            "port":57291, "target":"runtime"},
+                {"component":"validator",          "bin":"miden-validator",       "port":50101, "target":"runtime"},
+                {"component":"ntx-builder",        "bin":"miden-ntx-builder",     "port":50301, "target":"runtime"},
+                {"component":"remote-prover",      "bin":"miden-remote-prover",   "port":50051, "target":"runtime"},
+                {"component":"network-monitor",    "bin":"miden-network-monitor", "port":3000,  "target":"runtime"},
+                {"component":"node-tps-benchmark", "bin":"miden-benchmark",                     "target":"runtime-tool"}
               ]
             '
           )"
@@ -187,7 +187,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.commit }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Build binaries
@@ -218,31 +217,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.commit }}
-          fetch-depth: 0
           persist-credentials: false
-
-      - name: Resolve build inputs
-        id: build-inputs
-        env:
-          COMPONENT: ${{ matrix.component }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${COMPONENT}" == "faucet" ]]; then
-            context="$(docker compose --profile faucet config --format json | jq -er '.services.faucet.build.context')"
-            echo "context=${context}" >> "${GITHUB_OUTPUT}"
-            echo "file=Dockerfile" >> "${GITHUB_OUTPUT}"
-          else
-            echo "context=." >> "${GITHUB_OUTPUT}"
-            echo "file=./Dockerfile" >> "${GITHUB_OUTPUT}"
-          fi
 
       - name: Validate Docker image
         uses: WarpBuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9
         with:
-          context: ${{ steps.build-inputs.outputs.context }}
+          context: .
           push: false
-          file: ${{ steps.build-inputs.outputs.file }}
+          file: ./Dockerfile
           target: ${{ matrix.target }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
@@ -265,7 +247,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.commit }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Dry-run Compose publishing
@@ -305,7 +286,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.commit }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Log in to the Container registry
@@ -315,28 +295,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Resolve build inputs
-        id: build-inputs
-        env:
-          COMPONENT: ${{ matrix.component }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${COMPONENT}" == "faucet" ]]; then
-            context="$(docker compose --profile faucet config --format json | jq -er '.services.faucet.build.context')"
-            echo "context=${context}" >> "${GITHUB_OUTPUT}"
-            echo "file=Dockerfile" >> "${GITHUB_OUTPUT}"
-          else
-            echo "context=." >> "${GITHUB_OUTPUT}"
-            echo "file=./Dockerfile" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Build and push Docker image
         uses: WarpBuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9
         with:
-          context: ${{ steps.build-inputs.outputs.context }}
+          context: .
           push: true
-          file: ${{ steps.build-inputs.outputs.file }}
+          file: ./Dockerfile
           target: ${{ matrix.target }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
@@ -363,7 +327,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.preflight.outputs.commit }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Log in to the Container registry

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -168,9 +168,42 @@ jobs:
             echo "tag=${ref_name}"
           } >> "${GITHUB_OUTPUT}"
 
-  dry-run-docker:
-    name: Build ${{ matrix.component }}
+  build-binaries:
+    name: Build binaries (${{ matrix.platform }})
     needs: preflight
+    runs-on: warp-ubuntu-latest-x64-8x
+    permissions:
+      contents: read
+      # WarpBuild uses OIDC to authenticate its remote builder.
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.preflight.outputs.commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build binaries
+        uses: WarpBuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9
+        with:
+          context: .
+          push: false
+          file: ./Dockerfile
+          target: builder
+          platforms: ${{ matrix.platform }}
+          profile-name: ${{ vars.WARPBUILD_DOCKER_BUILDER_PROFILE }}
+          pull: true
+
+  dry-run-docker:
+    name: Validate ${{ matrix.component }} image
+    needs: [preflight, build-binaries]
     runs-on: warp-ubuntu-latest-x64-8x
     permissions:
       contents: read
@@ -204,7 +237,7 @@ jobs:
             echo "file=./Dockerfile" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Build Docker image
+      - name: Validate Docker image
         uses: WarpBuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9
         with:
           context: ${{ steps.build-inputs.outputs.context }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,15 @@
 
 ARG RUST_VERSION=1.98
 ARG DEBIAN_RELEASE=bookworm
+ARG KACHE_VERSION=0.16.0
 ARG BIN
 ARG PORT
-# Builder stage the runtime binary is copied from: `builder-ci` compiles one
-# binary per image (concurrent CI matrix builds), `builder-local` compiles
-# every binary in one invocation (sequential local builds).
-ARG BUILDER=builder-ci
 
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} AS build-base
+ARG KACHE_VERSION
+ARG TARGETARCH
 # Used by our codegen code.
 RUN rustup component add rustfmt
-# Disable incremental compilation: its reuse depends on the same mtime-based
-# fingerprinting that the shared CI target cache cannot make safe (see
-# builder-ci below), and release builds gain nothing from it anyway. Dep
-# .rlibs in the /app/target cache mount still accelerate builds.
-ENV CARGO_INCREMENTAL=0
 # Install build dependencies. RocksDB is compiled from source by librocksdb-sys.
 RUN apt-get update && \
     apt-get -y upgrade && \
@@ -27,79 +21,80 @@ RUN apt-get update && \
         cmake \
         pkg-config \
         libssl-dev \
+        curl \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*
+
+# Verify the release archive before Kache becomes a compiler wrapper.
+RUN case "${TARGETARCH}" in \
+        amd64) \
+            KACHE_ARCH=x86_64; \
+            KACHE_SHA256=caee657c662379475af2a0a7611ad32a6d053822036c1ec191bb8fd1c826d54b \
+            ;; \
+        arm64) \
+            KACHE_ARCH=aarch64; \
+            KACHE_SHA256=6eabb67867022eecdbfffe43c16e75b5c5b561983742bda3c900a4cb4c50e4a7 \
+            ;; \
+        *) \
+            echo "Unsupported target architecture: ${TARGETARCH}" >&2; \
+            exit 1 \
+            ;; \
+    esac && \
+    KACHE_ARCHIVE="kache-${KACHE_ARCH}-unknown-linux-musl.tar.gz" && \
+    curl --fail --location --silent --show-error \
+        "https://github.com/kunobi-ninja/kache/releases/download/v${KACHE_VERSION}/${KACHE_ARCHIVE}" \
+        --output "/tmp/${KACHE_ARCHIVE}" && \
+    printf '%s  %s\n' "${KACHE_SHA256}" "/tmp/${KACHE_ARCHIVE}" | \
+        sha256sum --check --strict && \
+    tar -xzf "/tmp/${KACHE_ARCHIVE}" -C /usr/local/bin kache && \
+    rm "/tmp/${KACHE_ARCHIVE}"
+
+# These flags are stable build inputs. Kache must classify them before it can
+# cache native objects from RocksDB and the other C and C++ dependencies.
+RUN printf '%s\n' \
+        '[cc]' \
+        'extra_allowlist_flags = [' \
+        '    "-fmerge-all-constants",' \
+        '    "-mno-omit-leaf-frame-pointer",' \
+        ']' \
+        > /etc/kache.toml
+
+ENV CARGO_INCREMENTAL=0 \
+    RUSTC_WRAPPER=kache \
+    CC="kache cc" \
+    CXX="kache c++" \
+    CC_KNOWN_WRAPPER_CUSTOM=kache \
+    KACHE_BASE_DIR=/app \
+    KACHE_CACHE_DIR=/var/cache/kache \
+    KACHE_CONFIG=/etc/kache.toml \
+    KACHE_AUTO_GC=true \
+    KACHE_MAX_SIZE=30GiB \
+    KACHE_RUNTIME_DIR=/tmp/kache-runtime
 WORKDIR /app
 
-FROM build-base AS builder-ci
-ARG BIN
-# All cache mounts are keyed by BIN and TARGETARCH. The arch keying keeps
-# amd64/arm64 artifacts apart. The BIN keying serves two purposes: for the
-# target mount, each binary enables different feature sets on shared deps, so
-# a shared locked mount would only serialize matrix builds on artifacts they
-# cannot reuse; for the registry/git-db mounts, two concurrent cargo processes
-# extracting the same crate race on creating `.cargo-ok`, and the loser fails
-# the build ("failed to open .cargo-ok ... File exists") — keying by BIN
-# removes all concurrency on a mount, since builds of the same binary are
-# already serialized by the locked target mount. The cost is one registry
-# copy per binary per arch.
-#
-# The target mount is sharing=locked because the touch-then-build sequence
-# below must not interleave with another build's writes; the registry/git-db
-# mounts stay sharing=shared since the keying already guarantees exclusivity.
+FROM build-base AS builder
+ARG CARGO_BUILD_JOBS
 ARG TARGETARCH
-COPY . .
-# Cargo fingerprints workspace path crates by mtime: a crate is rebuilt only
-# if a source file is newer than the cached artifact. The /app/target mount is
-# shared across branches and PRs on the persistent builder, so a source mtime
-# older than another build's artifacts (warm checkouts, git-derived
-# timestamps) makes Cargo silently link a stale, incompatible .rlib. Touch all
-# sources so workspace crates always rebuild; external deps are fingerprinted
-# by checksum and stay cached. The touch must happen after the locked target
-# mount is acquired — a concurrent build of another branch could otherwise
-# write artifacts newer than our sources after we touch them — and prunes
-# ./target from the walk so cached artifacts keep their mtimes.
-#
-# Cargo's git DB is cached but checkout worktrees stay ephemeral; shared
-# checkouts are fragile under concurrent or interrupted builds.
+COPY Cargo.toml Cargo.lock ./
+COPY .cargo/config.toml .cargo/config.toml
+COPY bin/ bin/
+COPY crates/ crates/
+COPY proto/ proto/
+# Cargo loads each workspace member before it selects the requested binaries.
+COPY xtask/Cargo.toml xtask/Cargo.toml
+COPY xtask/src/main.rs xtask/src/main.rs
+# Kache stores compiler outputs by content. The target directory stays local to
+# this build and does not depend on source timestamps from another checkout.
+# The locks prevent concurrent builds from writing to the same cache mounts.
 #
 # An interrupted build can leave a partially extracted crate in the cached
 # registry (source dir present, `.cargo-ok` missing or empty). Cargo never
 # recovers from this, so drop any such partial extraction before building.
-RUN --mount=type=cache,sharing=shared,id=cargo-registry-${BIN}-${TARGETARCH},target=/usr/local/cargo/registry \
-    --mount=type=cache,sharing=shared,id=cargo-git-${BIN}-${TARGETARCH},target=/usr/local/cargo/git/db \
-    --mount=type=cache,sharing=locked,id=app-target-${BIN}-${TARGETARCH},target=/app/target \
-    if [ -d /usr/local/cargo/registry/src ]; then \
-        find /usr/local/cargo/registry/src -mindepth 2 -maxdepth 2 -type d \
-            '!' -exec test -s '{}/.cargo-ok' ';' -exec rm -rf '{}' +; \
-    fi && \
-    find . -path ./target -prune -o -type f -exec touch {} + && \
-    cargo build --release --locked --bin ${BIN} && \
-    mkdir -p /app/bin && \
-    cp /app/target/release/${BIN} /app/bin/${BIN}
-
-# Local builder: compiles every image's binary in one cargo invocation. Local
-# images are built sequentially on one machine, so the per-BIN mount keying
-# above would only multiply work (each binary compiling its own copy of the
-# dependency tree, including RocksDB). This stage never references BIN, so its
-# layers are identical across all image builds: the first build compiles and
-# the rest hit cache.
-#
-# Sources are not touched here: a local context preserves real mtimes and git
-# updates the mtime of anything it changes, so Cargo's fingerprinting is sound
-# and rebuilds are genuinely incremental. The `.cargo-ok` heal is kept — an
-# interrupted (Ctrl-C) build corrupts the cached registry just like in CI.
-#
-# Parallelism is capped at ~2GiB of memory per job: the release profile
-# carries full debug info, and an uncapped build OOMs the default ~8GiB
-# Docker Desktop VM. Pass CARGO_BUILD_JOBS to override.
-FROM build-base AS builder-local
-ARG TARGETARCH
-ARG CARGO_BUILD_JOBS
-COPY . .
-RUN --mount=type=cache,sharing=shared,id=cargo-registry-local-${TARGETARCH},target=/usr/local/cargo/registry \
-    --mount=type=cache,sharing=shared,id=cargo-git-local-${TARGETARCH},target=/usr/local/cargo/git/db \
-    --mount=type=cache,sharing=locked,id=app-target-local-${TARGETARCH},target=/app/target \
+# Use at most one Cargo job per 2 GiB of memory. Set CARGO_BUILD_JOBS to
+# override the calculated limit.
+RUN --mount=type=cache,sharing=locked,id=cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry \
+    --mount=type=cache,sharing=locked,id=cargo-git-${TARGETARCH},target=/usr/local/cargo/git/db \
+    --mount=type=cache,sharing=locked,id=kache-v1-${TARGETARCH},target=/var/cache/kache \
     if [ -d /usr/local/cargo/registry/src ]; then \
         find /usr/local/cargo/registry/src -mindepth 2 -maxdepth 2 -type d \
             '!' -exec test -s '{}/.cargo-ok' ';' -exec rm -rf '{}' +; \
@@ -107,7 +102,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo-registry-local-${TARGETARCH},targ
     JOBS="${CARGO_BUILD_JOBS:-$(awk -v ncpu="$(nproc)" \
         '/MemTotal/ { j = int($2 / (2 * 1024 * 1024)); if (j < 1) j = 1; if (j > ncpu) j = ncpu; print j }' \
         /proc/meminfo)}" && \
-    cargo build --release --locked --jobs "$JOBS" \
+    cargo build --release --locked --jobs "${JOBS}" \
         --bin miden-node \
         --bin miden-validator \
         --bin miden-ntx-builder \
@@ -121,10 +116,9 @@ RUN --mount=type=cache,sharing=shared,id=cargo-registry-local-${TARGETARCH},targ
         /app/target/release/miden-network-monitor \
         /app/target/release/miden-remote-prover \
         /app/target/release/miden-benchmark \
-        /app/bin/
-
-# Alias stage so the runtime COPY below can select a builder via build arg.
-FROM ${BUILDER} AS build-result
+        /app/bin/ && \
+    rm -rf /app/target && \
+    kache gc
 
 # Baseline runtime image with runtime dependencies installed.
 FROM debian:${DEBIAN_RELEASE}-slim AS runtime-base
@@ -145,7 +139,7 @@ RUN groupadd --gid 10001 miden && \
 
 FROM runtime-base AS runtime-common
 ARG BIN
-COPY --from=build-result /app/bin/${BIN} /usr/local/bin/${BIN}
+COPY --from=builder /app/bin/${BIN} /usr/local/bin/${BIN}
 LABEL org.opencontainers.image.authors=devops@miden.team \
     org.opencontainers.image.url=https://0xMiden.github.io/ \
     org.opencontainers.image.documentation=https://github.com/0xMiden/node \

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,6 @@ COMPOSE_OVERRIDE_ARGS = $(if $(COMPOSE_OVERRIDE_FILE),-f docker-compose.yml -f $
 DOCKER_COMMAND ?= docker
 DOCKER_PLATFORM ?=
 DOCKER_PLATFORM_ARG = $(if $(DOCKER_PLATFORM),--platform $(DOCKER_PLATFORM),)
-# Dockerfile builder stage to compile binaries in. The default `builder-ci`
-# compiles one binary per image with per-BIN cache mounts (matches CI);
-# local-network-build overrides it with `builder-local`, which compiles all
-# binaries once and shares the result across every image build.
-DOCKER_BUILDER ?= builder-ci
 DOCKER_PULL_ARG ?= --pull
 DOCKER_VERSION ?= $(shell awk -F '"' '/^version[[:space:]]*=/ { print $$2; exit }' Cargo.toml)
 CONFIG_DIR = .config
@@ -190,10 +185,7 @@ install-large-account-benchmark: ## Installs the large account benchmark binary
 # --- docker --------------------------------------------------------------------------------------
 
 .PHONY: local-network-build
-# Local builds are sequential on one machine, so compile all binaries in one
-# shared builder stage (see builder-local in the Dockerfile) instead of once
-# per image, and skip re-pulling base images on every build.
-local-network-build: DOCKER_BUILDER = builder-local
+# Compile all binaries in one shared builder stage. Skip repeated image pulls.
 local-network-build: DOCKER_PULL_ARG =
 local-network-build: docker-build ## Builds Docker images used by the local development network
 
@@ -225,7 +217,6 @@ docker-build-node: ## Builds the Miden node using Docker
                  --build-arg CREATED="$$CREATED" \
                  --build-arg VERSION="$$VERSION" \
                  --build-arg COMMIT="$$COMMIT" \
-                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
                  --build-arg BIN=miden-node \
                  --build-arg PORT=57291 \
                  -t miden-node .
@@ -239,7 +230,6 @@ docker-build-validator: ## Builds the Miden validator using Docker
                  --build-arg CREATED="$$CREATED" \
                  --build-arg VERSION="$$VERSION" \
                  --build-arg COMMIT="$$COMMIT" \
-                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
                  --build-arg BIN=miden-validator \
                  --build-arg PORT=50101 \
                  -t miden-validator .
@@ -253,7 +243,6 @@ docker-build-ntx-builder: ## Builds the Miden network transaction builder using 
                  --build-arg CREATED="$$CREATED" \
                  --build-arg VERSION="$$VERSION" \
                  --build-arg COMMIT="$$COMMIT" \
-                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
                  --build-arg BIN=miden-ntx-builder \
                  --build-arg PORT=50301 \
                  -t miden-ntx-builder .
@@ -267,7 +256,6 @@ docker-build-monitor: ## Builds the network monitor using Docker
                  --build-arg CREATED="$$CREATED" \
                  --build-arg VERSION="$$VERSION" \
                  --build-arg COMMIT="$$COMMIT" \
-                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
                  --build-arg BIN=miden-network-monitor \
                  --build-arg PORT=3000 \
                  -t miden-network-monitor .
@@ -281,7 +269,6 @@ docker-build-remote-prover: ## Builds the remote prover using Docker
                  --build-arg CREATED="$$CREATED" \
                  --build-arg VERSION="$$VERSION" \
                  --build-arg COMMIT="$$COMMIT" \
-                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
                  --build-arg BIN=miden-remote-prover \
                  --build-arg PORT=50051 \
                  -t miden-remote-prover .
@@ -295,7 +282,6 @@ docker-build-benchmark: ## Builds the benchmark and seed tool image using Docker
                  --build-arg CREATED="$$CREATED" \
                  --build-arg VERSION="$$VERSION" \
                  --build-arg COMMIT="$$COMMIT" \
-                 --build-arg BUILDER="$(DOCKER_BUILDER)" \
                  --build-arg BIN=miden-benchmark \
                  --target runtime-tool \
                  -t miden-node-tps-benchmark .


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

We've been struggling with caching in docker builds for a while now.

- `cargo chef` doesn't work well for our workflow
  - any dependency change invalidates the cache
  - release version bump invalidates the cache
- manual caching has been error prone and easy to screw up and also regularly explodes the cache limit

We've also been building each binary in parallel (in CI), which strains the disk space on the runner by effectively duplicating every dependency.

This PR does the following:

- CI now builds all binaries in one job. This is the same as how the local build works.
- Adds `kache` (a Rust sccache) to perform the caching.
  - Local testing showed a 80% warm build improvement.
  - 20% slower cold (but this is now unlikely to happen).
  - It caches and evicts per dependency, so this should result in a very warm cache constantly.
- Since ci and local are now similar, we only have a single flow.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Allowed scopes: rpc, protocol, docs, node, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, migration, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```
