### PR TITLE
Use new official rust image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,15 @@ ARG KACHE_VERSION=0.16.0
 ARG BIN
 ARG PORT
 
-FROM debian:${DEBIAN_RELEASE}-slim AS build-base
+FROM rust:${RUST_VERSION}-slim-${DEBIAN_RELEASE} AS build-base
 ARG KACHE_VERSION
 ARG TARGETARCH
+# Code generation requires rustfmt.
+RUN rustup component add rustfmt
 # Install build dependencies. RocksDB is compiled from source by librocksdb-sys.
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
-        build-essential \
         llvm \
         clang \
         libclang-dev \
@@ -23,18 +24,6 @@ RUN apt-get update && \
         curl \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:${PATH}
-ARG RUST_VERSION
-# Code generation requires rustfmt.
-RUN curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
-        --retry 5 --retry-max-time 120 \
-        https://sh.rustup.rs --output /tmp/rustup-init.sh && \
-    sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal \
-        --default-toolchain "${RUST_VERSION}" --component rustfmt && \
-    rm /tmp/rustup-init.sh
 
 # Verify the release archive before Kache becomes a compiler wrapper.
 RUN case "${TARGETARCH}" in \


### PR DESCRIPTION
## Summary

<!--
Explain the change for reviewers.

Why:
- What problem does this solve?
- What user/operator/developer behavior changes?
- Which issues does this close? Use "Closes #123" where applicable.

How:
- What is the main implementation approach?
- Mention important tradeoffs, migrations, compatibility notes, or follow-up work.
-->

The official images for 1.98.1 are finally here so we can stop using rustup.

## Changelog

<!--
Use one [[entry]] per release-note-worthy impact. If this PR does not change the public gRPC
interface or released binaries, replace the entry block with:

```toml
changelog = "none"
reason    = "Internal change only."
```

Do not add an entry for a protocol, Rust MSRV, or database migration version update. Release notes
derive these updates from repository files.

Allowed scopes: rpc, docs, node, note-transport, network-monitor, ntx-builder, prover, validator, internal, general
Allowed impacts: breaking, added, changed, fixed, removed, deprecated
-->

```toml
changelog = "none"
reason    = "Internal change only."
```
