### PR TITLE
feat(funding-service): add the Debian package and the systemd service

### DIFF
--- a/.github/workflows/publish-debian-all.yml
+++ b/.github/workflows/publish-debian-all.yml
@@ -38,6 +38,8 @@ jobs:
             extra_deps: true
           - name: network-monitor
             extra_deps: false
+          - name: funding-service
+            extra_deps: false
     runs-on:
       labels: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:

--- a/.github/workflows/publish-debian.yml
+++ b/.github/workflows/publish-debian.yml
@@ -8,6 +8,7 @@ on:
         required: true
         type: choice
         options:
+          - funding-service
           - network-monitor
           - node
           - ntx-builder

--- a/packaging/funding-service/miden-funding-service.service
+++ b/packaging/funding-service/miden-funding-service.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Miden funding service
+Wants=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=exec
+Environment="OTEL_SERVICE_NAME=miden-funding-service"
+ExecStart=/usr/bin/miden-funding-service start
+WorkingDirectory=/opt/miden-funding-service
+User=miden-funding-service
+RestartSec=5
+Restart=always
+LimitCORE=infinity

--- a/packaging/funding-service/postinst
+++ b/packaging/funding-service/postinst
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This is a postinstallation script so the service can be configured and started when requested.
+
+svc=miden-funding-service
+
+# user is expected by the systemd service file and `/opt/<user>` is its working directory,
+sudo adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent "$svc"
+
+# Working folder.
+if [ -d "/opt/$svc" ]
+then
+    echo "Directory /opt/$svc exists."
+else
+    mkdir -p "/opt/$svc"
+fi
+sudo chown -R "$svc" "/opt/$svc"
+
+# Configuration folder
+if [ -d "/etc/opt/$svc" ]
+then
+    echo "Directory /etc/opt/$svc exists."
+else
+    mkdir -p "/etc/opt/$svc"
+fi
+sudo chown -R "$svc" "/etc/opt/$svc"
+
+sudo systemctl daemon-reload

--- a/packaging/funding-service/postrm
+++ b/packaging/funding-service/postrm
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+###############
+# Remove miden-funding-service install
+##############
+svc=miden-funding-service
+
+sudo rm -rf "/lib/systemd/system/$svc.service"
+sudo rm -rf "/etc/opt/$svc"
+sudo deluser "$svc"
+
+sudo systemctl daemon-reload


### PR DESCRIPTION
Closes #2561 

## Summary

Adds `miden-funding-service` as a Debian package, the same way the other components are. The systemd unit runs the service as the system user `miden-funding-service`.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Do not add an entry for a protocol, Rust MSRV, or database migration version update. Release notes
derive these updates from repository files.

Allowed scopes: rpc, docs, node, note-transport, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, added, changed, fixed, removed, deprecated
-->

```toml
[[entry]]
scope       = "funding-service"
impact      = "added"
description = "The funding service is published as a Debian package with a systemd service."
```
