### PR TITLE
Patch docker file for rust 1.98.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ ARG KACHE_VERSION=0.16.0
 ARG BIN
 ARG PORT
 
-FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} AS build-base
+FROM debian:${DEBIAN_RELEASE}-slim AS build-base
 ARG KACHE_VERSION
 ARG TARGETARCH
-# Used by our codegen code.
-RUN rustup component add rustfmt
 # Install build dependencies. RocksDB is compiled from source by librocksdb-sys.
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
+        build-essential \
         llvm \
         clang \
         libclang-dev \
@@ -24,6 +23,18 @@ RUN apt-get update && \
         curl \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:${PATH}
+ARG RUST_VERSION
+# Code generation requires rustfmt.
+RUN curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+        --retry 5 --retry-max-time 120 \
+        https://sh.rustup.rs --output /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal \
+        --default-toolchain "${RUST_VERSION}" --component rustfmt && \
+    rm /tmp/rustup-init.sh
 
 # Verify the release archive before Kache becomes a compiler wrapper.
 RUN case "${TARGETARCH}" in \
@@ -42,6 +53,7 @@ RUN case "${TARGETARCH}" in \
     esac && \
     KACHE_ARCHIVE="kache-${KACHE_ARCH}-unknown-linux-musl.tar.gz" && \
     curl --fail --location --silent --show-error \
+        --retry 5 --retry-max-time 120 \
         "https://github.com/kunobi-ninja/kache/releases/download/v${KACHE_VERSION}/${KACHE_ARCHIVE}" \
         --output "/tmp/${KACHE_ARCHIVE}" && \
     printf '%s  %s\n' "${KACHE_SHA256}" "/tmp/${KACHE_ARCHIVE}" | \


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

Upstream docker image for rust 1.98.1 has not been published yet.

This PR works around this by manually invoking `rustup`. This is a temporary patch until upstream merges the PR.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Do not add an entry for a protocol, Rust MSRV, or database migration version update. Release notes
derive these updates from repository files.

Allowed scopes: rpc, docs, node, note-transport, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, added, changed, fixed, removed, deprecated
-->


```toml
changelog = "none"
reason    = "Internal change only."
```
