### PR TITLE
fix(node): clarify genesis deserialization error to hint at version mismatch

### DIFF
--- a/crates/utils/src/genesis.rs
+++ b/crates/utils/src/genesis.rs
@@ -54,5 +54,5 @@ pub async fn fetch_genesis_block(network: OfficialNetwork) -> anyhow::Result<Sig
 }
 
 fn deserialize_genesis_block(bytes: &[u8]) -> anyhow::Result<SignedBlock> {
-    SignedBlock::read_from_bytes(bytes).context("failed to deserialize genesis block")
+    SignedBlock::read_from_bytes(bytes).context("failed to deserialize genesis block; the genesis may have been produced by an incompatible node version")
 }


### PR DESCRIPTION
## Summary

Addresses #2588.

`bootstrap --network <preset>` (and any genesis load) surfaces a bare `invalid value: Invalid public key` when the fetched genesis was produced by an incompatible node version — e.g. bootstrapping a testnet whose genesis still uses the previous encoding. The message points at key material rather than the real cause (a version/encoding mismatch), so it is hard to act on.

This adds context to the deserialization error so the failure names the likely cause and is actionable:

```
failed to deserialize genesis block; the genesis may have been produced by an incompatible node version
```

No behavior change beyond the error message — the parse still fails as before.

## Changelog

```toml
[[entry]]
scope = "node"
impact = "changed"
description = "Clarify the genesis-block deserialization error to hint at a possible node-version mismatch"
```