### PR TITLE
fix(rpc): reject nullifier prefixes that exceed 16 bits

### DIFF
--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -65,8 +65,8 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
         }
 
         // Every prefix must fit in the requested 16-bit prefix length. The store narrows prefixes
-        // with `prefix as u16`, which would otherwise silently truncate an out-of-range value
-        // (e.g. 65536 -> 0) and query a different prefix than the client requested.
+        // with `prefix as u16`, which would otherwise silently truncate an out-of-range value (e.g.
+        // 65536 -> 0) and query a different prefix than the client requested.
         if let Some(&prefix) =
             request.nullifiers.iter().find(|&&prefix| prefix > u32::from(u16::MAX))
         {

--- a/crates/rpc/src/server/api/sync_nullifiers.rs
+++ b/crates/rpc/src/server/api/sync_nullifiers.rs
@@ -63,6 +63,18 @@ impl proto::server::rpc_api::SyncNullifiers for RpcService {
                 request.prefix_len
             )));
         }
+
+        // Every prefix must fit in the requested 16-bit prefix length. The store narrows prefixes
+        // with `prefix as u16`, which would otherwise silently truncate an out-of-range value
+        // (e.g. 65536 -> 0) and query a different prefix than the client requested.
+        if let Some(&prefix) =
+            request.nullifiers.iter().find(|&&prefix| prefix > u32::from(u16::MAX))
+        {
+            return Err(Status::invalid_argument(format!(
+                "nullifier prefix {prefix} does not fit in the requested prefix length of 16 bits"
+            )));
+        }
+
         let block_range = range
             .into_inclusive_range::<RpcInvalidBlockRange>()
             .map_err(invalid_block_range_to_status)?;

--- a/crates/rpc/src/tests.rs
+++ b/crates/rpc/src/tests.rs
@@ -1395,6 +1395,30 @@ fn sync_chain_mmr_block_header_matches_chain_commitment() {
     assert_eq!(client_mmr.peaks().hash_peaks(), server_mmr.peaks().hash_peaks());
 }
 
+/// A nullifier prefix that does not fit in the requested 16-bit prefix length must be rejected with
+/// `InvalidArgument`. The store narrows prefixes with `prefix as u16`, so without this check 65536
+/// would be truncated to 0 and silently query a different prefix than the client requested.
+#[tokio::test]
+async fn sync_nullifiers_rejects_prefix_above_u16() {
+    let (mut rpc_client, _rpc_addr, _store, _server) = start_rpc().await;
+
+    let status = rpc_client
+        .sync_nullifiers(proto::rpc::SyncNullifiersRequest {
+            block_range: Some(proto::rpc::BlockRange { block_from: 0, block_to: 0 }),
+            prefix_len: 16,
+            nullifiers: vec![u32::from(u16::MAX) + 1],
+        })
+        .await
+        .expect_err("sync_nullifiers should reject a prefix that does not fit in 16 bits");
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(
+        status.message().contains("does not fit"),
+        "error should mention the prefix does not fit, got: {}",
+        status.message()
+    );
+}
+
 /// All paginated sync endpoints must reject a `block_to` that is greater than the chain tip.
 ///
 /// After bootstrapping, the chain tip is the genesis block (0), so a range ending at block 1 is


### PR DESCRIPTION
## Summary

Fixes #2543.

`SyncNullifiers` validates that `prefix_len == 16` but does not validate that each requested prefix fits in 16 bits. The store then narrows prefixes with `prefix as u16`, which silently truncates an out-of-range value (e.g. `65536 -> 0`) and queries a different prefix than the client requested.

- reject any prefix greater than `u16::MAX` with `InvalidArgument`, right after the existing `prefix_len` check, so the request fails before reaching the narrowing cast
- add a regression test asserting that a prefix of `65536` is rejected with `InvalidArgument`

## Changelog

```toml
[[entry]]
scope = "node"
impact = "fixed"
description = "Reject prefixes in `SyncNullifiers` that have more than 16 bits instead of silently truncating them"
```
