### PR TITLE
Reserve fee notes for batch builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8381,13 +8381,14 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff 0.14.0",
  "group 0.14.0",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]

--- a/crates/block-producer/src/errors.rs
+++ b/crates/block-producer/src/errors.rs
@@ -78,6 +78,12 @@ pub enum MempoolSubmissionError {
     #[error("transaction {transaction_id} does not contain a non-zero TX_FEE output note")]
     MissingFee { transaction_id: TransactionId },
 
+    #[error("transaction {transaction_id} consumes in-flight TX_FEE notes: {note_ids:?}")]
+    ConsumesInflightFeeNotes {
+        transaction_id: TransactionId,
+        note_ids: Vec<Word>,
+    },
+
     #[error("mempool lock is poisoned")]
     #[grpc(internal)]
     MempoolPoisoned(#[source] MempoolPoisonError),

--- a/crates/block-producer/src/mempool/graph/dag.rs
+++ b/crates/block-producer/src/mempool/graph/dag.rs
@@ -278,6 +278,12 @@ where
     pub(super) fn get_mut(&mut self, node: &N::Id) -> Option<&mut N> {
         self.nodes.get_mut(node)
     }
+
+    /// Returns the node that created the specified note.
+    pub(super) fn note_creator(&self, note: &miden_protocol::Word) -> Option<&N> {
+        let creator = self.state.note_creator(note)?;
+        self.nodes.get(&creator)
+    }
 }
 
 // GRAPH DAG TESTS

--- a/crates/block-producer/src/mempool/graph/state.rs
+++ b/crates/block-producer/src/mempool/graph/state.rs
@@ -171,6 +171,11 @@ where
     pub fn output_note_count(&self) -> usize {
         self.notes_created.len()
     }
+
+    /// Returns the node that created the specified note.
+    pub(super) fn note_creator(&self, note: &Word) -> Option<K> {
+        self.notes_created.get(note).copied()
+    }
 }
 
 /// Tracks the per-account state transitions that are in-flight within the mempool graph.

--- a/crates/block-producer/src/mempool/graph/transaction.rs
+++ b/crates/block-producer/src/mempool/graph/transaction.rs
@@ -6,7 +6,7 @@ use miden_protocol::account::AccountId;
 use miden_protocol::batch::BatchId;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::Nullifier;
-use miden_protocol::transaction::TransactionId;
+use miden_protocol::transaction::{OutputNote, TransactionId};
 
 use crate::domain::batch::{BatchParameters, SelectedBatch};
 use crate::domain::transaction::AuthenticatedTransaction;
@@ -132,6 +132,19 @@ impl TransactionGraph {
 
     pub fn append(&mut self, tx: Arc<AuthenticatedTransaction>) -> Result<(), StateConflict> {
         self.inner.append(tx)
+    }
+
+    /// Returns the transaction and output note that created the specified note ID.
+    pub fn output_note(&self, note_id: Word) -> Option<(TransactionId, &OutputNote)> {
+        let creator = self.inner.note_creator(&note_id)?;
+        let output_note = creator
+            .raw_proven_transaction()
+            .output_notes()
+            .iter()
+            .find(|note| note.id().as_word() == note_id)
+            .expect("the note creator must contain the indexed output note");
+
+        Some((creator.id(), output_note))
     }
 
     /// Appends the transactions into the graph as an atomic unit.

--- a/crates/block-producer/src/mempool/mod.rs
+++ b/crates/block-producer/src/mempool/mod.rs
@@ -57,7 +57,8 @@ use std::sync::{Arc, LockResult, Mutex, MutexGuard};
 use miden_node_tracing::{ErrorReport, debug, miden_instrument, miden_span_record};
 use miden_protocol::batch::{BatchId, ProvenBatch};
 use miden_protocol::block::{BlockHeader, BlockNumber};
-use miden_protocol::transaction::TransactionHeader;
+use miden_protocol::transaction::{OutputNote, TransactionHeader, TransactionId};
+use miden_standards::note::TxFeeNote;
 use thiserror::Error;
 
 use crate::block_builder::SelectedBlock;
@@ -251,6 +252,7 @@ impl Mempool {
 
         self.authentication_staleness_check(tx.authentication_height())?;
         self.expiration_check(tx.expires_at())?;
+        self.fee_note_consumption_check(&tx)?;
 
         // Insert the transaction node.
         self.transactions
@@ -721,6 +723,46 @@ impl Mempool {
         }
 
         Ok(())
+    }
+
+    /// Rejects transactions that consume an uncommitted `TX_FEE` note.
+    fn fee_note_consumption_check(
+        &self,
+        tx: &AuthenticatedTransaction,
+    ) -> Result<(), MempoolSubmissionError> {
+        let fee_script_root = TxFeeNote::script_root();
+        let is_fee_note = |note: &OutputNote| {
+            note.recipient()
+                .is_some_and(|recipient| recipient.script().root() == fee_script_root)
+        };
+
+        let note_ids = tx
+            .unauthenticated_note_ids()
+            .filter(|note_id| {
+                let Some((creator, note)) = self.transactions.output_note(*note_id) else {
+                    return false;
+                };
+
+                !self.transaction_is_committed(creator) && is_fee_note(note)
+            })
+            .collect::<Vec<_>>();
+
+        if note_ids.is_empty() {
+            Ok(())
+        } else {
+            Err(MempoolSubmissionError::ConsumesInflightFeeNotes {
+                transaction_id: tx.id(),
+                note_ids,
+            })
+        }
+    }
+
+    fn transaction_is_committed(&self, transaction_id: TransactionId) -> bool {
+        self.committed_blocks
+            .iter()
+            .flat_map(|block| block.batches.iter())
+            .flat_map(|batch| batch.transactions().as_slice())
+            .any(|transaction| transaction.id() == transaction_id)
     }
 }
 

--- a/crates/block-producer/src/mempool/tests/add_transaction.rs
+++ b/crates/block-producer/src/mempool/tests/add_transaction.rs
@@ -2,11 +2,15 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use miden_protocol::Word;
+use miden_protocol::batch::ProvenBatch;
 use miden_protocol::block::BlockHeader;
+use miden_protocol::transaction::{OutputNote, PublicOutputNote};
 
 use crate::domain::transaction::AuthenticatedTransaction;
 use crate::errors::{MempoolSubmissionError, StateConflict};
 use crate::mempool::Mempool;
+use crate::test_utils::batch::TransactionBatchConstructor;
+use crate::test_utils::note::mock_fee_note;
 use crate::test_utils::{MockProvenTxBuilder, mock_account_id};
 
 #[test]
@@ -306,6 +310,59 @@ fn unknown_unauthenticated_notes_are_rejected() {
             StateConflict::UnauthenticatedNotesMissing(..)
         ))
     );
+}
+
+#[test]
+fn inflight_fee_note_consumption_is_rejected() {
+    let (mut uut, _) = Mempool::for_tests();
+    let (producer, consumer, fee_note_id) = fee_note_dependency();
+
+    uut.add_transaction(producer).unwrap();
+    let reference = uut.clone();
+    let result = uut.add_transaction(consumer.clone());
+
+    assert_matches!(
+        result,
+        Err(MempoolSubmissionError::ConsumesInflightFeeNotes {
+            transaction_id,
+            note_ids,
+        }) if transaction_id == consumer.id() && note_ids == vec![fee_note_id]
+    );
+    assert_eq!(uut, reference);
+}
+
+#[test]
+fn committed_fee_note_consumption_is_accepted() {
+    let (mut uut, _) = Mempool::for_tests();
+    let (producer, consumer, _) = fee_note_dependency();
+
+    uut.add_transaction(producer.clone()).unwrap();
+    uut.select_any_batch().unwrap();
+    uut.commit_batch(Arc::new(ProvenBatch::mocked_from_transactions([
+        producer.raw_proven_transaction()
+    ])));
+    let block = uut.select_block();
+    let header = BlockHeader::mock(block.block_number, None, None, &[], Word::empty());
+    uut.commit_block(&header);
+
+    uut.add_transaction(consumer).unwrap();
+}
+
+fn fee_note_dependency() -> (Arc<AuthenticatedTransaction>, Arc<AuthenticatedTransaction>, Word) {
+    let fee_note = mock_fee_note(100);
+    let fee_note_id = fee_note.id().as_word();
+    let producer = MockProvenTxBuilder::with_account_index(100)
+        .output_notes(vec![OutputNote::Public(PublicOutputNote::new(fee_note.clone()).unwrap())])
+        .build();
+    let consumer = MockProvenTxBuilder::with_account_index(101)
+        .unauthenticated_notes(vec![fee_note])
+        .build();
+
+    (
+        Arc::new(AuthenticatedTransaction::from_inner(producer)),
+        Arc::new(AuthenticatedTransaction::from_inner(consumer)),
+        fee_note_id,
+    )
 }
 
 mod account_state {

--- a/crates/block-producer/src/test_utils/note.rs
+++ b/crates/block-producer/src/test_utils/note.rs
@@ -1,5 +1,8 @@
+use miden_protocol::Word;
+use miden_protocol::asset::FungibleAsset;
 use miden_protocol::note::Note;
 use miden_protocol::transaction::{OutputNote, PublicOutputNote};
+use miden_standards::note::TxFeeNote;
 use miden_standards::testing::note::NoteBuilder;
 use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::SeedableRng;
@@ -13,4 +16,16 @@ pub fn mock_note(num: u8) -> Note {
 
 pub fn mock_output_note(num: u8) -> OutputNote {
     OutputNote::Public(PublicOutputNote::new(mock_note(num)).unwrap())
+}
+
+pub fn mock_fee_note(num: u8) -> Note {
+    let asset = FungibleAsset::new(FungibleAsset::mock_issuer(), u64::from(num) + 1).unwrap();
+
+    TxFeeNote::builder()
+        .sender(mock_account_id(num))
+        .serial_number(Word::from([u32::from(num), 0, 0, 0]))
+        .asset(asset)
+        .build()
+        .unwrap()
+        .into()
 }


### PR DESCRIPTION
## Summary

The mempool rejects standalone transactions that consume fee notes from uncommitted transactions. This keeps those notes available to the batch builder for fee collection.

Committed, unspent fee notes remain available to consume. User-submitted batches can consume fee notes as their reward for building the batch.

Closes #2558. Part of #2501.

## Changelog

```toml
[[entry]]
scope       = "node"
impact      = "changed"
description = "Reject standalone transactions that consume fee notes from uncommitted transactions."
```
